### PR TITLE
Added /Qspectre to MSVC compiler of the native simulator

### DIFF
--- a/src/Simulation/Native/CMakeLists.txt
+++ b/src/Simulation/Native/CMakeLists.txt
@@ -34,6 +34,7 @@ option(USE_GATE_FUSION "Use gate fusion" ON)
 if (MSVC)
   # always create debug info
   add_definitions("/Zi")
+  add_definitions("/Qspectre")
 
   # build with no VC runtime depedencies:
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")


### PR DESCRIPTION
This is to enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities.