### PR TITLE
Fix SourceLink version.

### DIFF
--- a/src/Simulation/Common/DebugSymbols.props
+++ b/src/Simulation/Common/DebugSymbols.props
@@ -12,6 +12,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates the version of SourceLink injected by DebugSymbols.props to match the 1.0.0 version used in the standard and domain-specific libraries projects. This resolves MSB4062 errors when attempting to build a release from all repos together.