### PR TITLE
Copyright symbol

### DIFF
--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.nuspec.template
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.nuspec.template
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Classical simulators of quantum computers for the Q# programming language.</description>
     <releaseNotes>See: https://docs.microsoft.com/en-us/quantum/relnotes/</releaseNotes>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <tags>Quantum Q# Qsharp </tags>
   </metadata>
 


### PR DESCRIPTION
Copyright symbol was getting corrupted when generating the nuspec file from the template.