### PR TITLE
Add "submit" command to the standalone executable using a mock IQuantumMachine

### DIFF
--- a/src/Simulation/CsharpGeneration.Tests/Circuits/EntryPointTests.qs
+++ b/src/Simulation/CsharpGeneration.Tests/Circuits/EntryPointTests.qs
@@ -192,6 +192,46 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 // ---
 
 //
+// Tuples
+//
+
+namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+    @EntryPoint()
+    operation RedundantOneTuple((x : Int)) : String {
+        return $"{x}";
+    }
+}
+
+// ---
+
+namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+    @EntryPoint()
+    operation RedundantTwoTuple((x : Int, y : Int)) : String {
+        return $"{x} {y}";
+    }
+}
+
+// ---
+
+namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+    @EntryPoint()
+    operation OneTuple(x : Int, (y : Int)) : String {
+        return $"{x} {y}";
+    }
+}
+
+// ---
+
+namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+    @EntryPoint()
+    operation TwoTuple(x : Int, (y : Int, z : Int)) : String {
+        return $"{x} {y} {z}";
+    }
+}
+
+// ---
+
+//
 // Name Conversion
 //
 

--- a/src/Simulation/CsharpGeneration.Tests/EntryPointTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/EntryPointTests.fs
@@ -501,7 +501,8 @@ Options:
   -?, -h, --help                                      Show help and usage information
 
 Commands:
-  simulate    (default) Run the program using a local simulator."
+  simulate    (default) Run the program using a local simulator.
+  submit      Submit the program to Azure Quantum."
 
     let given = test 31
     given ["--help"] |> yields message

--- a/src/Simulation/CsharpGeneration.Tests/EntryPointTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/EntryPointTests.fs
@@ -362,17 +362,40 @@ let ``Requires all options`` () =
     given [] |> fails
 
 
+// Tuples
+
+[<Fact>]
+let ``Accepts redundant one-tuple`` () =
+    let given = test 21
+    given ["-x"; "7"] |> yields "7"
+    
+[<Fact>]
+let ``Accepts redundant two-tuple`` () =
+    let given = test 22
+    given ["-x"; "7"; "-y"; "8"] |> yields "7 8"
+    
+[<Fact>]
+let ``Accepts one-tuple`` () =
+    let given = test 23
+    given ["-x"; "7"; "-y"; "8"] |> yields "7 8"
+
+[<Fact>]    
+let ``Accepts two-tuple`` () =
+    let given = test 24
+    given ["-x"; "7"; "-y"; "8"; "-z"; "9"] |> yields "7 8 9"
+
+
 // Name Conversion
 
 [<Fact>]
 let ``Uses kebab-case`` () =
-    let given = test 21
+    let given = test 25
     given ["--camel-case-name"; "foo"] |> yields "foo"
     given ["--camelCaseName"; "foo"] |> fails
 
 [<Fact>]
 let ``Uses single-dash short names`` () =
-    let given = test 22
+    let given = test 26
     given ["-x"; "foo"] |> yields "foo"
     given ["--x"; "foo"] |> fails
 
@@ -381,7 +404,7 @@ let ``Uses single-dash short names`` () =
 
 [<Fact>]
 let ``Shadows --simulator`` () =
-    let given = test 23
+    let given = test 27
     given ["--simulator"; "foo"] |> yields "foo"
     given ["--simulator"; AssemblyConstants.ResourcesEstimator] |> yields AssemblyConstants.ResourcesEstimator
     given ["-s"; AssemblyConstants.ResourcesEstimator; "--simulator"; "foo"] |> fails 
@@ -389,14 +412,14 @@ let ``Shadows --simulator`` () =
 
 [<Fact>]
 let ``Shadows -s`` () =
-    let given = test 24
+    let given = test 28
     given ["-s"; "foo"] |> yields "foo"
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "-s"; "foo"] |> yields "foo"
     given ["--simulator"; "bar"; "-s"; "foo"] |> fails
 
 [<Fact>]
 let ``Shadows --version`` () =
-    let given = test 25
+    let given = test 29
     given ["--version"; "foo"] |> yields "foo"
 
 
@@ -415,30 +438,30 @@ BorrowedWidth   0"
 
 [<Fact>]
 let ``Supports QuantumSimulator`` () =
-    let given = test 26
+    let given = test 30
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "false"] |> yields "Hello, World!"
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "true"] |> yields "Hello, World!"
 
 [<Fact>]
 let ``Supports ToffoliSimulator`` () =
-    let given = test 26
+    let given = test 30
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "--use-h"; "false"] |> yields "Hello, World!"
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "--use-h"; "true"] |> fails
 
 [<Fact>]
 let ``Supports ResourcesEstimator`` () =
-    let given = test 26
+    let given = test 30
     given ["--simulator"; AssemblyConstants.ResourcesEstimator; "--use-h"; "false"] |> yields resourceSummary
     given ["--simulator"; AssemblyConstants.ResourcesEstimator; "--use-h"; "true"] |> yields resourceSummary
 
 [<Fact>]
 let ``Rejects unknown simulator`` () =
-    let given = test 26
+    let given = test 30
     given ["--simulator"; "FooSimulator"; "--use-h"; "false"] |> fails
 
 [<Fact>]
 let ``Supports default standard simulator`` () =
-    let given = testWith 26 AssemblyConstants.ResourcesEstimator
+    let given = testWith 30 AssemblyConstants.ResourcesEstimator
     given ["--use-h"; "false"] |> yields resourceSummary
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "false"] |> yields "Hello, World!"
 
@@ -446,7 +469,7 @@ let ``Supports default standard simulator`` () =
 let ``Supports default custom simulator`` () =
     // This is not really a "custom" simulator, but the driver does not recognize the fully-qualified name of the
     // standard simulators, so it is treated as one.
-    let given = testWith 26 typeof<ToffoliSimulator>.FullName
+    let given = testWith 30 typeof<ToffoliSimulator>.FullName
     given ["--use-h"; "false"] |> yields "Hello, World!"
     given ["--use-h"; "true"] |> fails
     given ["--simulator"; typeof<ToffoliSimulator>.FullName; "--use-h"; "false"] |> yields "Hello, World!"
@@ -479,7 +502,7 @@ Options:
 Commands:
   simulate    (default) Run the program using a local simulator."
 
-    let given = test 27
+    let given = test 31
     given ["--help"] |> yields message
     given ["-h"] |> yields message
     given ["-?"] |> yields message

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1046,6 +1046,22 @@ module SimulationCode =
         args
         |> flatOne [] 
 
+    /// Maps the name and type of each named item in the argument tuple.
+    let internal mapArgumentTuple mapping context arguments (argumentType : ResolvedType) =
+        let rec buildTuple = function
+            | QsTupleItem one ->
+                match one.VariableName with
+                | ValidName n -> mapping (n.Value, roslynTypeName context one.Type) :> ExpressionSyntax
+                | InvalidName -> mapping ("", roslynTypeName context one.Type) :> ExpressionSyntax
+            | QsTuple many ->
+                many |> Seq.map buildTuple |> List.ofSeq |> ``tuple``
+        if isTuple argumentType.Resolution
+        then buildTuple arguments
+        else match flatArgumentsList context arguments with 
+             | [] -> ``ident`` "QVoid" <|.|> ``ident`` "Instance"
+             | [name, typeName] -> mapping (name, typeName) :> ExpressionSyntax
+             | flatArgs -> flatArgs |> List.map mapping |> ``tuple``
+
     let buildRun context className arguments argumentType returnType : MemberDeclarationSyntax =
         let inType =  roslynTypeName context argumentType 
         let outType = roslynTypeName context returnType
@@ -1053,24 +1069,9 @@ module SimulationCode =
         let task = sprintf "System.Threading.Tasks.Task<%s>" outType
         let flatArgs = arguments |> flatArgumentsList context
         let opFactoryTypes =  [ className; inType; outType ]
-
-        let runArgs = 
-            if (isTuple argumentType.Resolution) then 
-                let rec buildTuple = function
-                    | QsTupleItem one ->
-                        match one.VariableName with
-                        | ValidName n -> ``ident`` n.Value  :> ExpressionSyntax
-                        | InvalidName -> ``ident`` ""       :> ExpressionSyntax
-                    | QsTuple many ->       
-                        many |> Seq.map buildTuple |> List.ofSeq |> ``tuple``
-                buildTuple arguments
-            else
-                match flatArgs with 
-                | []        -> (``ident`` "QVoid") <|.|> (``ident`` "Instance")
-                | [(id, _)] -> ``ident`` id :> ExpressionSyntax
-                | _         -> flatArgs |> List.map (fst >> ``ident``)  |> ``tuple``
        
         let uniqueArgName = "__m__"
+        let runArgs = mapArgumentTuple (fst >> ``ident``) context arguments argumentType
         let body = 
             [ 
                 ``return`` (Some ((``ident`` uniqueArgName) <.> (``generic`` "Run" ``<<`` opFactoryTypes ``>>``, [ runArgs ])))

--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -13,50 +13,35 @@ using System.Threading.Tasks;
 using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.Simulation.Core;
 using Microsoft.Quantum.Simulation.Simulators;
+using static Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Driver;
 
 namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
 {
     /// <summary>
     /// The entry point driver is the entry point for the C# application that executes the Q# entry point.
     /// </summary>
-    public static class Driver
+    public sealed class Driver<TCallable, TIn, TOut> where TCallable : AbstractCallable, ICallable
     {
         /// <summary>
-        /// A modification of the command line <see cref="HelpBuilder"/> class.
+        /// The entry point.
         /// </summary>
-        private sealed class QsHelpBuilder : HelpBuilder
-        {
-            public QsHelpBuilder(IConsole console) : base(console) { }
-
-            protected override string ArgumentDescriptor(IArgument argument)
-            {
-                // Hide long argument descriptors.
-                var descriptor = base.ArgumentDescriptor(argument);
-                return descriptor.Length > 30 ? argument.Name : descriptor;
-            }
-        }
+        private readonly IEntryPoint<TIn> entryPoint;
 
         /// <summary>
-        /// The option aliases for the simulator option.
+        /// Creates a new driver for the entry point.
         /// </summary>
-        private static readonly IReadOnlyCollection<string> SimulatorOptions = Array.AsReadOnly(new[]
-        {
-            "--" + CommandLineArguments.SimulatorOption.Item1,
-            "-" + CommandLineArguments.SimulatorOption.Item2
-        });
+        /// <param name="entryPoint">The entry point.</param>
+        public Driver(IEntryPoint<TIn> entryPoint) => this.entryPoint = entryPoint;
 
         /// <summary>
         /// Runs the entry point using the command-line arguments.
         /// </summary>
-        /// <typeparam name="T">The entry point's return type.</typeparam>
-        /// <param name="entryPoint">The entry point.</param>
         /// <param name="args">The command-line arguments.</param>
         /// <returns>The exit code.</returns>
-        public static async Task<int> Run<T>(IEntryPoint<T> entryPoint, string[] args)
+        public async Task<int> Run(string[] args)
         {
             var simulate = new Command("simulate", "(default) Run the program using a local simulator.");
             TryCreateOption(
-                    entryPoint,
                     SimulatorOptions,
                     () => entryPoint.DefaultSimulator,
                     "The name of the simulator to use.")
@@ -65,8 +50,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
                     AssemblyConstants.ToffoliSimulator,
                     AssemblyConstants.ResourcesEstimator,
                     entryPoint.DefaultSimulator)));
-            simulate.Handler = CommandHandler.Create(
-                (ParseResult parseResult, string simulator) => Simulate(entryPoint, parseResult, simulator));
+            simulate.Handler = CommandHandler.Create<ParseResult, string>(Simulate);
 
             var root = new RootCommand(entryPoint.Summary) { simulate };
             foreach (var option in entryPoint.Options) { root.AddGlobalOption(option); }
@@ -85,18 +69,16 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         /// <summary>
         /// Simulates the entry point.
         /// </summary>
-        /// <typeparam name="T">The entry point's return type.</typeparam>
-        /// <param name="entryPoint">The entry point.</param>
-        /// <param name="parseResult">The result of parsing the command-line options.</param>
+        /// <param name="parseResult">The command-line parsing result.</param>
         /// <param name="simulator">The simulator to use.</param>
         /// <returns>The exit code.</returns>
-        private static async Task<int> Simulate<T>(IEntryPoint<T> entryPoint, ParseResult parseResult, string simulator)
+        private async Task<int> Simulate(ParseResult parseResult, string simulator)
         {
-            simulator = DefaultIfShadowed(entryPoint, SimulatorOptions.First(), simulator, entryPoint.DefaultSimulator);
+            simulator = DefaultIfShadowed(SimulatorOptions.First(), simulator, entryPoint.DefaultSimulator);
             if (simulator == AssemblyConstants.ResourcesEstimator)
             {
                 var resourcesEstimator = new ResourcesEstimator();
-                await entryPoint.Run(resourcesEstimator, parseResult);
+                await resourcesEstimator.Run<TCallable, TIn, TOut>(entryPoint.CreateArgument(parseResult));
                 Console.WriteLine(resourcesEstimator.ToTSV());
             }
             else
@@ -112,7 +94,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
                     DisplayCustomSimulatorError(simulator);
                     return 1;
                 }
-                await DisplayEntryPointResult(entryPoint, parseResult, createSimulator);
+                await DisplayEntryPointResult(parseResult, createSimulator);
             }
             return 0;
         }
@@ -120,17 +102,14 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         /// <summary>
         /// Runs the entry point on a simulator and displays its return value.
         /// </summary>
-        /// <typeparam name="T">The entry point's return type.</typeparam>
-        /// <param name="entryPoint">The entry point.</param>
-        /// <param name="parseResult">The result of parsing the command-line options.</param>
+        /// <param name="parseResult">The command-line parsing result.</param>
         /// <param name="createSimulator">A function that creates an instance of the simulator to use.</param>
-        private static async Task DisplayEntryPointResult<T>(
-            IEntryPoint<T> entryPoint, ParseResult parseResult, Func<IOperationFactory> createSimulator)
+        private async Task DisplayEntryPointResult(ParseResult parseResult, Func<IOperationFactory> createSimulator)
         {
             var simulator = createSimulator();
             try
             {
-                var value = await entryPoint.Run(simulator, parseResult);
+                var value = await simulator.Run<TCallable, TIn, TOut>(entryPoint.CreateArgument(parseResult));
                 if (!(value is QVoid))
                 {
                     Console.WriteLine(value);
@@ -148,28 +127,23 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         /// <summary>
         /// Returns true if the alias is not already used by an entry point option.
         /// </summary>
-        /// <typeparam name="T">The entry point's return type.</typeparam>
-        /// <param name="entryPoint">The entry point.</param>
         /// <param name="alias">The alias to check.</param>
         /// <returns>True if the alias is available for use by the driver.</returns>
-        private static bool IsAliasAvailable<T>(IEntryPoint<T> entryPoint, string alias) =>
+        private bool IsAliasAvailable(string alias) =>
             !entryPoint.Options.SelectMany(option => option.RawAliases).Contains(alias);
 
         /// <summary>
         /// Returns the default value and displays a warning if the alias is shadowed by an entry point option, and
         /// returns the original value otherwise.
         /// </summary>
-        /// <typeparam name="TOption">The type of the option values.</typeparam>
-        /// <typeparam name="TEntryPoint">The entry point's return type.</typeparam>
-        /// <param name="entryPoint">The entry point.</param>
+        /// <typeparam name="T">The type of the option values.</typeparam>
         /// <param name="alias">The primary option alias corresponding to the value.</param>
         /// <param name="value">The value of the option given on the command line.</param>
         /// <param name="defaultValue">The default value for the option.</param>
         /// <returns>The default value or the original value.</returns>
-        private static TOption DefaultIfShadowed<TOption, TEntryPoint>(
-            IEntryPoint<TEntryPoint> entryPoint, string alias, TOption value, TOption defaultValue)
+        private T DefaultIfShadowed<T>(string alias, T value, T defaultValue)
         {
-            if (IsAliasAvailable(entryPoint, alias))
+            if (IsAliasAvailable(alias))
             {
                 return value;
             }
@@ -188,25 +162,20 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         /// Tries to create an option by removing aliases that are already in use by the entry point. If the first
         /// alias, which is considered the primary alias, is in use, then the option is not created.
         /// </summary>
-        /// <typeparam name="TOption">The type of the option's argument.</typeparam>
-        /// <typeparam name="TEntryPoint">The entry point's return type.</typeparam>
-        /// <param name="entryPoint">The entry point.</param>
+        /// <typeparam name="T">The type of the option's argument.</typeparam>
         /// <param name="aliases">The option's aliases.</param>
         /// <param name="getDefaultValue">A function that returns the option's default value.</param>
         /// <param name="description">The option's description.</param>
         /// <returns>A validation of the option.</returns>
-        private static Validation<Option<TOption>> TryCreateOption<TOption, TEntryPoint>(
-                IEntryPoint<TEntryPoint> entryPoint,
-                IReadOnlyCollection<string> aliases,
-                Func<TOption> getDefaultValue,
-                string? description = null) =>
-            IsAliasAvailable(entryPoint, aliases.First())
-            ? Validation<Option<TOption>>.Success(
-                new Option<TOption>(
-                    aliases.Where(alias => IsAliasAvailable(entryPoint, alias)).ToArray(),
+        private Validation<Option<T>> TryCreateOption<T>(
+                IReadOnlyCollection<string> aliases, Func<T> getDefaultValue, string? description = null) =>
+            IsAliasAvailable(aliases.First())
+            ? Validation<Option<T>>.Success(
+                new Option<T>(
+                    aliases.Where(IsAliasAvailable).ToArray(),
                     getDefaultValue,
                     description))
-            : Validation<Option<TOption>>.Failure();
+            : Validation<Option<T>>.Failure();
 
         /// <summary>
         /// Displays an error message for using a non-default custom simulator.
@@ -225,6 +194,40 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             Console.Error.WriteLine("<PropertyGroup>");
             Console.Error.WriteLine($"  <DefaultSimulator>{name}</DefaultSimulator>");
             Console.Error.WriteLine("</PropertyGroup>");
+        }
+    }
+
+    /// <summary>
+    /// Static members for <see cref="Driver{TCallable,TIn,TOut}"/> that do not depend on its type parameters.
+    /// </summary>
+    internal static class Driver
+    {
+        /// <summary>
+        /// The option aliases for the simulator option.
+        /// </summary>
+        internal static readonly IReadOnlyCollection<string> SimulatorOptions = Array.AsReadOnly(new[]
+        {
+            "--" + CommandLineArguments.SimulatorOption.Item1,
+            "-" + CommandLineArguments.SimulatorOption.Item2
+        });
+    }
+    
+    /// <summary>
+    /// A modification of the command-line <see cref="HelpBuilder"/> class.
+    /// </summary>
+    internal sealed class QsHelpBuilder : HelpBuilder
+    {
+        /// <summary>
+        /// Creates a new help builder using the given console.
+        /// </summary>
+        /// <param name="console">The console to use.</param>
+        internal QsHelpBuilder(IConsole console) : base(console) { }
+
+        protected override string ArgumentDescriptor(IArgument argument)
+        {
+            // Hide long argument descriptors.
+            var descriptor = base.ArgumentDescriptor(argument);
+            return descriptor.Length > 30 ? argument.Name : descriptor;
         }
     }
 }

--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -114,10 +114,10 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         {
             // TODO: Use an actual quantum machine.
             var machine = new SimulatorMachine();
-            var (value, _) = await machine.ExecuteAsync(entryPoint.Info, entryPoint.CreateArgument(parseResult));
-            if (!(value is QVoid))
+            var output = await machine.ExecuteAsync(entryPoint.Info, entryPoint.CreateArgument(parseResult));
+            foreach (var (result, frequency) in output.Histogram)
             {
-                Console.WriteLine(value);
+                Console.WriteLine($"{result} (frequency = {frequency})");
             }
         }
 

--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         /// <summary>
         /// The entry point.
         /// </summary>
-        private readonly IEntryPoint<TIn> entryPoint;
+        private readonly IEntryPoint<TIn, TOut> entryPoint;
 
         /// <summary>
         /// Creates a new driver for the entry point.
         /// </summary>
         /// <param name="entryPoint">The entry point.</param>
-        public Driver(IEntryPoint<TIn> entryPoint) => this.entryPoint = entryPoint;
+        public Driver(IEntryPoint<TIn, TOut> entryPoint) => this.entryPoint = entryPoint;
 
         /// <summary>
         /// Runs the entry point using the command-line arguments.

--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             // TODO: Use an actual quantum machine.
             var machine = new SimulatorMachine();
             var output = await machine.ExecuteAsync(entryPoint.Info, entryPoint.CreateArgument(parseResult));
+            // TODO: Provide output options and show the most frequent output by default. 
             foreach (var (result, frequency) in output.Histogram)
             {
                 Console.WriteLine($"{result} (frequency = {frequency})");

--- a/src/Simulation/EntryPointDriver/IEntryPoint.cs
+++ b/src/Simulation/EntryPointDriver/IEntryPoint.cs
@@ -13,8 +13,9 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
     /// Contains entry point properties needed by the command-line interface and allows the entry point to use
     /// command-line arguments. The implementation of this interface is code-generated.
     /// </remarks>
-    /// <typeparam name="T">The entry point's argument type.</typeparam>
-    public interface IEntryPoint<out T>
+    /// <typeparam name="TIn">The entry point's argument type.</typeparam>
+    /// <typeparam name="TOut">The entry point's return type.</typeparam>
+    public interface IEntryPoint<TIn, TOut>
     {
         /// <summary>
         /// The summary from the entry point's documentation comment.
@@ -30,6 +31,11 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         /// The name of the default simulator to use when simulating the entry point.
         /// </summary>
         string DefaultSimulator { get; }
+        
+        /// <summary>
+        /// Additional information about the entry point.
+        /// </summary>
+        EntryPointInfo<TIn, TOut> Info { get; }
 
         /// <summary>
         /// Creates an instance of the default simulator if it is a custom simulator.
@@ -45,6 +51,6 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         /// </summary>
         /// <param name="parseResult">The command-line parsing result.</param>
         /// <returns>The argument to the entry point.</returns>
-        T CreateArgument(ParseResult parseResult);
+        TIn CreateArgument(ParseResult parseResult);
     }
 }

--- a/src/Simulation/EntryPointDriver/IEntryPoint.cs
+++ b/src/Simulation/EntryPointDriver/IEntryPoint.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Parsing;
-using System.Threading.Tasks;
 using Microsoft.Quantum.Simulation.Core;
 
 namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
@@ -14,8 +13,8 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
     /// Contains entry point properties needed by the command-line interface and allows the entry point to use
     /// command-line arguments. The implementation of this interface is code-generated.
     /// </remarks>
-    /// <typeparam name="T">The entry point's return type.</typeparam>
-    public interface IEntryPoint<T>
+    /// <typeparam name="T">The entry point's argument type.</typeparam>
+    public interface IEntryPoint<out T>
     {
         /// <summary>
         /// The summary from the entry point's documentation comment.
@@ -42,11 +41,10 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         IOperationFactory CreateDefaultCustomSimulator();
 
         /// <summary>
-        /// Runs the entry point.
+        /// Creates the argument to the entry point based on the command-line parsing result.
         /// </summary>
-        /// <param name="factory">The operation factory to use.</param>
-        /// <param name="parseResult">The result of parsing the command-line options.</param>
-        /// <returns>The return value of the entry point.</returns>
-        Task<T> Run(IOperationFactory factory, ParseResult parseResult);
+        /// <param name="parseResult">The command-line parsing result.</param>
+        /// <returns>The argument to the entry point.</returns>
+        T CreateArgument(ParseResult parseResult);
     }
 }

--- a/src/Simulation/EntryPointDriver/SimulatorMachine.cs
+++ b/src/Simulation/EntryPointDriver/SimulatorMachine.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Quantum.Runtime;
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
+{
+    /// <summary>
+    /// A quantum machine that runs an operation using a local quantum simulator.
+    /// </summary>
+    /// <remarks>
+    /// TODO: This class is only for testing the <see cref="IQuantumMachine{TJob,TRawResult}"/> interface. It should be
+    /// removed once an actual quantum machine implementation can be used.
+    /// </remarks>
+    internal class SimulatorMachine : IQuantumMachine<object?, object?>
+    {
+        public string ProviderId => nameof(SimulatorMachine);
+
+        public string Target => "QuantumSimulator";
+
+        public async Task<Tuple<TOut, object?>> ExecuteAsync<TIn, TOut>(EntryPointInfo<TIn, TOut> info, TIn input)
+        {
+            var result = await (Task<TOut>)typeof(QuantumSimulator)
+                .GetMethod(nameof(QuantumSimulator.Run))
+                .MakeGenericMethod(info.Operation, info.InType, info.OutType)
+                .Invoke(new QuantumSimulator(), new object?[] { input });
+            return new Tuple<TOut, object?>(result, null);
+        }
+
+        public Task<object?> SubmitAsync<TIn, TOut>(EntryPointInfo<TIn, TOut> info, TIn input) =>
+            throw new NotImplementedException();
+    }
+}

--- a/src/Simulation/EntryPointDriver/SimulatorMachine.cs
+++ b/src/Simulation/EntryPointDriver/SimulatorMachine.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.Quantum.Runtime;
 using Microsoft.Quantum.Simulation.Core;
@@ -10,25 +12,37 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
     /// A quantum machine that runs an operation using a local quantum simulator.
     /// </summary>
     /// <remarks>
-    /// TODO: This class is only for testing the <see cref="IQuantumMachine{TJob,TRawResult}"/> interface. It should be
-    /// removed once an actual quantum machine implementation can be used.
+    /// TODO: This class is only for testing the <see cref="IQuantumMachine"/> interface. It should be removed once an
+    /// actual quantum machine implementation can be used.
     /// </remarks>
-    internal class SimulatorMachine : IQuantumMachine<object?, object?>
+    internal class SimulatorMachine : IQuantumMachine
     {
         public string ProviderId => nameof(SimulatorMachine);
 
         public string Target => "QuantumSimulator";
 
-        public async Task<Tuple<TOut, object?>> ExecuteAsync<TIn, TOut>(EntryPointInfo<TIn, TOut> info, TIn input)
+        public async Task<IQuantumMachineOutput<TOut>> ExecuteAsync<TIn, TOut>(
+            EntryPointInfo<TIn, TOut> info, TIn input)
         {
             var result = await (Task<TOut>)typeof(QuantumSimulator)
                 .GetMethod(nameof(QuantumSimulator.Run))
                 .MakeGenericMethod(info.Operation, info.InType, info.OutType)
                 .Invoke(new QuantumSimulator(), new object?[] { input });
-            return new Tuple<TOut, object?>(result, null);
+            return new SimulatorMachineOutput<TOut>(result);
         }
 
-        public Task<object?> SubmitAsync<TIn, TOut>(EntryPointInfo<TIn, TOut> info, TIn input) =>
+        public Task<IQuantumMachineJob> SubmitAsync<TIn, TOut>(EntryPointInfo<TIn, TOut> info, TIn input) =>
             throw new NotImplementedException();
+    }
+
+    internal class SimulatorMachineOutput<T> : IQuantumMachineOutput<T>
+    {
+        public IReadOnlyDictionary<T, double> Histogram { get; }
+        
+        public IQuantumMachineJob Job => throw new NotImplementedException();
+
+        public int Shots => 1;
+
+        internal SimulatorMachineOutput(T result) => Histogram = ImmutableDictionary<T, double>.Empty.Add(result, 1);
     }
 }


### PR DESCRIPTION
This is a bare-bones implementation of the `submit` command. It doesn't support any options, and the `IQuantumMachine` that I am using just runs the entry point on the `QuantumSimulator`. But now everything should be ready to start adding support for actual `IQuantumMachine`s.

This depends on #180, so targeting that branch for an accurate diff, but after that's merged I'll un-draft this and retarget to the feature branch.