### PR TITLE
Adding a EnableTestingViaName attribute

### DIFF
--- a/src/Simulation/QsharpCore/Diagnostics/UnitTests.qs
+++ b/src/Simulation/QsharpCore/Diagnostics/UnitTests.qs
@@ -14,6 +14,16 @@ namespace Microsoft.Quantum.Diagnostics {
     ///
     @Attribute()
     newtype Test = (ExecutionTarget : String);
+
+    /// # Summary
+    /// Compiler recognized attribute via which an alternative name can be defined 
+    /// that may be used when loading a type or callable for testing purposes.
+    /// 
+    /// # Input
+    /// Defined name for testing purposes. 
+    /// The String is expected to contain a fully qualified name. 
+    @Attribute()
+    newtype EnableTestingViaName = String;
 }
 
 


### PR DESCRIPTION
For testing purposes, it is convenient if it is possible to compare different implementation for the same callables. We can facilitiate that with some built-in support. See also https://github.com/microsoft/qsharp-compiler/pull/373
