### PR TITLE
Generate private-protected C# properties for internal Q# callables

### DIFF
--- a/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
+++ b/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
@@ -1309,11 +1309,20 @@ namespace Microsoft.Quantum.Compiler.Generics {
 
     // Access Modifiers
 
-    internal function InternalFunction () : Unit {
-    }
+    internal function EmptyInternalFunction () : Unit { }
 
-    internal operation InternalOperation () : Unit {
-    }
+    internal operation EmptyInternalOperation () : Unit { }
 
     internal newtype InternalType = Unit;
+
+    internal operation MakeInternalType () : InternalType {
+        return InternalType();
+    }
+
+    operation UseInternalCallables () : Unit {
+        EmptyInternalFunction();
+        EmptyInternalOperation();
+        let x = InternalType();
+        let y = MakeInternalType();
+    }
 }

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -904,15 +904,15 @@ module SimulationCode =
     /// a Property that returns an instance of the operation by calling the
     /// IOperationFactory
     let buildOpsProperties context (operations : QsQualifiedName list): MemberDeclarationSyntax list =
-        let getAccessModifier qualifiedName =
+        let getCallableAccessModifier qualifiedName =
             match context.allCallables.TryGetValue qualifiedName with
             | true, callable -> Some callable.Modifiers.Access
             | false, _ -> None
 
-        let getModifiers qualifiedName =
+        let getPropertyModifiers qualifiedName =
             // Use the right accessibility for the property depending on the accessibility of the callable.
             // Note: In C#, "private protected" is the intersection of protected and internal.
-            match getAccessModifier qualifiedName |> Option.defaultValue DefaultAccess with
+            match getCallableAccessModifier qualifiedName |> Option.defaultValue DefaultAccess with
             | DefaultAccess -> [ ``protected`` ]
             | Internal -> [ ``private``; ``protected`` ]
 
@@ -921,7 +921,7 @@ module SimulationCode =
             /// protected opType opName { get; }
             let signature = roslynCallableTypeName context qualifiedName
             let name = getOpName context qualifiedName
-            let modifiers = getModifiers qualifiedName
+            let modifiers = getPropertyModifiers qualifiedName
             ``prop`` signature name modifiers
             :> MemberDeclarationSyntax
 

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -899,17 +899,24 @@ module SimulationCode =
             [ ``public`` ]
             ``{`` [] ``}``
         :> MemberDeclarationSyntax     
-       
+
     /// For each Operation used in the given OperationDeclartion, returns
-    /// a Property that returns an instance of the operation by calling the 
+    /// a Property that returns an instance of the operation by calling the
     /// IOperationFactory
     let buildOpsProperties context (operations : QsQualifiedName list): MemberDeclarationSyntax list =
-        let buildOne n =
+        let getModifiers qualifiedName =
+            // Use the right accessibility for the property depending on the accessibility of the callable. Note: In C#,
+            // "private protected" is the intersection of protected and internal.
+            match context.allCallables.[qualifiedName].Modifiers.Access with
+            | DefaultAccess -> [ ``protected`` ]
+            | Internal -> [ ``private``; ``protected`` ]
+        let buildOne qualifiedName =
             /// eg:
             /// protected opType opName { get; }
-            let signature = roslynCallableTypeName context n
-            let name = getOpName context n
-            ``prop`` signature name [ ``protected`` ] 
+            let signature = roslynCallableTypeName context qualifiedName
+            let name = getOpName context qualifiedName
+            let modifiers = getModifiers qualifiedName
+            ``prop`` signature name modifiers
             :> MemberDeclarationSyntax
         operations
         |> List.map buildOne

--- a/src/Simulation/Simulators.Tests/Circuits/CoreOperations.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/CoreOperations.qs
@@ -593,5 +593,24 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
 
         AssertEqual(true, (pi > 3.14 and pi < 3.15));
     }
-}
 
+    internal function EmptyInternalFunction() : Unit { }
+
+    internal operation EmptyInternalOperation() : Unit { }
+
+    internal newtype InternalType = Int;
+
+    internal operation MakeInternalType() : InternalType {
+        return InternalType(5);
+    }
+
+    // This is a public operation that uses an internal type inside to test the access modifiers of the generated
+    // operation properties.
+    operation InternalCallablesTest() : Unit {
+        EmptyInternalFunction();
+        EmptyInternalOperation();
+        let x = InternalType(3);
+        let y = MakeInternalType();
+        AssertEqual(15, x! * y!);
+    }
+}

--- a/src/Simulation/Simulators.Tests/CoreTests.cs
+++ b/src/Simulation/Simulators.Tests/CoreTests.cs
@@ -279,5 +279,9 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             }
             Assert.Equal(1, exceptionCount); // check that we cought exception once
         }
+
+        [Fact]
+        public void InternalCallables() =>
+            Helper.RunWithMultipleSimulators(s => Circuits.InternalCallablesTest.Run(s).Wait());
     }
 }


### PR DESCRIPTION
Fixes #164.