### PR TITLE
Alexva/result

### DIFF
--- a/src/Simulation/Core/TypeExtensions.cs
+++ b/src/Simulation/Core/TypeExtensions.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Quantum.Simulation.Core
             return (typeof(Qubit).IsAssignableFrom(t));
         }
 
+        public static bool IsResult(this Type t)
+        {
+            return (typeof(Result).IsAssignableFrom(t));
+        }
+
         // returns true if arg does not contain any field of type MissingParameter (recursive)
         public static bool IsFullyDefined(this Type arg)
         {
@@ -175,6 +180,10 @@ namespace Microsoft.Quantum.Simulation.Core
             else if (t.IsQubit())
             {
                 result = typeof(Qubit);
+            }
+            else if (t.IsResult())
+            {
+                result = typeof(Result);
             }
             else if (t.IsTuple())
             {

--- a/src/Simulation/Core/Types.cs
+++ b/src/Simulation/Core/Types.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 /// <summary>
 /// The types used to represent Q# type in the generated C# code.
@@ -16,7 +12,7 @@ namespace Microsoft.Quantum.Simulation.Core
     /// Represents the Result of a Measurement. Corresponds to Q# type <code>Result</code>.
     /// </summary>
     [Serializable]
-    public enum Result
+    public enum ResultValue
     {
         /// <summary>
         /// Corresponds to measuring +1 eigenstate of an observable or 
@@ -30,6 +26,103 @@ namespace Microsoft.Quantum.Simulation.Core
         /// Represents Q# <code>One</code> constant.
         /// </summary>
         One
+    }
+
+    /// <summary>
+    /// Represents the Result of a Measurement when value is known at the construction time. 
+    /// Corresponds to Q# type <code>Result</code>.
+    /// </summary>
+    [Serializable]
+    public class ResultConst : Result
+    {
+        private ResultValue Value;
+
+        public ResultConst(ResultValue value)
+        {
+            Value = value;
+        }
+
+        public override ResultValue GetValue()
+        {
+            return Value;
+        }
+    }
+
+    /// <summary>
+    /// Represents the Result of a Measurement. Corresponds to Q# type <code>Result</code>.
+    /// </summary>
+    [Serializable]
+    public abstract class Result : IEquatable<Result>
+    {
+        /// <summary>
+        /// Returns the actual value of the result.
+        /// Can be overridden to allow implementaiton of delayed result 
+        /// retrieval or controlled access to the usage of the result.
+        /// </summary>
+        public abstract ResultValue GetValue();
+
+        /// <summary>
+        /// Corresponds to measuring +1 eigenstate of an observable or 
+        /// measuring |0⟩ in computational basis.
+        /// Represents Q# <code>Zero</code> constant.
+        /// </summary>
+        public static Result Zero = new ResultConst(ResultValue.Zero);
+        /// <summary>
+        /// Corresponds to measuring -1 eigenstate of an observable or 
+        /// measuring |1⟩ in computational basis.
+        /// Represents Q# <code>One</code> constant.
+        /// </summary>
+        public static Result One = new ResultConst(ResultValue.One);
+
+        public override string ToString()
+        {
+            return GetValue().ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as Result);
+        }
+
+        public bool Equals(Result p)
+        {
+            if (Object.ReferenceEquals(p, null))
+            {
+                return false; // Returning false is required for null
+            }
+
+            // Optimization for the case when references are equal.
+            if (Object.ReferenceEquals(this, p))
+            {
+                return true;
+            }
+
+            return (GetValue() == p.GetValue());
+        }
+
+        public static bool operator ==(Result lhs, Result rhs)
+        {
+            if (Object.ReferenceEquals(lhs, null)) // Left side is null
+            {
+                if (Object.ReferenceEquals(rhs, null))
+                {
+                    return true; // null == null.
+                }
+
+                return false; // The left side is null, but the right side is not.
+            }
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator !=(Result lhs, Result rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        public override int GetHashCode()
+        {
+            return GetValue().GetHashCode();
+        }
     }
 
     /// <summary>

--- a/src/Simulation/Simulators.Tests/GenericsTests.cs
+++ b/src/Simulation/Simulators.Tests/GenericsTests.cs
@@ -124,13 +124,6 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 Assert.Same(typeof(ControlledOperation<((Qubit, bool), Result), QVoid>), gen0.Controlled.FindCallable(typeof((QArray<Qubit>, ((TestQubit, bool), Result))), typeof(QVoid)).GetType());
                 Assert.Same(typeof(ControlledOperation<long, QVoid>), gen0.Controlled.FindCallable(typeof((QArray<Qubit>, long)), typeof(QVoid)).GetType()); // Twice to check for caching.
 
-                // A bunch of Debug.Asserts are hit, but Controlled will create something even if given the wrong type of Input/output, 
-                // here just for check backwards compatibility. Evaluate if we need to change this behavior.
-                OperationsTestHelper.IgnoreDebugAssert(() =>
-                {
-                    Assert.Same(typeof(ControlledOperation<int, QVoid>), gen0.Controlled.FindCallable(typeof(Result), typeof(QVoid)).GetType());
-                });
-
                 var gen2 = new GenericCallable(s, typeof(Gen2<,>));
                 var r2 = gen2.Controlled.FindCallable(typeof((LittleEndian, (QArray<Qubit>, long, bool))), typeof(QVoid)) as ControlledOperation<(QArray<Qubit>, long, bool), QVoid>;
                 Assert.NotNull(r2);


### PR DESCRIPTION
Measurement result should be a class so that people can override its behavior. This is useful for retrieving delayed results or for providing access control to the value.
This fixes #28.