### PR TITLE
Qubit manager allows allocating zero qubits

### DIFF
--- a/src/Simulation/Common/QubitManager.cs
+++ b/src/Simulation/Common/QubitManager.cs
@@ -259,13 +259,17 @@ namespace Microsoft.Quantum.Simulation.Common
         /// </summary>
         public virtual IQArray<Qubit> Allocate(long numToAllocate)
         {
-            IgnorableAssert.Assert(numToAllocate > 0, "Attempt to allocate zero qubits.");
-            if (numToAllocate <= 0)
+            IgnorableAssert.Assert(numToAllocate >= 0, "Attempt to allocate negative number of qubits.");
+            if (numToAllocate < 0)
             {
-                throw new ArgumentException("Attempt to allocate zero qubits.");
+                throw new ArgumentException("Attempt to allocate negative number of qubits.");
+            }
+            else if (numToAllocate == 0)
+            {
+                return QArray<Qubit>.Create(0);
             }
 
-            var result = QArray<Qubit>.Create(numToAllocate); 
+            QArray<Qubit> result = QArray<Qubit>.Create(numToAllocate); 
 
             for (int i = 0; i < numToAllocate; i++)
             {
@@ -324,7 +328,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 return;
             }
 
-            foreach (var qubit in qubitsToRelease)
+            foreach (Qubit qubit in qubitsToRelease)
             {
                 this.ReleaseOneQubit(qubit, usedOnlyForBorrowing: false);
             }
@@ -361,7 +365,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 return;
             }
 
-            foreach (var qubit in qubitsToDisable)
+            foreach (Qubit qubit in qubitsToDisable)
             {
                 this.DisableOneQubit(qubit);
             }
@@ -412,10 +416,14 @@ namespace Microsoft.Quantum.Simulation.Common
         /// </summary>
         public virtual IQArray<Qubit> Borrow(long numToBorrow, IEnumerable<Qubit> excludedQubitsSortedById) // Note, excluded could be an array of Ids for efficiency, if it is convenient for compiler.
         {
-            IgnorableAssert.Assert(numToBorrow > 0, "Attempt to borrow zero qubits.");
-            if (numToBorrow <= 0)
+            IgnorableAssert.Assert(numToBorrow >= 0, "Attempt to borrow negative number of qubits.");
+            if (numToBorrow < 0)
             {
-                throw new ArgumentException("Attempt to borrow zero qubits.");
+                throw new ArgumentException("Attempt to borrow negative number of qubits.");
+            }
+            else if (numToBorrow == 0)
+            {
+                return QArray<Qubit>.Create(0);
             }
 
             if (DisableBorrowing)
@@ -427,7 +435,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 excludedQubitsSortedById = new Qubit[0];
             }
 
-            var result = QArray<Qubit>.Create(numToBorrow); 
+            QArray<Qubit> result = QArray<Qubit>.Create(numToBorrow); 
             long numBorrowed = TryBorrow(numToBorrow, result, excludedQubitsSortedById);
 
             if (numBorrowed < numToBorrow)
@@ -513,7 +521,7 @@ namespace Microsoft.Quantum.Simulation.Common
             }
 
             long count = 0;
-            foreach (var qubit in qubitsToReturn)
+            foreach (Qubit qubit in qubitsToReturn)
             {
                 if (this.ToBeReleasedAfterReturn(qubit)) 
                 { 
@@ -557,7 +565,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 return;
             }
 
-            foreach (var qubit in qubitsToReturn)
+            foreach (Qubit qubit in qubitsToReturn)
             {
                 this.Return(qubit);
             }

--- a/src/Simulation/Simulators.Tests/QubitManagerTests.cs
+++ b/src/Simulation/Simulators.Tests/QubitManagerTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.True(q1.Id == 0);
 
             // Test allocation of multiple qubits
-            var qa1 = qm.Allocate(4);
+            IQArray<Qubit> qa1 = qm.Allocate(4);
             Assert.True(qa1.Length == 4);
             Assert.True(qa1[0].Id == 1);
             Assert.True(qa1[1].Id == 2);
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Qubit q2 = qm.Allocate();
             Assert.True(q2.Id == 2);
 
-            var qa2 = qm.Allocate(3);
+            IQArray<Qubit> qa2 = qm.Allocate(3);
             Assert.True(qa2.Length == 3);
             Assert.True(qa2[0].Id == 5);
             Assert.True(qa2[1].Id == 6);
@@ -64,7 +64,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             long qubitsAvailable;
 
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qab = qm.Borrow(5, exclusion);
+            IQArray<Qubit> qab = qm.Borrow(5, exclusion);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 1);
             Assert.True(qab[0].Id == 0);
             Assert.True(qab[1].Id == 2);
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             // Test borrowing of the same qubit again
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qb1 = qm.Borrow(1, exclusion);
+            IQArray<Qubit> qb1 = qm.Borrow(1, exclusion);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 0);
             Assert.True(qb1[0].Id == 0);
             qm.Return(qb1[0]);
@@ -93,7 +93,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             qm.Release(qa1[2]);
             qm.Release(q1);
 
-            var qa3 = qm.Allocate(4);
+            IQArray<Qubit> qa3 = qm.Allocate(4);
             Assert.True(qa3.Length == 4);
             Assert.True(qa3[0].Id == 0);
             Assert.True(qa3[1].Id == 3);
@@ -104,15 +104,24 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Qubit q8 = qm.Allocate();
             Assert.True(q8.Id == 11);
             qm.Disable(q8);
-            var qab2 = qm.Borrow(12, null);
+            IQArray<Qubit> qab2 = qm.Borrow(12, null);
             Assert.True(qab2[11].Id == 12);  // make sure 11 is not borrowed.
             qm.Release(q8);
             qm.Return(qab2);
 
-            var qa4 = qm.Allocate(2);
+            IQArray<Qubit> qa4 = qm.Allocate(2);
             Assert.True(qa4[0].Id == 12); // make sure 11 is not reused.
             Assert.True(qa4[1].Id == 13); // make sure 11 is not reused.
             qm.Release(qa4);
+
+
+            { // Test allocating zero qubits
+                IQArray<Qubit> n_q;
+                n_q = qm.Allocate(0);
+                Assert.True(n_q.Length == 0);
+                n_q = qm.Borrow(0, exclusion);
+                Assert.True(n_q.Length == 0);
+            }
 
             // Test allocating qubits over capacity
             OperationsTestHelper.IgnoreDebugAssert(() =>
@@ -122,9 +131,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 Assert.Throws<NotEnoughQubits>(() => n_q = qm.Allocate(10));
                 Assert.Throws<NotEnoughQubits>(() => n_q = qm.Borrow(25, exclusion));
 
-                Assert.Throws<ArgumentException>(() => n_q = qm.Allocate(0));
                 Assert.Throws<ArgumentException>(() => n_q = qm.Allocate(-2));
-                Assert.Throws<ArgumentException>(() => n_q = qm.Borrow(0, exclusion));
                 Assert.Throws<ArgumentException>(() => n_q = qm.Borrow(-2, exclusion));
             });
         }
@@ -140,7 +147,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Qubit q1 = qm.Allocate();
             Assert.True(q1.Id == 0);
 
-            var qa1 = qm.Allocate(4);
+            IQArray<Qubit> qa1 = qm.Allocate(4);
             Assert.True(qa1.Length == 4);
             Assert.True(qa1[0].Id == 1);
             Assert.True(qa1[1].Id == 2);
@@ -155,7 +162,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             long qubitsAvailable;
 
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qb1 = qm.Borrow(3);
+            IQArray<Qubit> qb1 = qm.Borrow(3);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 1);
             Assert.True(qb1[0].Id == 0);
             Assert.True(qb1[1].Id == 5);
@@ -164,7 +171,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             qm.Return(qb1[2]);
 
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qb2 = qm.Borrow(3);
+            IQArray<Qubit> qb2 = qm.Borrow(3);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 2);
             Assert.True(qb2[0].Id == 0);
             Assert.True(qb2[1].Id == 6);
@@ -174,7 +181,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 qm.OnOperationStart(null, qb2);
 
                 qubitsAvailable = qm.GetFreeQubitsCount();
-                var qb3 = qm.Borrow(3);
+                IQArray<Qubit> qb3 = qm.Borrow(3);
                 Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 0);
                 Assert.True(qb3[0].Id == 1);
                 Assert.True(qb3[1].Id == 2);
@@ -184,7 +191,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             }
 
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qb4 = qm.Borrow(1);
+            IQArray<Qubit> qb4 = qm.Borrow(1);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 1);
             Assert.True(qb4[0].Id == 8);
 
@@ -199,7 +206,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Qubit q1 = qm.Allocate();
             Assert.True(q1.Id == 0);
 
-            var qa1 = qm.Allocate(4);
+            IQArray<Qubit> qa1 = qm.Allocate(4);
             Assert.True(qa1.Length == 4);
             Assert.True(qa1[0].Id == 1);
             Assert.True(qa1[1].Id == 2);
@@ -214,7 +221,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             long qubitsAvailable;
 
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qb1 = qm.Borrow(3);
+            IQArray<Qubit> qb1 = qm.Borrow(3);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 3);
             Assert.True(qb1[0].Id == 6);
             Assert.True(qb1[1].Id == 7);
@@ -228,7 +235,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.True(qubitsAvailable == 13);
 
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qb2 = qm.Borrow(3);
+            IQArray<Qubit> qb2 = qm.Borrow(3);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 3);
             Assert.True(qb2[0].Id == 8);
             Assert.True(qb2[1].Id == 6);
@@ -240,7 +247,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 qm.OnOperationStart(null, qb2);
 
                 qubitsAvailable = qm.GetFreeQubitsCount();
-                var qb3 = qm.Borrow(3);
+                IQArray<Qubit> qb3 = qm.Borrow(3);
                 Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 3);
                 Assert.True(qb3[0].Id == 10);
                 Assert.True(qb3[1].Id == 11);
@@ -257,7 +264,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.True(qubitsAvailable == 8);
 
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qb4 = qm.Borrow(1);
+            IQArray<Qubit> qb4 = qm.Borrow(1);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 1);
             Assert.True(qb4[0].Id == 6);
             qubitsAvailable = qm.GetFreeQubitsCount();
@@ -274,7 +281,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Qubit q1 = qm.Allocate();
             Assert.True(q1.Id == 0);
 
-            var qa1 = qm.Allocate(4);
+            IQArray<Qubit> qa1 = qm.Allocate(4);
             Assert.True(qa1.Length == 4);
             Assert.True(qa1[0].Id == 1);
             Assert.True(qa1[1].Id == 2);
@@ -289,7 +296,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             long qubitsAvailable;
 
             qubitsAvailable = qm.GetFreeQubitsCount();
-            var qb1 = qm.Borrow(3);
+            IQArray<Qubit> qb1 = qm.Borrow(3);
             Assert.True(qubitsAvailable - qm.GetFreeQubitsCount() == 1);
             Assert.True(qb1[0].Id == 0);
             Assert.True(qb1[1].Id == 5);
@@ -299,7 +306,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             qubitsAvailable = qm.GetFreeQubitsCount();
             Assert.True(qubitsAvailable == 1);
-            var qb2 = qm.Borrow(3); // This should grow qubit capacity
+            IQArray<Qubit> qb2 = qm.Borrow(3); // This should grow qubit capacity
             qubitsAvailable = qm.GetFreeQubitsCount();
             Assert.True(qubitsAvailable == 6);
             Assert.True(qb2[0].Id == 0);
@@ -310,7 +317,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             qubitsAvailable = qm.GetFreeQubitsCount();
             Assert.True(qubitsAvailable == 6);
-            var qa2 = qm.Allocate(4);
+            IQArray<Qubit> qa2 = qm.Allocate(4);
             qubitsAvailable = qm.GetFreeQubitsCount();
             Assert.True(qubitsAvailable == 2);
             Assert.True(qa2.Length == 4);
@@ -325,7 +332,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             qubitsAvailable = qm.GetFreeQubitsCount();
             Assert.True(qubitsAvailable == 3);
 
-            var qa3 = qm.Allocate(4); // This should grow qubit capacity
+            IQArray<Qubit> qa3 = qm.Allocate(4); // This should grow qubit capacity
             qubitsAvailable = qm.GetFreeQubitsCount();
             Assert.True(qubitsAvailable == 13);
             Assert.True(qa3.Length == 4);


### PR DESCRIPTION
Customers tend to prefer to think that allocating zero qubits should not cause an exception, but instead return an empty array of qubits. While this is questionable, returning empty array will cause them less issues at this point.