### PR TITLE
Bug fix for chained copy-and-update expressions for named items

### DIFF
--- a/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
+++ b/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
@@ -1301,7 +1301,8 @@ namespace Microsoft.Quantum.Compiler.Generics {
     function UpdateUdtItems (udt : MyType2) : MyType2 {
     
         return udt
-            w/ i1 <- 0; 
+            w/ i1 <- 0
+            w/ i4 <- "Hello";
     
     }
 }

--- a/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
+++ b/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
@@ -1301,9 +1301,9 @@ namespace Microsoft.Quantum.Compiler.Generics {
     function UpdateUdtItems (udt : MyType2) : MyType2 {
     
         return udt
-            w/ i1 <- 0
-            w/ i4 <- "Hello";
-    
+            w/ i1 <- -5
+            w/ i4 <- "Hello"
+            w/ i1 <- 1;    
     }
 }
 

--- a/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
+++ b/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
@@ -1294,7 +1294,16 @@ namespace Microsoft.Quantum.Compiler.Generics {
             set arr = arr w/ i <- map(arr[i]);
         }
     }
+
+    newtype MyType1 = (i1 : Int[], i2 : Double);
+    newtype MyType2 = (i1 : Int, i2 : MyType1, (i3 : Int[], i4 : String));
+
+    function UpdateUdtItems (udt : MyType2) : MyType2 {
     
+        return udt
+            w/ i1 <- 0; 
+    
+    }
 }
 
 

--- a/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
+++ b/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
@@ -1300,9 +1300,10 @@ namespace Microsoft.Quantum.Compiler.Generics {
 
     function UpdateUdtItems (udt : MyType2) : MyType2 {
     
+        mutable arr = new Int[10];
         return udt
             w/ i1 <- -5
-            w/ i4 <- "Hello"
+            w/ i3 <- arr 
             w/ i1 <- 1;    
     }
 }

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -2638,7 +2638,7 @@ namespace N1
         public override Func<MyType2, MyType2> Body => (__in__) => 
         {
             var udt = __in__;
-            return new MyType2((newMyType2((0L,udt.Data.Item2,(udt.Data.Item3.Item1,udt.Data.Item3.Item2))).Data.Item1,newMyType2((0L,udt.Data.Item2,(udt.Data.Item3.Item1,udt.Data.Item3.Item2))).Data.Item2,(newMyType2((0L,udt.Data.Item2,(udt.Data.Item3.Item1,udt.Data.Item3.Item2))).Data.Item3.Item1,"Hello")));
+            return new MyType2((1L,udt.Data.Item2,(udt.Data.Item3.Item1,"Hello")));
         };
         
         public override void Init() { }

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -2638,7 +2638,8 @@ namespace N1
         public override Func<MyType2, MyType2> Body => (__in__) => 
         {
             var udt = __in__;
-            return new MyType2((1L,udt.Data.Item2,(udt.Data.Item3.Item1,"Hello")));
+            vararr=QArray<Int64>.Create(10L);
+            return new MyType2((1L,udt.Data.Item2,(arr?.Copy(),udt.Data.Item3.Item2)));
         };
         
         public override void Init() { }

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -2638,7 +2638,7 @@ namespace N1
         public override Func<MyType2, MyType2> Body => (__in__) => 
         {
             var udt = __in__;
-            return new MyType2((0L,udt.Data.Item2,(udt.Data.Item3.Item1,udt.Data.Item3.Item2)));
+            return new MyType2((newMyType2((0L,udt.Data.Item2,(udt.Data.Item3.Item1,udt.Data.Item3.Item2))).Data.Item1,newMyType2((0L,udt.Data.Item2,(udt.Data.Item3.Item1,udt.Data.Item3.Item2))).Data.Item2,(newMyType2((0L,udt.Data.Item2,(udt.Data.Item3.Item1,udt.Data.Item3.Item2))).Data.Item3.Item1,"Hello")));
         };
         
         public override void Init() { }

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -193,6 +193,7 @@ namespace N1
     let returnTest10                            = findCallable @"returnTest10"
     let bitOperations                           = findCallable @"bitOperations"
     let testLengthDependency                    = findCallable @"testLengthDependency"
+    let UpdateUdtItems                          = findCallable @"UpdateUdtItems"
     
     let udt_args0                               = findUdt @"udt_args0"
     let udt_args1                               = findUdt @"udt_args1"
@@ -2621,6 +2622,38 @@ namespace N1
 
     [<Fact>]
     let ``buildOperationClass - concrete functions`` () = 
+        """
+    [SourceLocation("%%%", OperationFunctor.Body, 1301,-1)]
+    public partial class UpdateUdtItems : Function<MyType2, MyType2>, ICallable
+    {
+        public UpdateUdtItems(IOperationFactorym) : base(m)
+        {
+        }
+        
+        String ICallable.Name => "UpdateUdtItems";
+        String ICallable.FullName => "Microsoft.Quantum.Compiler.Generics.UpdateUdtItems";
+        
+        public static OperationInfo<MyType2, MyType2> Info => new OperationInfo<MyType2, MyType2>(typeof(UpdateUdtItems));
+        
+        public override Func<MyType2, MyType2> Body => (__in__) => 
+        {
+            var udt = __in__;
+            return new MyType2((0L,udt.Data.Item2,(udt.Data.Item3.Item1,udt.Data.Item3.Item2)));
+        };
+        
+        public override void Init() { }
+        
+        public override IApplyData __dataIn(MyType2data) => data;
+        public override IApplyData __dataOut(MyType2data) => data;
+        public static System.Threading.Tasks.Task<MyType2> Run(IOperationFactory __m__, MyType2 udt)
+        {
+            return __m__.Run<UpdateUdtItems,MyType2,MyType2>(udt);
+        }
+    }
+        """
+        |> testOneClass UpdateUdtItems
+
+
         """
     public abstract partial class emptyFunction : Function<QVoid, QVoid>, ICallable
     {

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -423,19 +423,23 @@ module SimulationCode =
                 lhsAsQArray <.> (``ident`` "Modify", [ buildExpression accEx; captureExpression rhsEx ]) // in-place modification
             | _ -> lhsEx.ResolvedType.Resolution |> function
                 | UserDefinedType udt -> 
-                    let itemName = accEx.Expression |> function
-                        | Identifier (LocalVariable id, Null) -> id
-// TODO: Diagnostics
-                        | _ -> failwith "item access expression in copy-and-update expression for user defined type is not a suitable identifier"
                     let name = QsQualifiedName.New (udt.Namespace, udt.Name)
                     let decl = findUdt context name
-                    let root = (buildExpression lhsEx) <|.|> (``ident`` "Data")
+
+                    let updatedItems = accEx.Expression |> function
+                        | Identifier (LocalVariable id, Null) -> id.Value, captureExpression rhsEx
+// TODO: Diagnostics
+                        | _ -> failwith "item access expression in copy-and-update expression for user defined type is not a suitable identifier"
+
+                    let lhs = buildExpression lhsEx // FIXME: THIS IS BAD! WE NEED TO CONSOLIDATE FIRST!
+
+                    let root = lhs <|.|> (``ident`` "Data")
                     let items = getAllItems root decl.Type
                     let rec buildArg  = function 
                         | QsTuple args -> args |> Seq.map buildArg |> Seq.toList |> ``tuple``
-                        | QsTupleItem (Named item) when item.VariableName.Value = itemName.Value -> 
+                        | QsTupleItem (Named item) when item.VariableName.Value = fst updatedItems -> 
                             items.Dequeue() |> ignore
-                            captureExpression rhsEx
+                            snd updatedItems
                         | QsTupleItem _ -> items.Dequeue()
                     ``new`` (``type`` [ justTheName context name ]) ``(`` [buildArg decl.TypeItems] ``)``                       
                 | _ -> failwith "copy-and-update expressions are currently only supported for arrays and user defined types"


### PR DESCRIPTION
This should fix https://github.com/microsoft/qsharp-runtime/issues/150, as well as a performance issue for one of the ML samples. 