### PR TITLE
Added new events for allocating/releasing qubits.

### DIFF
--- a/src/Simulation/Common/SimulatorBase.cs
+++ b/src/Simulation/Common/SimulatorBase.cs
@@ -21,6 +21,10 @@ namespace Microsoft.Quantum.Simulation.Common
     {
         public event Action<ICallable, IApplyData> OnOperationStart = null;
         public event Action<ICallable, IApplyData> OnOperationEnd = null;
+        public event Action<long> OnAllocateQubits = null;
+        public event Action<IQArray<Qubit>> OnReleaseQubits = null;
+        public event Action<long> OnBorrowQubits = null;
+        public event Action<IQArray<Qubit>> OnReturnQubits = null;
         public event Action<string> OnLog = null;
 
         public IQubitManager QubitManager { get; }
@@ -161,10 +165,12 @@ namespace Microsoft.Quantum.Simulation.Common
         /// </summary>
         public class Allocate : Intrinsic.Allocate
         {
+            private SimulatorBase sim;
             private IQubitManager manager;
 
             public Allocate(SimulatorBase m) : base(m)
             {
+                this.sim = m;
                 this.manager = m.QubitManager;
             }
 
@@ -181,6 +187,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 }
                 else if (count == 0)
                 {
+                    sim.OnAllocateQubits?.Invoke(count);
                     return new QArray<Qubit>();
                 }
                 else
@@ -196,20 +203,24 @@ namespace Microsoft.Quantum.Simulation.Common
         /// </summary>
         public class Release : Intrinsic.Release
         {
+            private SimulatorBase sim;
             private IQubitManager manager;
 
             public Release(SimulatorBase m) : base(m)
             {
+                this.sim = m;
                 this.manager = m.QubitManager;
             }
 
             public override void Apply(Qubit q)
             {
+                sim.OnReleaseQubits?.Invoke(new QArray<Qubit>(new[] { q }));
                 manager.Release(q);
             }
 
             public override void Apply(IQArray<Qubit> qubits)
             {
+                sim.OnReleaseQubits?.Invoke(qubits);
                 manager.Release(qubits);
             }
         }
@@ -234,6 +245,7 @@ namespace Microsoft.Quantum.Simulation.Common
 
             public override IQArray<Qubit> Apply(long count)
             {
+                sim.OnBorrowQubits?.Invoke(count);
                 return sim.QubitManager.Borrow(count);
             }
         }
@@ -253,11 +265,13 @@ namespace Microsoft.Quantum.Simulation.Common
 
             public override void Apply(Qubit q)
             {
+                sim.OnReturnQubits?.Invoke(new QArray<Qubit>(new[] { q }));
                 sim.QubitManager.Return(q);
             }
 
             public override void Apply(IQArray<Qubit> qubits)
             {
+                sim.OnReturnQubits?.Invoke(qubits);
                 sim.QubitManager.Return(qubits);
             }
         }

--- a/src/Simulation/Common/SimulatorBase.cs
+++ b/src/Simulation/Common/SimulatorBase.cs
@@ -176,6 +176,7 @@ namespace Microsoft.Quantum.Simulation.Common
 
             public override Qubit Apply()
             {
+                sim.OnAllocateQubits?.Invoke(1);
                 return manager.Allocate();
             }
 
@@ -192,6 +193,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 }
                 else
                 {
+                    sim.OnAllocateQubits?.Invoke(count);
                     return manager.Allocate(count);
                 }
             }

--- a/src/Simulation/Simulators.Tests/SimulatorBaseTests.cs
+++ b/src/Simulation/Simulators.Tests/SimulatorBaseTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Xunit;
+using Xunit.Abstractions;
 
 using Microsoft.Quantum.Simulation.Core;
 using Microsoft.Quantum.Simulation.Common;
@@ -23,6 +24,12 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
     public class SimulatorBaseTests
     {
+        private readonly ITestOutputHelper output;
+
+        public SimulatorBaseTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
 
         /// <summary>
         /// Verifies that built-in operations (Allocate/Relase) can be retrieved and succesfully applied from a TrivialSimulator.
@@ -41,9 +48,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var calledOnAllocate = false;
             var calledOnRelease = false;
             subject.OnAllocateQubits += count => {
+                output.WriteLine($"Allocate count = {count}");
                 calledOnAllocate = true;
             };
-            subject.OnReleaseQubits += count => {
+            subject.OnReleaseQubits += register => {
+                output.WriteLine($"Release qubits = {register}");
                 calledOnRelease = true;
             };
 
@@ -52,9 +61,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             // Try the operations
             var qubits = allocate.Apply(3);
+            Assert.True(calledOnAllocate);
             Assert.Equal(3, qubits.Length);
 
             release.Apply(qubits);
+            Assert.True(calledOnRelease);
 
             subject.CheckNoQubitLeak();
         }

--- a/src/Simulation/Simulators.Tests/SimulatorBaseTests.cs
+++ b/src/Simulation/Simulators.Tests/SimulatorBaseTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
     public class SimulatorBaseTests
     {
+
         /// <summary>
         /// Verifies that built-in operations (Allocate/Relase) can be retrieved and succesfully applied from a TrivialSimulator.
         /// </summary>
@@ -34,6 +35,17 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var subject = new TrivialSimulator();
 
             Assert.Equal(typeof(TrivialSimulator).Name, subject.Name);
+
+            // Check whether our events for allocation and deallocation
+            // are actually called.
+            var calledOnAllocate = false;
+            var calledOnRelease = false;
+            subject.OnAllocateQubits += count => {
+                calledOnAllocate = true;
+            };
+            subject.OnReleaseQubits += count => {
+                calledOnRelease = true;
+            };
 
             var allocate = subject.Get<Intrinsic.Allocate>();
             var release = subject.Get<Intrinsic.Release>();


### PR DESCRIPTION
This PR allows for code calling into simulators to attach event callbacks that observe the allocation, releasing, borrowing, and returning of qubits. For example, this will allow for the visual debugger contributed with Microsoft/quantum#221 to intercept allocation and deallocation events without needing to register additional intrinsic or emulated operations.