### PR TITLE
Changed stack matching algorithm not to match some Q# frames

### DIFF
--- a/src/Simulation/Common/StackTrace.cs
+++ b/src/Simulation/Common/StackTrace.cs
@@ -162,11 +162,11 @@ namespace Microsoft.Quantum.Simulation.Common
         /// <summary>
         /// Return next Q# stack frame that has enough information to match
         /// </summary>
-        private static StackFrame GetNextQSharpStackFrame(StackFrame[] qsharpStackFrames, ref int currentFrameIndex)
+        private static StackFrame GetNextQSharpStackFrame(StackFrame[] qsharpStack, ref int currentFrameIndex)
         {
-            while (currentFrameIndex < qsharpStackFrames.Length)
+            while (currentFrameIndex < qsharpStack.Length)
             {
-                StackFrame currentFrame = qsharpStackFrames[currentFrameIndex];
+                StackFrame currentFrame = qsharpStack[currentFrameIndex];
                 currentFrameIndex++;
                 if (!string.IsNullOrEmpty(currentFrame.SourceFile))
                 {
@@ -179,11 +179,11 @@ namespace Microsoft.Quantum.Simulation.Common
         /// <summary>
         /// Return next C# stack frame that has enough information to match
         /// </summary>
-        private static System.Diagnostics.StackFrame GetNextCSharpStackFrame(System.Diagnostics.StackFrame[] csharpCallStack, ref int currentFrameIndex)
+        private static System.Diagnostics.StackFrame GetNextCSharpStackFrame(System.Diagnostics.StackFrame[] csharpStack, ref int currentFrameIndex)
         {
-            while(currentFrameIndex < csharpCallStack.Length)
+            while(currentFrameIndex < csharpStack.Length)
             {
-                System.Diagnostics.StackFrame currentFrame = csharpCallStack[currentFrameIndex];
+                System.Diagnostics.StackFrame currentFrame = csharpStack[currentFrameIndex];
                 currentFrameIndex++;
                 if (!string.IsNullOrEmpty(currentFrame.GetFileName()) && currentFrame.GetFileLineNumber() != 0)
                 {

--- a/src/Simulation/Simulators.Tests/StackTraceTests.cs
+++ b/src/Simulation/Simulators.Tests/StackTraceTests.cs
@@ -38,7 +38,19 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 catch (AggregateException ex)
                 {
                     Assert.True(ex.InnerException is ExecutionFailException);
-                    // TODO: Need more checks here - stack frames and line numbers
+
+                    StackFrame[] stackFrames = sim.CallStack;
+
+                    // The following assumes that Assert is on Q# stack.
+                    Assert.Equal(2, stackFrames.Length);
+
+                    Assert.Equal("Microsoft.Quantum.Intrinsic.Assert", stackFrames[0].Callable.FullName);
+                    Assert.Equal(namespacePrefix + "AllocateQubit2", stackFrames[1].Callable.FullName);
+
+                    Assert.Equal(OperationFunctor.Body, stackFrames[0].Callable.Variant);
+                    Assert.Equal(OperationFunctor.Body, stackFrames[1].Callable.Variant);
+
+                    Assert.Equal(94, stackFrames[1].FailedLineNumber);
                 }
             }
         }


### PR DESCRIPTION
Updated Q# - C# stack matching algorithm. Skipping Q# frames that have no chance of matching - i.e. those that have no source information.
This helps continue matching even if Q# intrinsic function is on stack, which has no source information.
