### PR TITLE
Full name for the simulator base in generated unit tests

### DIFF
--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -3297,7 +3297,7 @@ namespace Microsoft.Quantum.Tests.UnitTests
 #line 22 "%%%"
             {
                 var sim = new Microsoft.Quantum.Simulation.Simulators.QuantumSimulator();
-                if (sim is Common.SimulatorBase baseSim && this.Output != null)
+                if (sim is Microsoft.Quantum.Simulation.Common.SimulatorBase baseSim && this.Output != null)
                 {
                     baseSim.OnLog += this.Output.WriteLine;
                 }
@@ -3329,7 +3329,7 @@ namespace Microsoft.Quantum.Tests.UnitTests
 #line 22 "%%%"
             {
                 var sim = new Microsoft.Quantum.Simulation.Simulators.ToffoliSimulator();
-                if (sim is Common.SimulatorBase baseSim && this.Output != null)
+                if (sim is Microsoft.Quantum.Simulation.Common.SimulatorBase baseSim && this.Output != null)
                 {
                     baseSim.OnLog += this.Output.WriteLine;
                 }
@@ -3390,7 +3390,7 @@ namespace Microsoft.Quantum.Tests.UnitTests
 #line 26 "%%%"
             {
                 var sim = new SomeNamespace.CustomSimulator();
-                if (sim is Common.SimulatorBase baseSim && this.Output != null)
+                if (sim is Microsoft.Quantum.Simulation.Common.SimulatorBase baseSim && this.Output != null)
                 {
                     baseSim.OnLog += this.Output.WriteLine;
                 }

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1162,7 +1162,7 @@ module SimulationCode =
         let ``sim.OnLog`` = baseSim <|.|> ``ident`` "OnLog"
         let Run = generic "Run" ``<<`` [opName; "QVoid"; "QVoid"] ``>>``
 
-        let simCond = sim |> ``is assign`` "Common.SimulatorBase" baseSim .&&. ``this.Output`` .!=. ``null``
+        let simCond = sim |> ``is assign`` "Microsoft.Quantum.Simulation.Common.SimulatorBase" baseSim .&&. ``this.Output`` .!=. ``null``
 
         let getSimulator = ``var`` "sim" (``:=`` <| ``new`` (``ident`` <| targetName.ToString()) ``(`` [] ``)``)
         let assignLogEvent =


### PR DESCRIPTION
We need the full name here, since test project (opposed to the ones in the runtime solution) won't have the necessary namespace open. 