### PR TITLE
Additional handles in generated code

### DIFF
--- a/src/Simulation/Core/Attributes.cs
+++ b/src/Simulation/Core/Attributes.cs
@@ -7,14 +7,14 @@ using System;
 namespace Microsoft.Quantum.Simulation.Core
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class SpecializationRangeAttribute : Attribute
+    public class SourceLocationAttribute : Attribute
     { 
         public string SourceFile { get; }
-        public string SpecializationKind { get; }
+        public OperationFunctor SpecializationKind { get; }
         public int StartLine { get; }
         public int EndLine { get; }
 
-        public SpecializationRangeAttribute(string sourceFile, string kind, int startLine, int endLine)
+        public SourceLocationAttribute(string sourceFile, OperationFunctor kind, int startLine, int endLine)
         {
             this.SourceFile = sourceFile;
             this.SpecializationKind = kind;

--- a/src/Simulation/Core/Attributes.cs
+++ b/src/Simulation/Core/Attributes.cs
@@ -6,6 +6,7 @@ using System;
 
 namespace Microsoft.Quantum.Simulation.Core
 {
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class SpecializationRangeAttribute : Attribute
     { 
         public string SourceFile { get; }

--- a/src/Simulation/Core/Attributes.cs
+++ b/src/Simulation/Core/Attributes.cs
@@ -6,6 +6,22 @@ using System;
 
 namespace Microsoft.Quantum.Simulation.Core
 {
+    public class SpecializationRangeAttribute : Attribute
+    { 
+        public string SourceFile { get; }
+        public string SpecializationKind { get; }
+        public int StartLine { get; }
+        public int EndLine { get; }
+
+        public SpecializationRangeAttribute(string sourceFile, string kind, int startLine, int endLine)
+        {
+            this.SourceFile = sourceFile;
+            this.SpecializationKind = kind;
+            this.StartLine = startLine;
+            this.EndLine = endLine;
+        }
+    }
+
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public class CallableDeclarationAttribute : Attribute
     {

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -1617,7 +1617,7 @@ namespace N1
        
     let testOneSpecialization pick (_,op) expected =
         let context = createTestContext op
-        let actual  = op |> pick |> buildSpecialization context |> Option.map formatSyntaxTree
+        let actual  = op |> pick |> buildSpecialization context |> Option.map (fst >> formatSyntaxTree)
         Assert.Equal(expected |> Option.map clearFormatting, actual |> Option.map clearFormatting)
 
     [<Fact>]
@@ -2237,7 +2237,8 @@ namespace N1
         false |> testOne differentArgsOperation
         false |> testOne randomOperation
 
-    let testOneClass (_,op) expected =
+    let testOneClass (_,op : QsCallable) (expected : string) =
+        let expected = expected.Replace("%%%", op.SourceFile.Value)
         let context = createContext None syntaxTree 
         let actual = (buildOperationClass context op).ToFullString()
         Assert.Equal(expected |> clearFormatting, actual |> clearFormatting)
@@ -2303,6 +2304,10 @@ namespace N1
         |> testOneClass randomAbstractOperation
 
         """
+    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "AdjointBody", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "ControlledBody", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "ControlledAdjointBody", 0, 0)]
     public partial class oneQubitOperation : Unitary<Qubit>, ICallable
     {
         public oneQubitOperation(IOperationFactory m) : base(m)
@@ -2400,6 +2405,7 @@ namespace N1
         |> testOneClass genCtrl3
         
         """
+    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
     public partial class composeImpl<__A__, __B__> : Operation<(ICallable,ICallable,__B__), QVoid>, ICallable
     {
         public composeImpl(IOperationFactory m) : base(m)
@@ -2548,6 +2554,7 @@ namespace N1
         |> testOneClass emptyFunction
 
         """
+    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
     public partial class intFunction : Function<QVoid, Int64>, ICallable
     {
         public intFunction(IOperationFactory m) : base(m)
@@ -2575,6 +2582,7 @@ namespace N1
         |> testOneClass intFunction
 
         """
+    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
     public partial class powFunction : Function<(Int64,Int64), Int64>, ICallable
     {
         public powFunction(IOperationFactory m) : base(m)
@@ -2611,6 +2619,7 @@ namespace N1
         |> testOneClass powFunction
 
         """
+    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
     public partial class bigPowFunction : Function<(System.Numerics.BigInteger,Int64), System.Numerics.BigInteger>, ICallable
     {
         public bigPowFunction(IOperationFactory m) : base(m)
@@ -3049,6 +3058,7 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.Inline
 {
+    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
     public partial class HelloWorld : Operation<Int64, Int64>, ICallable
     {
         public HelloWorld(IOperationFactory m) : base(m)
@@ -3094,6 +3104,7 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.LineNumbers
 {
+    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
     public partial class TestLineInBlocks : Operation<Int64, Result>, ICallable
     {
         public TestLineInBlocks(IOperationFactory m) : base(m)

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -2304,10 +2304,10 @@ namespace N1
         |> testOneClass randomAbstractOperation
 
         """
-    [SpecializationRangeAttribute("%%%", "Body", 107, 112)]
-    [SpecializationRangeAttribute("%%%", "AdjointBody", 112, 118)]
-    [SpecializationRangeAttribute("%%%", "ControlledBody", 118, 125)]
-    [SpecializationRangeAttribute("%%%", "ControlledAdjointBody", 125, 131)]
+    [SourceLocation("%%%", OperationFunctor.Body, 107, 112)]
+    [SourceLocation("%%%", OperationFunctor.AdjointBody, 112, 118)]
+    [SourceLocation("%%%", OperationFunctor.ControlledBody, 118, 125)]
+    [SourceLocation("%%%", OperationFunctor.ControlledAdjointBody, 125, 131)]
     public partial class oneQubitOperation : Unitary<Qubit>, ICallable
     {
         public oneQubitOperation(IOperationFactory m) : base(m)
@@ -2405,7 +2405,7 @@ namespace N1
         |> testOneClass genCtrl3
         
         """
-    [SpecializationRangeAttribute("%%%", "Body", 1265, 1271)]
+    [SourceLocation("%%%", OperationFunctor.Body, 1265, 1271)]
     public partial class composeImpl<__A__, __B__> : Operation<(ICallable,ICallable,__B__), QVoid>, ICallable
     {
         public composeImpl(IOperationFactory m) : base(m)
@@ -2554,7 +2554,7 @@ namespace N1
         |> testOneClass emptyFunction
 
         """
-    [SpecializationRangeAttribute("%%%", "Body", 32, 39)]
+    [SourceLocation("%%%", OperationFunctor.Body, 32, 39)]
     public partial class intFunction : Function<QVoid, Int64>, ICallable
     {
         public intFunction(IOperationFactory m) : base(m)
@@ -2582,7 +2582,7 @@ namespace N1
         |> testOneClass intFunction
 
         """
-    [SpecializationRangeAttribute("%%%", "Body", 44, 50)]
+    [SourceLocation("%%%", OperationFunctor.Body, 44, 50)]
     public partial class powFunction : Function<(Int64,Int64), Int64>, ICallable
     {
         public powFunction(IOperationFactory m) : base(m)
@@ -2619,7 +2619,7 @@ namespace N1
         |> testOneClass powFunction
 
         """
-    [SpecializationRangeAttribute("%%%", "Body", 50, 56)]
+    [SourceLocation("%%%", OperationFunctor.Body, 50, 56)]
     public partial class bigPowFunction : Function<(System.Numerics.BigInteger,Int64), System.Numerics.BigInteger>, ICallable
     {
         public bigPowFunction(IOperationFactory m) : base(m)
@@ -3058,7 +3058,7 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.Inline
 {
-    [SpecializationRangeAttribute("%%%", "Body", 6, -1)]
+    [SourceLocation("%%%", OperationFunctor.Body, 6, -1)]
     public partial class HelloWorld : Operation<Int64, Int64>, ICallable
     {
         public HelloWorld(IOperationFactory m) : base(m)
@@ -3104,7 +3104,7 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.LineNumbers
 {
-    [SpecializationRangeAttribute("%%%", "Body", 8, -1)]
+    [SourceLocation("%%%", OperationFunctor.Body, 8, -1)]
     public partial class TestLineInBlocks : Operation<Int64, Result>, ICallable
     {
         public TestLineInBlocks(IOperationFactory m) : base(m)

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -2305,9 +2305,9 @@ namespace N1
 
         """
     [SourceLocation("%%%", OperationFunctor.Body, 107, 112)]
-    [SourceLocation("%%%", OperationFunctor.AdjointBody, 112, 118)]
-    [SourceLocation("%%%", OperationFunctor.ControlledBody, 118, 125)]
-    [SourceLocation("%%%", OperationFunctor.ControlledAdjointBody, 125, 131)]
+    [SourceLocation("%%%", OperationFunctor.Adjoint, 112, 118)]
+    [SourceLocation("%%%", OperationFunctor.Controlled, 118, 125)]
+    [SourceLocation("%%%", OperationFunctor.ControlledAdjoint, 125, 131)]
     public partial class oneQubitOperation : Unitary<Qubit>, ICallable
     {
         public oneQubitOperation(IOperationFactory m) : base(m)

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -2304,10 +2304,10 @@ namespace N1
         |> testOneClass randomAbstractOperation
 
         """
-    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
-    [SpecializationRangeAttribute("%%%", "AdjointBody", 0, 0)]
-    [SpecializationRangeAttribute("%%%", "ControlledBody", 0, 0)]
-    [SpecializationRangeAttribute("%%%", "ControlledAdjointBody", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "Body", 107, 112)]
+    [SpecializationRangeAttribute("%%%", "AdjointBody", 112, 118)]
+    [SpecializationRangeAttribute("%%%", "ControlledBody", 118, 125)]
+    [SpecializationRangeAttribute("%%%", "ControlledAdjointBody", 125, 131)]
     public partial class oneQubitOperation : Unitary<Qubit>, ICallable
     {
         public oneQubitOperation(IOperationFactory m) : base(m)
@@ -2405,7 +2405,7 @@ namespace N1
         |> testOneClass genCtrl3
         
         """
-    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "Body", 1265, 1271)]
     public partial class composeImpl<__A__, __B__> : Operation<(ICallable,ICallable,__B__), QVoid>, ICallable
     {
         public composeImpl(IOperationFactory m) : base(m)
@@ -2554,7 +2554,7 @@ namespace N1
         |> testOneClass emptyFunction
 
         """
-    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "Body", 32, 39)]
     public partial class intFunction : Function<QVoid, Int64>, ICallable
     {
         public intFunction(IOperationFactory m) : base(m)
@@ -2582,7 +2582,7 @@ namespace N1
         |> testOneClass intFunction
 
         """
-    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "Body", 44, 50)]
     public partial class powFunction : Function<(Int64,Int64), Int64>, ICallable
     {
         public powFunction(IOperationFactory m) : base(m)
@@ -2619,7 +2619,7 @@ namespace N1
         |> testOneClass powFunction
 
         """
-    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "Body", 50, 56)]
     public partial class bigPowFunction : Function<(System.Numerics.BigInteger,Int64), System.Numerics.BigInteger>, ICallable
     {
         public bigPowFunction(IOperationFactory m) : base(m)
@@ -3058,7 +3058,7 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.Inline
 {
-    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "Body", 6, -1)]
     public partial class HelloWorld : Operation<Int64, Int64>, ICallable
     {
         public HelloWorld(IOperationFactory m) : base(m)
@@ -3104,7 +3104,7 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.LineNumbers
 {
-    [SpecializationRangeAttribute("%%%", "Body", 0, 0)]
+    [SpecializationRangeAttribute("%%%", "Body", 8, -1)]
     public partial class TestLineInBlocks : Operation<Int64, Result>, ICallable
     {
         public TestLineInBlocks(IOperationFactory m) : base(m)

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1025,7 +1025,7 @@ module SimulationCode =
                 match context.declarationPositions.TryGetValue sp.SourceFile with 
                 | true, startPositions -> 
                     let index = startPositions.IndexOf sp.Location.Offset
-                    if index = startPositions.Count then -1 else fst startPositions.[index + 1]
+                    if index + 1 >= startPositions.Count then -1 else fst startPositions.[index + 1]
 //TODO: diagnostics.
                 | false, _ -> startLine
             ``attribute`` None (ident "SpecializationRangeAttribute") [ 

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1015,9 +1015,9 @@ module SimulationCode =
         let bodyName = 
             match sp.Kind with 
             | QsBody              -> "Body"
-            | QsAdjoint           -> "AdjointBody"
-            | QsControlled        -> "ControlledBody"
-            | QsControlledAdjoint -> "ControlledAdjointBody"
+            | QsAdjoint           -> "Adjoint"
+            | QsControlled        -> "Controlled"
+            | QsControlledAdjoint -> "ControlledAdjoint"
         let body = (buildSpecializationBody context sp)
         let attribute = 
             let startLine = fst sp.Location.Offset
@@ -1037,6 +1037,7 @@ module SimulationCode =
 
         match body with 
         | Some body ->
+            let bodyName = if bodyName = "Body" then bodyName else bodyName + "Body"
             let impl = 
                 ``property-arrow_get`` propertyType bodyName [``public``; ``override``]
                     ``get``

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1020,11 +1020,20 @@ module SimulationCode =
             | QsControlledAdjoint -> "ControlledAdjointBody"
         let body = (buildSpecializationBody context sp)
         let attribute = 
-            let source = ``literal`` sp.SourceFile.Value
-            let kind = ``literal`` bodyName
-            let startLine, endLine = ``literal`` 0, ``literal`` 0 // FIXME
-            ``attribute`` None (ident "SpecializationRangeAttribute") [ source; kind; startLine; endLine ]
-
+            let startLine = fst sp.Location.Offset
+            let endLine = 
+                match context.declarationPositions.TryGetValue sp.SourceFile with 
+                | true, startPositions -> 
+                    let index = startPositions.IndexOf sp.Location.Offset
+                    if index = startPositions.Count then -1 else fst startPositions.[index + 1]
+//TODO: diagnostics.
+                | false, _ -> startLine
+            ``attribute`` None (ident "SpecializationRangeAttribute") [ 
+                ``literal`` sp.SourceFile.Value 
+                ``literal`` bodyName 
+                ``literal`` startLine 
+                ``literal`` endLine
+            ]
 
         match body with 
         | Some body ->

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -291,7 +291,7 @@ module SimulationCode =
                 let (current, _) = loc.Offset
                 this._StatementKind.LineNumber <- this._StatementKind.StartLine |> Option.map (fun start -> start + current + 1) // The Q# compiler reports 0-based line numbers.
             | Null -> 
-                this._StatementKind.LineNumber <- Some 0 // indicates a hidden line
+                this._StatementKind.LineNumber <- None // auto-generated statement; the line number will be set to the specialization declaration
             this.DeclarationsInStatement <- node.SymbolDeclarations
             this.DeclarationsInScope <- LocalDeclarations.Concat this.DeclarationsInScope this.DeclarationsInStatement // only fine because/if a new StatementBlockBuilder is created for every block!
             base.onStatement node
@@ -310,6 +310,10 @@ module SimulationCode =
                 ``#line hidden`` <| s
             | Some n, Some ln -> 
                 ``#line`` ln n s
+            | Some n, None -> startLine |> function 
+                | Some ln -> 
+                    ``#line`` ln n s
+                | None -> s
             | _ -> s
             
         let QArrayType = function

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1028,9 +1028,9 @@ module SimulationCode =
                     if index + 1 >= startPositions.Count then -1 else fst startPositions.[index + 1]
 //TODO: diagnostics.
                 | false, _ -> startLine
-            ``attribute`` None (ident "SpecializationRangeAttribute") [ 
+            ``attribute`` None (ident "SourceLocation") [ 
                 ``literal`` sp.SourceFile.Value 
-                ``literal`` bodyName 
+                ``ident`` "OperationFunctor" <|.|> ``ident`` bodyName 
                 ``literal`` startLine 
                 ``literal`` endLine
             ]

--- a/src/Simulation/RoslynWrapper/ClassDeclaration.fs
+++ b/src/Simulation/RoslynWrapper/ClassDeclaration.fs
@@ -10,6 +10,11 @@ module ClassDeclaration =
     open Microsoft.CodeAnalysis.CSharp
     open Microsoft.CodeAnalysis.CSharp.Syntax
 
+    let private setAttributes (attributes : AttributeListSyntax seq) (cd : ClassDeclarationSyntax) = 
+        attributes
+        |> SyntaxFactory.List
+        |> cd.WithAttributeLists
+
     let private setModifiers modifiers (cd : ClassDeclarationSyntax)  =
         modifiers
         |> Seq.map SyntaxFactory.Token
@@ -38,6 +43,9 @@ module ClassDeclaration =
     let genericBase name ``<<`` typeParam ``>>`` = 
         generic name ``<<`` typeParam ``>>``|> SyntaxFactory.SimpleBaseType
 
+    let ``attributes`` attributes (classDecl : ClassDeclarationSyntax) = 
+        classDecl |> setAttributes attributes
+        
     let ``class`` className ``<<`` typeParameters ``>>``
             ``:`` baseClassName ``,`` baseInterfaces
             modifiers
@@ -49,3 +57,7 @@ module ClassDeclaration =
             |> setBases (baseClassName ?+ baseInterfaces)
             |> setModifiers modifiers
             |> setMembers members
+
+
+
+            


### PR DESCRIPTION
This PR addresses #68. 
It sets the line numbers for autogenerated statements to the line number of the corresponding implicit or explicit specialization declaration in the Q# code, and adds an attribute for each specialization to the callable class that contains the source file where it has been specified as well as the start and end line of the specialization declaration.
The line numbers are 0-based and the end line number is set to -1 if it is the last specialization declaration in the file. 