### PR TITLE
Test attribute definition

### DIFF
--- a/src/Simulation/Intrinsic/Diagnostics/UnitTests.qs
+++ b/src/Simulation/Intrinsic/Diagnostics/UnitTests.qs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Diagnostics {
+
+    /// # Summary
+    /// Compiler recognized attribute used to mark a unit test.
+    /// 
+    /// # Input
+    /// ## ExecutionTarget
+    /// The name of the target to execute the test on. 
+    /// Possible values are: QuantumSimulator, TraceSimulator, ToffoliSimulator
+    ///
+    @Attribute()
+    newtype TestOperation = (ExecutionTarget : String);
+}
+
+

--- a/src/Simulation/Intrinsic/Diagnostics/UnitTests.qs
+++ b/src/Simulation/Intrinsic/Diagnostics/UnitTests.qs
@@ -9,7 +9,8 @@ namespace Microsoft.Quantum.Diagnostics {
     /// # Input
     /// ## ExecutionTarget
     /// The name of the target to execute the test on. 
-    /// Possible values are: QuantumSimulator, TraceSimulator, ToffoliSimulator
+    /// The name has to be either one of the known targets, or a fully qualified name.
+    /// Known targets are: QuantumSimulator, TraceSimulator, ToffoliSimulator.
     ///
     @Attribute()
     newtype TestOperation = (ExecutionTarget : String);


### PR DESCRIPTION
Adding an attribute TestOperation to Microsoft.Quantum.Diagnostics. The attribute is recognized by the compiler and can be used to indicate a unit test. 