### PR TITLE
Updating the compiler and sdk package to the latest release

### DIFF
--- a/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
+++ b/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2001.1505-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2001.2831" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.1505-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2831">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\Simulators.Dev.props" />

--- a/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
+++ b/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.1505-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2831">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulation.Simulators.csproj
+++ b/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulation.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.1505-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2831">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulation.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulation.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.1505-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2831">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />


### PR DESCRIPTION
The currently used alpha version does not have the right format for diagnostics for them to be picked up by MsBuild. 