### PR TITLE
Fix mismatch in line break format in ToffoliDumpState test

### DIFF
--- a/src/Simulation/Simulators.Tests/ToffoliSimulatorTests.cs
+++ b/src/Simulation/Simulators.Tests/ToffoliSimulatorTests.cs
@@ -222,6 +222,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         [Fact]
         public void ToffoliDumpState()
         {
+            var NL = System.Environment.NewLine;
+            var expectedHeader = "Offset  \tState Data" + NL +
+                                 "========\t==========" + NL;
+
             var sim = new ToffoliSimulator();
 
             var allocate = sim.Get<Intrinsic.Allocate>();
@@ -251,32 +255,20 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var testPath = Path.GetTempFileName();
             output.WriteLine($"Dumping machine to {testPath}.");
             dumpMachine.Apply(testPath);
-            var expected = @"Offset  \tState Data
-========\t==========
-00000000\t1001001001001
-"
-                .Replace("\\t", "\t");
-            Assert.Equal(expected, File.ReadAllText(testPath));
+            var expectedAutomatic = expectedHeader + "00000000\t1001001001001" + NL;
+            Assert.Equal(expectedAutomatic, File.ReadAllText(testPath));
 
             sim.DumpFormat = ToffoliDumpFormat.Bits;
             testPath = Path.GetTempFileName();
             dumpMachine.Apply(testPath);
-            expected = @"Offset  \tState Data
-========\t==========
-00000000\t1001001001001
-"
-                .Replace("\\t", "\t");
-            Assert.Equal(expected, File.ReadAllText(testPath));
+            var expectedBits = expectedHeader + "00000000\t1001001001001" + NL;
+            Assert.Equal(expectedBits, File.ReadAllText(testPath));
 
             sim.DumpFormat = ToffoliDumpFormat.Hex;
             testPath = Path.GetTempFileName();
             dumpMachine.Apply(testPath);
-            expected = @"Offset  \tState Data
-========\t==========
-00000000\t49 12
-"
-                .Replace("\\t", "\t");
-            Assert.Equal(expected, File.ReadAllText(testPath));
+            var expectedHex = expectedHeader + "00000000\t49 12" + NL;
+            Assert.Equal(expectedHex, File.ReadAllText(testPath));
 
             // Reset and return our qubits for the next example.
             Prepare(qubits);
@@ -291,35 +283,26 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             sim.DumpFormat = ToffoliDumpFormat.Automatic;
             testPath = Path.GetTempFileName();
             dumpMachine.Apply(testPath);
-            expected = @"Offset  \tState Data
-========\t==========
-00000000\t49 92 24 49 92 24 49 92
-"
-                .Replace("\\t", "\t");
-            Assert.Equal(expected, File.ReadAllText(testPath));
+            var expectedAutomaticLarge =
+                    expectedHeader + "00000000\t49 92 24 49 92 24 49 92" + NL;
+            Assert.Equal(expectedAutomaticLarge, File.ReadAllText(testPath));
 
             sim.DumpFormat = ToffoliDumpFormat.Bits;
             testPath = Path.GetTempFileName();
             dumpMachine.Apply(testPath);
-            expected = @"Offset  \tState Data
-========\t==========
-00000000\t1001001001001001
-00000002\t0010010010010010
-00000004\t0100100100100100
-00000006\t1001001001001001
-"
-                .Replace("\\t", "\t");
-            Assert.Equal(expected, File.ReadAllText(testPath));
+            var expectedBitsLarge = expectedHeader +
+                                    "00000000\t1001001001001001" + NL +
+                                    "00000002\t0010010010010010" + NL +
+                                    "00000004\t0100100100100100" + NL +
+                                    "00000006\t1001001001001001" + NL;
+            Assert.Equal(expectedBitsLarge, File.ReadAllText(testPath));
 
             sim.DumpFormat = ToffoliDumpFormat.Hex;
             testPath = Path.GetTempFileName();
             dumpMachine.Apply(testPath);
-            expected = @"Offset  \tState Data
-========\t==========
-00000000\t49 92 24 49 92 24 49 92
-"
-                .Replace("\\t", "\t");
-            Assert.Equal(expected, File.ReadAllText(testPath));
+            var expectedHexLarge =
+                    expectedHeader + "00000000\t49 92 24 49 92 24 49 92" + NL;
+            Assert.Equal(expectedHexLarge, File.ReadAllText(testPath));
 
             // Reset and return our qubits for the next example.
             Prepare(qubits);


### PR DESCRIPTION
The test was failing locally on my machine due to mismatch between the oracle strings (\r) and the text dumped into the file (\r\n). I've changed the string to use Environment.NewLine. It passes on my machine now. Hopefully, it can work with other system defaults as well.