### PR TITLE
Revert "Additional handles in generated code (#75)"

### DIFF
--- a/src/Simulation/Core/Attributes.cs
+++ b/src/Simulation/Core/Attributes.cs
@@ -6,23 +6,6 @@ using System;
 
 namespace Microsoft.Quantum.Simulation.Core
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class SourceLocationAttribute : Attribute
-    { 
-        public string SourceFile { get; }
-        public OperationFunctor SpecializationKind { get; }
-        public int StartLine { get; }
-        public int EndLine { get; }
-
-        public SourceLocationAttribute(string sourceFile, OperationFunctor kind, int startLine, int endLine)
-        {
-            this.SourceFile = sourceFile;
-            this.SpecializationKind = kind;
-            this.StartLine = startLine;
-            this.EndLine = endLine;
-        }
-    }
-
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public class CallableDeclarationAttribute : Attribute
     {

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -1617,7 +1617,7 @@ namespace N1
        
     let testOneSpecialization pick (_,op) expected =
         let context = createTestContext op
-        let actual  = op |> pick |> buildSpecialization context |> Option.map (fst >> formatSyntaxTree)
+        let actual  = op |> pick |> buildSpecialization context |> Option.map formatSyntaxTree
         Assert.Equal(expected |> Option.map clearFormatting, actual |> Option.map clearFormatting)
 
     [<Fact>]
@@ -2237,8 +2237,7 @@ namespace N1
         false |> testOne differentArgsOperation
         false |> testOne randomOperation
 
-    let testOneClass (_,op : QsCallable) (expected : string) =
-        let expected = expected.Replace("%%%", op.SourceFile.Value)
+    let testOneClass (_,op) expected =
         let context = createContext None syntaxTree 
         let actual = (buildOperationClass context op).ToFullString()
         Assert.Equal(expected |> clearFormatting, actual |> clearFormatting)
@@ -2304,10 +2303,6 @@ namespace N1
         |> testOneClass randomAbstractOperation
 
         """
-    [SourceLocation("%%%", OperationFunctor.Body, 107, 112)]
-    [SourceLocation("%%%", OperationFunctor.Adjoint, 112, 118)]
-    [SourceLocation("%%%", OperationFunctor.Controlled, 118, 125)]
-    [SourceLocation("%%%", OperationFunctor.ControlledAdjoint, 125, 131)]
     public partial class oneQubitOperation : Unitary<Qubit>, ICallable
     {
         public oneQubitOperation(IOperationFactory m) : base(m)
@@ -2405,7 +2400,6 @@ namespace N1
         |> testOneClass genCtrl3
         
         """
-    [SourceLocation("%%%", OperationFunctor.Body, 1265, 1271)]
     public partial class composeImpl<__A__, __B__> : Operation<(ICallable,ICallable,__B__), QVoid>, ICallable
     {
         public composeImpl(IOperationFactory m) : base(m)
@@ -2554,7 +2548,6 @@ namespace N1
         |> testOneClass emptyFunction
 
         """
-    [SourceLocation("%%%", OperationFunctor.Body, 32, 39)]
     public partial class intFunction : Function<QVoid, Int64>, ICallable
     {
         public intFunction(IOperationFactory m) : base(m)
@@ -2582,7 +2575,6 @@ namespace N1
         |> testOneClass intFunction
 
         """
-    [SourceLocation("%%%", OperationFunctor.Body, 44, 50)]
     public partial class powFunction : Function<(Int64,Int64), Int64>, ICallable
     {
         public powFunction(IOperationFactory m) : base(m)
@@ -2619,7 +2611,6 @@ namespace N1
         |> testOneClass powFunction
 
         """
-    [SourceLocation("%%%", OperationFunctor.Body, 50, 56)]
     public partial class bigPowFunction : Function<(System.Numerics.BigInteger,Int64), System.Numerics.BigInteger>, ICallable
     {
         public bigPowFunction(IOperationFactory m) : base(m)
@@ -3058,7 +3049,6 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.Inline
 {
-    [SourceLocation("%%%", OperationFunctor.Body, 6, -1)]
     public partial class HelloWorld : Operation<Int64, Int64>, ICallable
     {
         public HelloWorld(IOperationFactory m) : base(m)
@@ -3104,7 +3094,6 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.LineNumbers
 {
-    [SourceLocation("%%%", OperationFunctor.Body, 8, -1)]
     public partial class TestLineInBlocks : Operation<Int64, Result>, ICallable
     {
         public TestLineInBlocks(IOperationFactory m) : base(m)

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -31,39 +31,14 @@ module SimulationCode =
     open Microsoft.Quantum.QsCompiler.Transformations
     open System.Globalization
 
-    type DeclarationPositions() = 
-        inherit SyntaxTreeTransformation<NoScopeTransformations>(new NoScopeTransformations())
-
-        let mutable currentSource = null
-        let declarationLocations = new List<NonNullable<string> * (int * int)>()
-
-        member this.DeclarationLocations = 
-            declarationLocations.ToLookup (fst, snd)
-
-        static member Apply (syntaxTree : IEnumerable<QsNamespace>) = 
-            let walker = new DeclarationPositions()
-            for ns in syntaxTree do 
-                walker.Transform ns |> ignore
-            walker.DeclarationLocations
-
-        override this.onSourceFile file = 
-            currentSource <- file.Value
-            file
-
-        override this.onLocation (loc : QsLocation) = 
-            if currentSource <> null then
-                declarationLocations.Add (NonNullable<string>.New currentSource, loc.Offset)
-            loc
-
     type CodegenContext = { 
-        allQsElements           : IEnumerable<QsNamespace>
-        allUdts                 : ImmutableDictionary<QsQualifiedName,QsCustomType>
-        allCallables            : ImmutableDictionary<QsQualifiedName,QsCallable>
-        declarationPositions    : ImmutableDictionary<NonNullable<string>, ImmutableSortedSet<int * int>>
-        byName                  : ImmutableDictionary<NonNullable<string>,(NonNullable<string>*QsCallable) list>
-        current                 : QsQualifiedName option
-        signature               : ResolvedSignature option
-        fileName                : string option
+        allQsElements   : IEnumerable<QsNamespace>
+        allUdts         : ImmutableDictionary<QsQualifiedName,QsCustomType>
+        allCallables    : ImmutableDictionary<QsQualifiedName,QsCallable>
+        byName          : ImmutableDictionary<NonNullable<string>,(NonNullable<string>*QsCallable) list>
+        current         : QsQualifiedName option
+        signature       : ResolvedSignature option
+        fileName        : string option
     } 
     
     type CodegenContext with
@@ -73,7 +48,6 @@ module SimulationCode =
     let createContext fileName syntaxTree =        
         let udts = GlobalTypeResolutions syntaxTree
         let callables = GlobalCallableResolutions syntaxTree
-        let positionInfos = DeclarationPositions.Apply syntaxTree
         let callablesByName = 
             let result = new Dictionary<NonNullable<string>,(NonNullable<string>*QsCallable) list>()
             syntaxTree |> Seq.collect (fun ns -> ns.Elements |> Seq.choose (function
@@ -83,16 +57,7 @@ module SimulationCode =
                 if result.ContainsKey c.FullName.Name then result.[c.FullName.Name] <- (ns.Name, c) :: (result.[c.FullName.Name]) 
                 else result.[c.FullName.Name] <- [ns.Name, c])
             result.ToImmutableDictionary()
-        { 
-            allQsElements = syntaxTree; 
-            byName = callablesByName; 
-            allUdts = udts; 
-            allCallables = callables; 
-            declarationPositions = positionInfos.ToImmutableDictionary((fun g -> g.Key), (fun g -> g.ToImmutableSortedSet()))
-            current = None; 
-            fileName = fileName; 
-            signature = None 
-        }
+        { allQsElements = syntaxTree; byName = callablesByName; allUdts = udts; allCallables = callables; current = None; fileName = fileName; signature = None }
               
     let autoNamespaces = 
         [
@@ -326,7 +291,7 @@ module SimulationCode =
                 let (current, _) = loc.Offset
                 this._StatementKind.LineNumber <- this._StatementKind.StartLine |> Option.map (fun start -> start + current + 1) // The Q# compiler reports 0-based line numbers.
             | Null -> 
-                this._StatementKind.LineNumber <- None // auto-generated statement; the line number will be set to the specialization declaration
+                this._StatementKind.LineNumber <- Some 0 // indicates a hidden line
             this.DeclarationsInStatement <- node.SymbolDeclarations
             this.DeclarationsInScope <- LocalDeclarations.Concat this.DeclarationsInScope this.DeclarationsInStatement // only fine because/if a new StatementBlockBuilder is created for every block!
             base.onStatement node
@@ -345,10 +310,6 @@ module SimulationCode =
                 ``#line hidden`` <| s
             | Some n, Some ln -> 
                 ``#line`` ln n s
-            | Some n, None -> startLine |> function 
-                | Some ln -> 
-                    ``#line`` ln n s
-                | None -> s
             | _ -> s
             
         let QArrayType = function
@@ -1008,41 +969,25 @@ module SimulationCode =
         | _ -> 
             None
         
-    let buildSpecialization context (sp:QsSpecialization) : (PropertyDeclarationSyntax * _) option =
+    let buildSpecialization context (sp:QsSpecialization) : PropertyDeclarationSyntax option =
         let inType  = roslynTypeName context sp.Signature.ArgumentType
         let outType = roslynTypeName context sp.Signature.ReturnType
         let propertyType = "Func<" + inType + ", " + outType + ">"
         let bodyName = 
             match sp.Kind with 
             | QsBody              -> "Body"
-            | QsAdjoint           -> "Adjoint"
-            | QsControlled        -> "Controlled"
-            | QsControlledAdjoint -> "ControlledAdjoint"
+            | QsAdjoint           -> "AdjointBody"
+            | QsControlled        -> "ControlledBody"
+            | QsControlledAdjoint -> "ControlledAdjointBody"
         let body = (buildSpecializationBody context sp)
-        let attribute = 
-            let startLine = fst sp.Location.Offset
-            let endLine = 
-                match context.declarationPositions.TryGetValue sp.SourceFile with 
-                | true, startPositions -> 
-                    let index = startPositions.IndexOf sp.Location.Offset
-                    if index + 1 >= startPositions.Count then -1 else fst startPositions.[index + 1]
-//TODO: diagnostics.
-                | false, _ -> startLine
-            ``attribute`` None (ident "SourceLocation") [ 
-                ``literal`` sp.SourceFile.Value 
-                ``ident`` "OperationFunctor" <|.|> ``ident`` bodyName 
-                ``literal`` startLine 
-                ``literal`` endLine
-            ]
 
         match body with 
         | Some body ->
-            let bodyName = if bodyName = "Body" then bodyName else bodyName + "Body"
-            let impl = 
+            Some (
                 ``property-arrow_get`` propertyType bodyName [``public``; ``override``]
                     ``get``
                     (``=>`` body)
-            Some (impl, attribute)
+            )
         | None ->
             None        
 
@@ -1286,9 +1231,7 @@ module SimulationCode =
         let typeArgsInterface = if (baseOp = "Operation" || baseOp = "Function") then [inType; outType] else [inType]
         let typeParameters = typeParametersNames op.Signature
         let baseClass = genericBase baseOp ``<<`` typeArgsInterface ``>>``
-        let bodies, attr = 
-            op.Specializations |> Seq.map (buildSpecialization context) |> Seq.choose id |> Seq.toList 
-            |> List.map (fun (x, y) -> (x :> MemberDeclarationSyntax, y)) |> List.unzip
+        let bodies = op.Specializations |> Seq.map (buildSpecialization context) |> Seq.choose id |> Seq.toList |> List.map (fun x -> x :> MemberDeclarationSyntax)
         let inData  = (buildDataWrapper context "In"  op.Signature.ArgumentType) 
         let outData = (buildDataWrapper context "Out" op.Signature.ReturnType)
         let innerClasses = [ inData |> snd;  outData |> snd ] |> List.choose id
@@ -1300,13 +1243,11 @@ module SimulationCode =
             else
                 [``public``; ``partial`` ]
 
-        ``attributes`` attr (
-            ``class`` name ``<<`` typeParameters ``>>``
-                ``:`` (Some baseClass) ``,`` [ ``simpleBase`` "ICallable" ] modifiers
-                ``{``
-                    (constructors @ innerClasses @ properties @ bodies @ methods) 
-                ``}``
-            )
+        ``class`` name ``<<`` typeParameters ``>>``
+            ``:`` (Some baseClass) ``,`` [ ``simpleBase`` "ICallable" ] modifiers
+            ``{``
+                (constructors @ innerClasses @ properties @ bodies @ methods) 
+            ``}``
         :> MemberDeclarationSyntax     
 
     let isUDTDeclaration =                          function | QsCustomType udt -> Some udt | _ -> None

--- a/src/Simulation/RoslynWrapper/ClassDeclaration.fs
+++ b/src/Simulation/RoslynWrapper/ClassDeclaration.fs
@@ -10,11 +10,6 @@ module ClassDeclaration =
     open Microsoft.CodeAnalysis.CSharp
     open Microsoft.CodeAnalysis.CSharp.Syntax
 
-    let private setAttributes (attributes : AttributeListSyntax seq) (cd : ClassDeclarationSyntax) = 
-        attributes
-        |> SyntaxFactory.List
-        |> cd.WithAttributeLists
-
     let private setModifiers modifiers (cd : ClassDeclarationSyntax)  =
         modifiers
         |> Seq.map SyntaxFactory.Token
@@ -43,9 +38,6 @@ module ClassDeclaration =
     let genericBase name ``<<`` typeParam ``>>`` = 
         generic name ``<<`` typeParam ``>>``|> SyntaxFactory.SimpleBaseType
 
-    let ``attributes`` attributes (classDecl : ClassDeclarationSyntax) = 
-        classDecl |> setAttributes attributes
-        
     let ``class`` className ``<<`` typeParameters ``>>``
             ``:`` baseClassName ``,`` baseInterfaces
             modifiers
@@ -57,7 +49,3 @@ module ClassDeclaration =
             |> setBases (baseClassName ?+ baseInterfaces)
             |> setModifiers modifiers
             |> setMembers members
-
-
-
-            


### PR DESCRIPTION
This reverts commit 095ab80369a35800ad27cc78aff522b01b754bfa, since this should not have gotten into the October release. I'll put up a separate PR again with the same content for proper testing before it gets into the November release. 