### PR TITLE
QuantumProcessor interface calls with empty controls

### DIFF
--- a/src/Simulation/Common/QuantumProcessorBase.cs
+++ b/src/Simulation/Common/QuantumProcessorBase.cs
@@ -181,7 +181,10 @@ namespace Microsoft.Quantum.Simulation.Common
 
         public virtual long StartConditionalStatement(IQArray<Result> measurementResults, IQArray<Result> resultsValues)
         {
+            if (measurementResults == null) { return 1; };
+            if (resultsValues == null) { return 1; };
             Debug.Assert(measurementResults.Count == resultsValues.Count);
+            if (measurementResults.Count != resultsValues.Count) { return 1; };
 
             int equal = 1;
 

--- a/src/Simulation/Simulators/QuantumProcessor/Assert.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Assert.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> Body => (_args) =>
             {
-                var (paulis, qubits, result, msg) = _args;
+                (IQArray<Pauli> paulis, IQArray<Qubit> qubits, Result result, string msg) = _args;
                 if (paulis.Length != qubits.Length)
                 {
                     IgnorableAssert.Assert((paulis.Length != qubits.Length), "Arrays length mismatch");

--- a/src/Simulation/Simulators/QuantumProcessor/AssertProb.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/AssertProb.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> Body => (_args) =>
             {
-                var (paulis, qubits, result, expectedPr, msg, tol) = _args;
+                (IQArray<Pauli> paulis, IQArray<Qubit> qubits, Result result, double expectedPr, string msg, double tol) = _args;
                 if (paulis.Length != qubits.Length)
                 {
                     IgnorableAssert.Assert((paulis.Length != qubits.Length), "Arrays length mismatch");
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 
                 double probabilityOfZero = result == Result.Zero ? expectedPr : 1.0 - expectedPr;
                 CommonUtils.PruneObservable(paulis, qubits, out QArray<Pauli> newPaulis, out QArray<Qubit> newQubits);
-                Simulator.QuantumProcessor.AssertProb(newPaulis, newQubits, probabilityOfZero, msg, tol );
+                Simulator.QuantumProcessor.AssertProb(newPaulis, newQubits, probabilityOfZero, msg, tol);
                 return QVoid.Instance;
             };
 

--- a/src/Simulation/Simulators/QuantumProcessor/ClassicalControl.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/ClassicalControl.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> Body => (q) =>
             {
-                var (measurementResults, resultsValues, onEqualOp, onNonEqualOp) = q;
+                (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 

--- a/src/Simulation/Simulators/QuantumProcessor/ClassicalControl.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/ClassicalControl.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(Result, ICallable, ICallable), QVoid> Body => (q) =>
             {
-                var (measurementResult, onZero, onOne) = q;
+                (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
             };
         }
@@ -104,13 +104,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(Result, IAdjointable, IAdjointable), QVoid> Body => (q) =>
             {
-                var (measurementResult, onZero, onOne) = q;
+                (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
             };
 
             public override Func<(Result, IAdjointable, IAdjointable), QVoid> AdjointBody => (q) =>
             {
-                var (measurementResult, onZero, onOne) = q;
+                (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Adjoint, null);
             };
         }
@@ -123,14 +123,21 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(Result, IControllable, IControllable), QVoid> Body => (q) =>
             {
-                var (measurementResult, onZero, onOne) = q;
+                (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
             };
 
             public override Func<(IQArray<Qubit>, (Result, IControllable, IControllable)), QVoid> ControlledBody => (q) =>
             {
-                var (ctrls, (measurementResult, onZero, onOne)) = q;
-                return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Controlled, ctrls);
+                (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
+                }
+                else
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Controlled, ctrls);
+                }
             };
         }
 
@@ -142,26 +149,42 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(Result, IUnitary, IUnitary), QVoid> Body => (q) =>
             {
-                var (measurementResult, onZero, onOne) = q;
+                (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
             };
 
             public override Func<(Result, IUnitary, IUnitary), QVoid> AdjointBody => (q) =>
             {
-                var (measurementResult, onZero, onOne) = q;
+                (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Adjoint, null);
             };
 
             public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> ControlledBody => (q) =>
             {
-                var (ctrls, (measurementResult, onZero, onOne)) = q;
-                return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Controlled, ctrls);
+                (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
+                }
+                else
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Controlled, ctrls);
+                }
             };
 
             public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> ControlledAdjointBody => (q) =>
             {
-                var (ctrls, (measurementResult, onZero, onOne)) = q;
-                return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.ControlledAdjoint, ctrls);
+                (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Adjoint, null);
+                }
+                else
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.ControlledAdjoint, ctrls);
+                }
             };
         }
 
@@ -175,7 +198,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Result>, IQArray<Result>, ICallable, ICallable), QVoid> Body => (q) =>
             {
-                var (measurementResults, resultsValues, onEqualOp, onNonEqualOp) = q;
+                (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
         }
@@ -188,13 +211,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> Body => (q) =>
             {
-                var (measurementResults, resultsValues, onEqualOp, onNonEqualOp) = q;
+                (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 
             public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> AdjointBody => (q) =>
             {
-                var (measurementResults, resultsValues, onEqualOp, onNonEqualOp) = q;
+                (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Adjoint, null);
             };
         }
@@ -207,14 +230,22 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Result>, IQArray<Result>, IControllable, IControllable), QVoid> Body => (q) =>
             {
-                var (measurementResults, resultsValues, onEqualOp, onNonEqualOp) = q;
+                (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IControllable, IControllable)), QVoid> ControlledBody => (q) =>
             {
-                var (ctrls, (measurementResults, resultsValues, onEqualOp, onNonEqualOp)) = q;
-                return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Controlled, ctrls);
+                (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
+                }
+                else
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Controlled, ctrls);
+                }
             };
         }
 
@@ -232,20 +263,36 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> AdjointBody => (q) =>
             {
-                var (measurementResults, resultsValues, onEqualOp, onNonEqualOp) = q;
+                (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Adjoint, null);
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> ControlledBody => (q) =>
             {
-                var (ctrls, (measurementResults, resultsValues, onEqualOp, onNonEqualOp)) = q;
-                return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Controlled, ctrls);
+                (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
+                }
+                else
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Controlled, ctrls);
+                }
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> ControlledAdjointBody => (q) =>
             {
-                var (ctrls, (measurementResults, resultsValues, onEqualOp, onNonEqualOp)) = q;
-                return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.ControlledAdjoint, ctrls);
+                (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Adjoint, null);
+                }
+                else
+                {
+                    return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.ControlledAdjoint, ctrls);
+                }
             };
         }
 

--- a/src/Simulation/Simulators/QuantumProcessor/Exp.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Exp.cs
@@ -20,38 +20,55 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> Body => (_args) =>
             {
-                var (paulis, theta, qubits) = _args;
+                (IQArray<Pauli> paulis, double angle, IQArray<Qubit> qubits) = _args;
 
                 if (paulis.Length != qubits.Length)
                 {
-                    throw new InvalidOperationException($"Both input arrays for {this.GetType().Name} (paulis,qubits), must be of same size.");
+                    throw new InvalidOperationException(
+                        $"Both input arrays for {this.GetType().Name} (paulis,qubits), must be of same size.");
                 }
 
                 CommonUtils.PruneObservable(paulis, qubits, out QArray<Pauli> newPaulis, out QArray<Qubit> newQubits);
-                Simulator.QuantumProcessor.Exp(newPaulis, theta, newQubits);
+
+                Simulator.QuantumProcessor.Exp(newPaulis, angle, newQubits);
 
                 return QVoid.Instance;
             };
 
             public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> AdjointBody => (_args) =>
             {
-                var (paulis, angle, qubits) = _args;
+                (IQArray<Pauli> paulis, double angle, IQArray<Qubit> qubits) = _args;
+                
                 return this.Body.Invoke((paulis, -angle, qubits));
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledBody => (_args) =>
             {
-                var (ctrls, (paulis, theta, qubits)) = _args;
+                (IQArray<Qubit> ctrls, (IQArray<Pauli> paulis, double angle, IQArray<Qubit> qubits)) = _args;
 
+                if (paulis.Length != qubits.Length)
+                {
+                    throw new InvalidOperationException(
+                        $"Both input arrays for {this.GetType().Name} (paulis,qubits), must be of same size.");
+                }
+                
                 CommonUtils.PruneObservable(paulis, qubits, out QArray<Pauli> newPaulis, out QArray<Qubit> newQubits);
-                Simulator.QuantumProcessor.ControlledExp(ctrls, newPaulis, theta, newQubits);
+                
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.Exp(newPaulis, angle, newQubits);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledExp(ctrls, newPaulis, angle, newQubits);
+                }
 
                 return QVoid.Instance;
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledAdjointBody => (_args) =>
             {
-                var (ctrls, (paulis, angle, qubits)) = _args;
+                (IQArray<Qubit> ctrls, (IQArray<Pauli> paulis, double angle, IQArray<Qubit> qubits)) = _args;
 
                 return this.ControlledBody.Invoke((ctrls, (paulis, -angle, qubits)));
             };

--- a/src/Simulation/Simulators/QuantumProcessor/H.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/H.cs
@@ -26,8 +26,17 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
             {
-                var (ctrls, q1) = args;
-                Simulator.QuantumProcessor.ControlledH(ctrls, q1);
+                (IQArray<Qubit> ctrls, Qubit q1) = args;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.H(q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledH(ctrls, q1);
+                }
+
                 return QVoid.Instance;
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/Measure.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Measure.cs
@@ -20,14 +20,16 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> Body => (_args) =>
             {
-                var (paulis, qubits) = _args;
+                (IQArray<Pauli> paulis, IQArray<Qubit> qubits) = _args;
 
                 if (paulis.Length != qubits.Length)
                 {
-                    throw new InvalidOperationException($"Both input arrays for {this.GetType().Name} (paulis,qubits), must be of same size");
+                    throw new InvalidOperationException(
+                        $"Both input arrays for {this.GetType().Name} (paulis,qubits), must be of same size");
                 }
 
                 CommonUtils.PruneObservable(paulis, qubits, out QArray<Pauli> newPaulis, out QArray<Qubit> newQubits);
+
                 return Simulator.QuantumProcessor.Measure( newPaulis, newQubits);
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/R.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/R.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(Pauli, double, Qubit), QVoid> Body => (_args) =>
             {
-                var (basis, angle, q1) = _args;
+                (Pauli basis, double angle, Qubit q1) = _args;
                 if (basis != Pauli.PauliI)
                 {
                     Simulator.QuantumProcessor.R(basis, angle,q1);
@@ -31,21 +31,30 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(Pauli, double, Qubit), QVoid> AdjointBody => (_args) =>
             {
-                var (basis, angle, q1) = _args;
+                (Pauli basis, double angle, Qubit q1) = _args;
                 return this.Body.Invoke((basis, -angle, q1));
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledBody => (_args) =>
             {
-                var (ctrls, (basis, angle, q1)) = _args;
-                Simulator.QuantumProcessor.ControlledR(ctrls, basis, angle, q1);
+                (IQArray<Qubit> ctrls, (Pauli basis, double angle, Qubit q1)) = _args;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.R(basis, angle, q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledR(ctrls, basis, angle, q1);
+                }
+
                 return QVoid.Instance;
             };
 
 
             public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
             {
-                var (ctrls, (basis, angle, q1)) = _args;
+                (IQArray<Qubit> ctrls, (Pauli basis, double angle, Qubit q1)) = _args;
                 return this.ControlledBody.Invoke((ctrls, (basis, -angle, q1)));
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/R1.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/R1.cs
@@ -20,28 +20,37 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(double, Qubit), QVoid> Body => (_args) =>
             {
-                var (angle, q1) = _args;
+                (double angle, Qubit q1) = _args;
                 Simulator.QuantumProcessor.R1(angle, q1);
                 return QVoid.Instance;
             };
 
             public override Func<(double, Qubit), QVoid> AdjointBody => (_args) =>
             {
-                var (angle, q1) = _args;
+                (double angle, Qubit q1) = _args;
                 return this.Body.Invoke((-angle, q1));
             };
 
             public override Func<(IQArray<Qubit>, ( double, Qubit)), QVoid> ControlledBody => (_args) =>
             {
-                var (ctrls, (angle, q1)) = _args;
-                Simulator.QuantumProcessor.ControlledR1(ctrls, angle, q1);
+                (IQArray<Qubit> ctrls, (double angle, Qubit q1)) = _args;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.R1(angle, q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledR1(ctrls, angle, q1);
+                }
+
                 return QVoid.Instance;
             };
 
 
             public override Func<(IQArray<Qubit>, (double, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
             {
-                var (ctrls, (angle, q1)) = _args;
+                (IQArray<Qubit> ctrls, (double angle, Qubit q1)) = _args;
                 return this.ControlledBody.Invoke((ctrls, (-angle, q1)));
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/R1Frac.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/R1Frac.cs
@@ -21,29 +21,38 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(long, long, Qubit), QVoid> Body => (_args) =>
             {
-                var (num, denom , q1) = _args;
-                var (numNew, denomNew) = CommonUtils.Reduce(num, denom);
+                (long num, long denom, Qubit q1) = _args;
+                (long numNew, long denomNew) = CommonUtils.Reduce(num, denom);
                 Simulator.QuantumProcessor.R1Frac(numNew, denomNew, q1);
                 return QVoid.Instance;
             };
 
             public override Func<(long, long, Qubit), QVoid> AdjointBody => (_args) =>
             {
-                var (num, denom, q1) = _args;
+                (long num, long denom, Qubit q1) = _args;
                 return this.Body.Invoke((-num, denom, q1));
             };
 
             public override Func<(IQArray<Qubit>, (long, long, Qubit)), QVoid> ControlledBody => (_args) =>
             {
-                var (ctrls, (num, denom, q1)) = _args;
-                var (numNew, denomNew) = CommonUtils.Reduce(num, denom);
-                Simulator.QuantumProcessor.ControlledR1Frac(ctrls, numNew, denomNew, q1);
+                (IQArray<Qubit> ctrls, (long num, long denom, Qubit q1)) = _args;
+                (long numNew, long denomNew) = CommonUtils.Reduce(num, denom);
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.R1Frac(numNew, denomNew, q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledR1Frac(ctrls, numNew, denomNew, q1);
+                }
+
                 return QVoid.Instance;
             };
 
             public override Func<(IQArray<Qubit>, (long, long, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
             {
-                var (ctrls, (num, denom, q1)) = _args;
+                (IQArray<Qubit> ctrls, (long num, long denom, Qubit q1)) = _args;
                 return this.ControlledBody.Invoke((ctrls, (-num, denom, q1)));
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/RFrac.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/RFrac.cs
@@ -22,10 +22,10 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(Pauli, long, long, Qubit), QVoid> Body => (_args) =>
             {
-                var (basis, num, denom , q1) = _args;
+                (Pauli basis, long num, long denom, Qubit q1) = _args;
                 if (basis != Pauli.PauliI)
                 {
-                    var (numNew, denomNew) = CommonUtils.Reduce(num, denom);
+                    (long numNew, long denomNew) = CommonUtils.Reduce(num, denom);
                     Simulator.QuantumProcessor.RFrac(basis, numNew, denomNew, q1);
                 }
                 return QVoid.Instance;
@@ -33,21 +33,30 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(Pauli, long, long, Qubit), QVoid> AdjointBody => (_args) =>
             {
-                var (basis, num, denom, q1) = _args;
+                (Pauli basis, long num, long denom, Qubit q1) = _args;
                 return this.Body.Invoke((basis, -num, denom, q1));
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledBody => (_args) =>
             {
-                var (ctrls, (basis, num, denom, q1)) = _args;
-                var (numNew, denomNew) = CommonUtils.Reduce(num, denom);
-                Simulator.QuantumProcessor.ControlledRFrac(ctrls, basis, numNew, denomNew, q1);
+                (IQArray<Qubit> ctrls, (Pauli basis, long num, long denom, Qubit q1)) = _args;
+                (long numNew, long denomNew) = CommonUtils.Reduce(num, denom);
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.RFrac(basis, numNew, denomNew, q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledRFrac(ctrls, basis, numNew, denomNew, q1);
+                }
+
                 return QVoid.Instance;
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
             {
-                var (ctrls, (basis, num, denom, q1)) = _args;
+                (IQArray<Qubit> ctrls, (Pauli basis, long num, long denom, Qubit q1)) = _args;
                 return this.ControlledBody.Invoke((ctrls, (basis, -num, denom, q1)));
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/S.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/S.cs
@@ -26,7 +26,16 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
             public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
-                Simulator.QuantumProcessor.ControlledS(ctrls, q1);
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.S(q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledS(ctrls, q1);
+                }
+
                 return QVoid.Instance;
             };
 
@@ -39,7 +48,16 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
             public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
-                Simulator.QuantumProcessor.ControlledSAdjoint(ctrls, q1);
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.SAdjoint(q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledSAdjoint(ctrls, q1);
+                }
+
                 return QVoid.Instance;
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/SWAP.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/SWAP.cs
@@ -25,8 +25,17 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Qubit>, (Qubit, Qubit)), QVoid> ControlledBody => (args) =>
             {
-                var (ctrls, q1) = args;
-                Simulator.QuantumProcessor.ControlledSWAP(ctrls, q1.Item1, q1.Item2);
+                (IQArray<Qubit> ctrls, (Qubit q1, Qubit q2) ) = args;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.SWAP(q1, q2);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledSWAP(ctrls, q1, q2);
+                }
+
                 return QVoid.Instance;
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/T.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/T.cs
@@ -41,7 +41,16 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
             public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
-                Simulator.QuantumProcessor.ControlledTAdjoint(ctrls, q1);
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.TAdjoint(q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledTAdjoint(ctrls, q1);
+                }
+
                 return QVoid.Instance;
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/X.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/X.cs
@@ -25,8 +25,17 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
             {
-                var (ctrls, q1) = args;
-                Simulator.QuantumProcessor.ControlledX(ctrls, q1);
+                (IQArray<Qubit> ctrls, Qubit q1) = args;
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.X(q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledX(ctrls, q1);
+                }
+
                 return QVoid.Instance;
             };
         }

--- a/src/Simulation/Simulators/QuantumProcessor/Y.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Y.cs
@@ -26,7 +26,16 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
             public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
-                Simulator.QuantumProcessor.ControlledY(ctrls, q1);
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.Y(q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledY(ctrls, q1);
+                }
+
                 return QVoid.Instance;
             };            
         }

--- a/src/Simulation/Simulators/QuantumProcessor/Z.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Z.cs
@@ -26,7 +26,16 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
             public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
-                Simulator.QuantumProcessor.ControlledZ(ctrls, q1);
+
+                if ((ctrls == null) || (ctrls.Count == 0))
+                {
+                    Simulator.QuantumProcessor.Z(q1);
+                }
+                else
+                {
+                    Simulator.QuantumProcessor.ControlledZ(ctrls, q1);
+                }
+
                 return QVoid.Instance;
             };
         }


### PR DESCRIPTION
QuantumProcessor interface will not call controlled versions of APIs when the list of controls is empty or null. It will call non-controlled versions instead.