### PR TITLE
Adding project templates.

### DIFF
--- a/src/ProjectTemplates/Microsoft.Quantum.ProjectTemplates.nuspec
+++ b/src/ProjectTemplates/Microsoft.Quantum.ProjectTemplates.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.Quantum.ProjectTemplates</id>
+    <version>$version$</version>
+    <title>Microsoft Quantum Project Templates</title>
+    <authors>Microsoft</authors>
+    <owners>QuantumEngineering, Microsoft</owners>
+
+    <licenseUrl>https://docs.microsoft.com/en-us/quantum/license</licenseUrl>
+    <projectUrl>https://docs.microsoft.com/en-us/quantum</projectUrl>
+    <iconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</iconUrl>
+
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>.NET Core templates pack for Q#, part of the Microsoft Quantum Development Kit.</description>
+
+    <releaseNotes>See: https://docs.microsoft.com/en-us/quantum/relnotes/</releaseNotes>
+
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>Quantum Q# Qsharp</tags>
+
+    <packageTypes>
+      <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+
+  <files>
+    <file src="**" target="content" exclude="**\bin\**;**\obj\**;**\*.v.template;*.nuspec" />
+  </files>
+
+</package>

--- a/src/ProjectTemplates/Quantum.App1/.template.config/template.json
+++ b/src/ProjectTemplates/Quantum.App1/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "classifications": ["Common", "Console"],  
+    "name": "Console Application",
+    "description": "A project for creating a console application to execute Q# operations",
+    "groupIdentity": "Microsoft.Common.Console",
+    "identity": "Microsoft.Common.Console.QSharp.0.6",
+    "shortName": "console",
+    "tags": {
+      "language": "Q#",
+      "type": "project"
+    },
+    "sourceName": "Quantum.App1",
+    "preferNameDirectory": true
+}

--- a/src/ProjectTemplates/Quantum.App1/Driver.cs
+++ b/src/ProjectTemplates/Quantum.App1/Driver.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+
+namespace Quantum.App1
+{
+    class Driver
+    {
+        static void Main(string[] args)
+        {
+            using (var qsim = new QuantumSimulator())
+            {
+                HelloQ.Run(qsim).Wait();
+            }
+        }
+    }
+}

--- a/src/ProjectTemplates/Quantum.App1/Operations.qs
+++ b/src/ProjectTemplates/Quantum.App1/Operations.qs
@@ -1,0 +1,9 @@
+﻿namespace Quantum.App1
+{
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Intrinsic;
+
+    operation HelloQ () : Unit {
+        Message("Hello quantum world!");
+    }
+}

--- a/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj
+++ b/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.7.1905.3109" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.7.1905.3109" />
+  </ItemGroup>
+
+</Project>

--- a/src/ProjectTemplates/Quantum.Library1/.template.config/template.json
+++ b/src/ProjectTemplates/Quantum.Library1/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "classifications": ["Common", "Library"],  
+    "name": "Class library",
+    "description": "A project for creating a class library for Q#",
+    "groupIdentity": "Microsoft.Common.Library",
+    "identity": "Microsoft.Common.Library.QSharp.0.6",
+    "shortName": "classlib",
+    "tags": {
+      "language": "Q#",
+      "type": "project"
+    },
+    "sourceName": "Quantum.Library1",
+    "preferNameDirectory": true
+}

--- a/src/ProjectTemplates/Quantum.Library1/Operations.qs
+++ b/src/ProjectTemplates/Quantum.Library1/Operations.qs
@@ -1,0 +1,9 @@
+﻿namespace Quantum.Library1
+{
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Intrinsic;
+
+    operation HelloQ () : Unit {
+        Message("Hello quantum world library!");
+    }
+}

--- a/src/ProjectTemplates/Quantum.Library1/Quantum.Library1.csproj
+++ b/src/ProjectTemplates/Quantum.Library1/Quantum.Library1.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.7.1905.3109" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.7.1905.3109" />
+  </ItemGroup>
+</Project>

--- a/src/ProjectTemplates/Quantum.Test1/.template.config/template.json
+++ b/src/ProjectTemplates/Quantum.Test1/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "classifications": ["Test", "xUnit"],  
+    "name": "xUnit Test Project",
+    "description": "A project for creating xUnit tests for Q# operations",
+    "groupIdentity": "Microsoft.Test.xUnit",
+    "identity": "Microsoft.Test.xUnit.QSharp.0.6",
+    "shortName": "xunit",
+    "tags": {
+      "language": "Q#",
+      "type": "project"
+    },
+    "sourceName": "Quantum.Test1",
+    "preferNameDirectory": true
+}

--- a/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj
+++ b/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.7.1905.3109" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.7.1905.3109" />
+    <PackageReference Include="Microsoft.Quantum.xUnit" Version="0.7.1905.3109" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+</Project>

--- a/src/ProjectTemplates/Quantum.Test1/TestSuiteRunner.cs
+++ b/src/ProjectTemplates/Quantum.Test1/TestSuiteRunner.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Quantum.Simulation.XUnit;
+using Microsoft.Quantum.Simulation.Simulators;
+using Xunit.Abstractions;
+using System.Diagnostics;
+
+namespace Quantum.Test1
+{
+    public class TestSuiteRunner
+    {
+        private readonly ITestOutputHelper output;
+
+        public TestSuiteRunner(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        /// <summary>
+        /// This driver will run all Q# tests (operations named "...Test") 
+        /// that belong to namespace Quantum.Test1.
+        ///
+        /// To execute your tests, just type "dotnet test" from the command line.
+        /// </summary>
+        [OperationDriver(TestNamespace = "Quantum.Test1")]
+        public void TestTarget(TestOperation op)
+        {
+            using (var sim = new QuantumSimulator())
+            {
+                // OnLog defines action(s) performed when Q# test calls function Message
+                sim.OnLog += (msg) => { output.WriteLine(msg); };
+                sim.OnLog += (msg) => { Debug.WriteLine(msg); };
+                op.TestOperationRunner(sim);
+            }
+        }
+    }
+}

--- a/src/ProjectTemplates/Quantum.Test1/Tests.qs
+++ b/src/ProjectTemplates/Quantum.Test1/Tests.qs
@@ -1,0 +1,13 @@
+﻿namespace Quantum.Test1
+{
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Intrinsic;
+
+    operation AllocateQubitTest () : Unit {
+        using (q = Qubit()) {
+            Assert([PauliZ], [q], Zero, "Newly allocated qubit must be in |0> state");
+        }
+        
+        Message("Test passed");
+    }
+}


### PR DESCRIPTION
Moving ProjectTemplates into runtime.
For this, I'm getting away with no using .v.template as the .csproj files will be updated during signed build using `updateQDKVersion.sh` (along with all other projects).