### PR TITLE
Intrinsic function BigIntAsInt

### DIFF
--- a/src/Simulation/Intrinsic/Convert/Convert.cs
+++ b/src/Simulation/Intrinsic/Convert/Convert.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Quantum.Convert
     }
 
 
-    public partial class BigIntAsInt
+    public partial class MaybeBigIntAsInt
     {
-        public class Native : BigIntAsInt
+        public class Native : MaybeBigIntAsInt
         {
-            static (long, bool) BigIntAsIntFunc(BigInteger x)
+            static (long, bool) MaybeBigIntAsIntFunc(BigInteger x)
             {
                 if (x > long.MaxValue || x < long.MinValue)
                 {
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Convert
             }
 
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<BigInteger, (long, bool)> Body => BigIntAsIntFunc;
+            public override Func<BigInteger, (long, bool)> Body => MaybeBigIntAsIntFunc;
         }
     }
 

--- a/src/Simulation/Intrinsic/Convert/Convert.cs
+++ b/src/Simulation/Intrinsic/Convert/Convert.cs
@@ -25,6 +25,29 @@ namespace Microsoft.Quantum.Convert
         }
     }
 
+
+    public partial class BigIntAsInt
+    {
+        public class Native : BigIntAsInt
+        {
+            static (long, bool) BigIntAsIntFunc(BigInteger x)
+            {
+                if (x > long.MaxValue || x < long.MinValue)
+                {
+                    return (0, false);
+                }
+                else
+                {
+                    return ((long)x, true);
+                }
+            }
+
+            public Native(IOperationFactory m) : base(m) { }
+            public override Func<BigInteger, (long, bool)> Body => BigIntAsIntFunc;
+        }
+    }
+
+
     public partial class BigIntAsBoolArray
     {
         public class Native : BigIntAsBoolArray

--- a/src/Simulation/Intrinsic/Convert/Convert.qs
+++ b/src/Simulation/Intrinsic/Convert/Convert.qs
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Convert {
     /// which is true, if and only if the conversion was possible.
     /// # Remarks
     /// See [C# BigInteger constructor](https://docs.microsoft.com/dotnet/api/system.numerics.biginteger.-ctor?view=netframework-4.7.2#System_Numerics_BigInteger__ctor_System_Int64_) for more details.
-    function BigIntAsInt(a : BigInt) : (Int, Bool) {
+    function MaybeBigIntAsInt(a : BigInt) : (Int, Bool) {
         body intrinsic;
     }
     

--- a/src/Simulation/Intrinsic/Convert/Convert.qs
+++ b/src/Simulation/Intrinsic/Convert/Convert.qs
@@ -32,6 +32,17 @@ namespace Microsoft.Quantum.Convert {
     
     
     /// # Summary
+    /// Converts a given big integer to an equivalent integer, if possible.
+    /// The function returns a pair of the resulting integer and a Boolean flag
+    /// which is true, if and only if the conversion was possible.
+    /// # Remarks
+    /// See [C# BigInteger constructor](https://docs.microsoft.com/dotnet/api/system.numerics.biginteger.-ctor?view=netframework-4.7.2#System_Numerics_BigInteger__ctor_System_Int64_) for more details.
+    function BigIntAsInt(a : BigInt) : (Int, Bool) {
+        body intrinsic;
+    }
+    
+    
+    /// # Summary
     /// Converts a given big integer to an array of Booleans.
     /// The 0 element of the array is the least significant bit of the big integer.
     /// # Remarks

--- a/src/Simulation/Simulators.Tests/Circuits/Convert.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/Convert.qs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
+    
+    open Microsoft.Quantum.Convert;
+    
+    
+    operation ConvertTest () : Unit {
+        let (v1, b1) = MaybeBigIntAsInt(10L);
+        let (v2, b2) = MaybeBigIntAsInt(9223372036854775807L);
+        let (v3, b3) = MaybeBigIntAsInt(9223372036854775808L);
+        let (v4, b4) = MaybeBigIntAsInt(-10L);
+        let (v5, b5) = MaybeBigIntAsInt(-9223372036854775808L);
+        let (v6, b6) = MaybeBigIntAsInt(-9223372036854775809L);
+
+        AssertEqual(10, v1);
+        AssertEqual(true, b1);
+
+        AssertEqual(9223372036854775807, v2);
+        AssertEqual(true, b2);
+
+        AssertEqual(0, v3);
+        AssertEqual(false, b3);
+
+        AssertEqual(-10, v4);
+        AssertEqual(true, b4);
+
+        //AssertEqual(-9223372036854775808, v5); should not fail
+        AssertEqual(true, b5);
+
+        AssertEqual(0, v6);
+        AssertEqual(false, b6);
+    }
+    
+}


### PR DESCRIPTION
Based on a discussion with @cgranade in https://github.com/microsoft/QuantumLibraries/pull/140, we were wondering whether it can be useful to have a function `BigIntAsInt` in the runtime. There is a use case in the PR, where I create a sequence from a range of `BigInteger`s specified given a `from` and `to` parameter. The difference is a `BigInteger`, which should be used as the length of a `BigInteger[]`, which must be an `Int`.

However, there are some open issues.

1. The conversion may fail, if the value held by the `BigInteger` is too large. My suggestion is to return a tuple `(Int, Bool)` instead of just an `Int`. The Boolean return value indicates whether the conversion was successful.
1. Further, I have not found a place where these conversion methods in the runtime are tested.