### PR TITLE
Increment version number and add prerelease feed to README.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+
+<!--
+    This configuration tells the .NET Core SDK to build the Q# runtime using the
+    Quantum Development Kit prerelease feed in addition to any other currently
+    configured NuGet feeds.
+    This allows us to use prerelease packages from other parts of the Quantum
+    Development Kit in between releases.
+
+    See https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied
+    for more information about how NuGet and the .NET Core SDK find package
+    sources from NuGet.Config files.
+-->
+<configuration>
+  <packageSources>
+    <add key="qdk-alpha" value="https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,7 @@
      Licensed under the MIT License. -->
 
 <!--
-    This configuration tells the .NET Core SDK to build the Q# runtime using the
+    This configuration tells the .NET Core SDK to look at the
     Quantum Development Kit prerelease feed in addition to any other currently
     configured NuGet feeds.
     This allows us to use prerelease packages from other parts of the Quantum

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ You may also visit our [Quantum](https://github.com/microsoft/quantum) repositor
 [![Build Status](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_apis/build/status/microsoft.qsharp-runtime?branchName=master)](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/latest?definitionId=15&branchName=master)
 
 
+Note that when building from source, this repository is configured so that .NET Core will automatically look at the [Quantum Development Kit prerelease feed](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_packaging?_a=feed&feed=alpha) in addition to any other feeds you may have configured.
+
+
 ### Windows ###
 
 To build on Windows:
@@ -107,32 +110,3 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 For more details, please see [CONTRIBUTING.md](./CONTRIBUTING.md), or the [contribution guide](https://docs.microsoft.com/quantum/contributing/).
-
-## [Optional] Using Prerelease Versions ##
-
-If you're interested in helping test the Q# runtime, or if you want to try out new features before they are released, you can add the [Quantum Development Kit prerelease feed](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_packaging?_a=feed&feed=alpha) to your .NET Core SDK configuration.
-Packages on the prerelease feed are marked with `-alpha` in their version number, so that projects built using released versions of Quantum Development Kit libraries will not be affected.
-Note that the prerelease feed is used automatically when building libraries in this repository.
-
-To use the prerelease feed, edit your `NuGet.Config` file to include the prerelease feed URL (`https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json`) as a package source.
-The location of this file varies depending on your operating system:
-
-| OS | NuGet config file location |
-|----|----------------------------|
-| Windows | `$Env:APPDATA/Roaming/NuGet/NuGet.Config` |
-| macOS / Linux | `~/.config/NuGet/NuGet.Config` or `~/.nuget/NuGet/NuGet.Config` |
-
-Note that this file may not already exist, depending on your configuration.
-
-For example, the following `NuGet.Config` file includes both the main NuGet package feed, and the Quantum Development Kit prerelease feed:
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="qdk-alpha" value="https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>
-```
-

--- a/README.md
+++ b/README.md
@@ -107,3 +107,30 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 For more details, please see [CONTRIBUTING.md](./CONTRIBUTING.md), or the [contribution guide](https://docs.microsoft.com/quantum/contributing/).
+
+## [Optional] Using Prerelease Versions ##
+
+If you're interested in helping test the Q# runtime, or if you want to try out new features before they are released, you can add the [Quantum Development Kit prerelease feed](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_packaging?_a=feed&feed=alpha) to your .NET Core SDK configuration.
+Packages on the prerelease feed are marked with `-alpha` in their version number, so that projects built using released versions of Quantum Development Kit libraries will not be affected.
+
+To use the prerelease feed, edit your `NuGet.Config` file to include the prerelease feed URL (`https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json`) as a package source.
+The location of this file varies depending on your operating system:
+
+| OS | NuGet config file location |
+|----|----------------------------|
+| Windows | `$Env:APPDATA/Roaming/NuGet/NuGet.Config` |
+| macOS / Linux | `~/.config/NuGet/NuGet.Config` or `~/.nuget/NuGet/NuGet.Config` |
+
+Note that this file may not already exist, depending on your configuration.
+
+For example, the following `NuGet.Config` file includes both the main NuGet package feed, and the Quantum Development Kit prerelease feed:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="qdk-alpha" value="https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>
+```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ For more details, please see [CONTRIBUTING.md](./CONTRIBUTING.md), or the [contr
 
 If you're interested in helping test the Q# runtime, or if you want to try out new features before they are released, you can add the [Quantum Development Kit prerelease feed](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_packaging?_a=feed&feed=alpha) to your .NET Core SDK configuration.
 Packages on the prerelease feed are marked with `-alpha` in their version number, so that projects built using released versions of Quantum Development Kit libraries will not be affected.
+Note that the prerelease feed is used automatically when building libraries in this repository.
 
 To use the prerelease feed, edit your `NuGet.Config` file to include the prerelease feed URL (`https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json`) as a package source.
 The location of this file varies depending on your operating system:
@@ -134,3 +135,4 @@ For example, the following `NuGet.Config` file includes both the main NuGet pack
   </packageSources>
 </configuration>
 ```
+

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -4,7 +4,7 @@ trigger:
 
 variables:
   Build.Major: 0
-  Build.Minor: 0
+  Build.Minor: 9
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
   Drop.Native: $(System.DefaultWorkingDirectory)/xplat
 

--- a/src/Microsoft.Quantum.Development.Kit.nuspec
+++ b/src/Microsoft.Quantum.Development.Kit.nuspec
@@ -20,7 +20,7 @@
     <tags>Quantum Q# Qsharp </tags>
 
     <dependencies>
-      <dependency id="Microsoft.Quantum.Simulators" version="0.8.1907.1701" />
+      <dependency id="Microsoft.Quantum.Simulators" version="$version$" />
     </dependencies>
   </metadata>
 


### PR DESCRIPTION
This PR updates the version number used to build the Q# runtime in CI and updates the README file to point to the public prerelease feed.