### PR TITLE
Removed type parameters from IQuantumMachine interface.

### DIFF
--- a/src/Simulation/Core/IQuantumMachine.cs
+++ b/src/Simulation/Core/IQuantumMachine.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Quantum.Runtime
         /// <typeparam name="TInput">Type of input the quantum program receives.</typeparam>
         /// <typeparam name="TOutput">Type of output the quantum program returns.</typeparam>
         /// <returns>An object that implements the IQuantumMachineOutput interface.</returns>
-        Task<IQuantumMachineOutput> ExecuteAsync<TInput, TOutput>(EntryPointInfo<TInput, TOutput> info, TInput input);
+        Task<IQuantumMachineOutput<TOutput>> ExecuteAsync<TInput, TOutput>(EntryPointInfo<TInput, TOutput> info, TInput input);
 
         /// <summary>
         /// Submits a job to execute a Q# program.

--- a/src/Simulation/Core/IQuantumMachine.cs
+++ b/src/Simulation/Core/IQuantumMachine.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.Quantum.Simulation.Core;
 
@@ -10,9 +9,7 @@ namespace Microsoft.Quantum.Runtime
     /// <summary>
     /// Interface that a quantum machine must implement.
     /// </summary>
-    /// <typeparam name="TJob">Type of job that handles the execution of a program in the quantum machine.</typeparam>
-    /// <typeparam name="TRawResult">Type of result the quantum machine returns.</typeparam>
-    public interface IQuantumMachine<TJob, TRawResult>
+    public interface IQuantumMachine
     {
         /// <summary>
         /// Gets the ID of the quantum machine provider.
@@ -29,14 +26,14 @@ namespace Microsoft.Quantum.Runtime
         /// <summary>
         /// Executes a Q# program.
         /// Submits a job to execute it and continuously checks whether it has been completed.
-        /// Once its execution completes, returns its output.
+        /// Once its execution completes, returns an object that implements the IQuantumMachineOutput interface through which the execution output can be obtained.
         /// </summary>
         /// <param name="info">Information about the Q# program</param>
         /// <param name="input">Input for the Q# program</param>
         /// <typeparam name="TInput">Type of input the quantum program receives.</typeparam>
         /// <typeparam name="TOutput">Type of output the quantum program returns.</typeparam>
-        /// <returns>Sampled output of the quantum program</returns>
-        Task<Tuple<TOutput, TRawResult>> ExecuteAsync<TInput, TOutput>(EntryPointInfo<TInput, TOutput> info, TInput input);
+        /// <returns>An object that implements the IQuantumMachineOutput interface.</returns>
+        Task<IQuantumMachineOutput> ExecuteAsync<TInput, TOutput>(EntryPointInfo<TInput, TOutput> info, TInput input);
 
         /// <summary>
         /// Submits a job to execute a Q# program.
@@ -46,7 +43,7 @@ namespace Microsoft.Quantum.Runtime
         /// <param name="input">Input for the Q# program</param>
         /// <typeparam name="TInput">Type of input the quantum program receives.</typeparam>
         /// <typeparam name="TOutput">Type of output the quantum program returns.</typeparam>
-        /// <returns>A Job instance. Status and results from the execution can be retrieved from this instance.</returns>
-        Task<TJob> SubmitAsync<TInput, TOutput>(EntryPointInfo<TInput, TOutput> info, TInput input);
+        /// <returns>An object that implements the IQuantumMachineJob interface through which data about the job can be obtained.</returns>
+        Task<IQuantumMachineJob> SubmitAsync<TInput, TOutput>(EntryPointInfo<TInput, TOutput> info, TInput input);
     }
 }

--- a/src/Simulation/Core/IQuantumMachineJob.cs
+++ b/src/Simulation/Core/IQuantumMachineJob.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Quantum.Runtime
+{
+    /// <summary>
+    /// Interface to track a job submitted to a quantum machine.
+    /// </summary>
+    public interface IQuantumMachineJob
+    {
+        /// <summary>
+        /// Gets the ID of submitted job.
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// Gets whether job execution is in progress.
+        /// </summary>
+        bool InProgress { get; }
+
+        /// <summary>
+        /// Gets the status of the submitted job.
+        /// </summary>
+        string Status { get; }
+
+        /// <summary>
+        /// Gets whether the job execution completed successfully.
+        /// </summary>
+        bool Succeeded { get;  }
+
+        /// <summary>
+        /// Gets an URI to access the job.
+        /// </summary>
+        Uri Uri { get; }
+
+        /// <summary>
+        /// Cancels the job.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task CancelAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Refreshes the state of the job.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task RefreshAsync(CancellationToken cancellationToken = default);
+
+    }
+}

--- a/src/Simulation/Core/IQuantumMachineJob.cs
+++ b/src/Simulation/Core/IQuantumMachineJob.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Quantum.Runtime
     public interface IQuantumMachineJob
     {
         /// <summary>
+        /// Gets whether job execution failed.
+        /// </summary>
+        bool Failed { get; }
+
+        /// <summary>
         /// Gets the ID of submitted job.
         /// </summary>
         string Id { get; }
@@ -40,14 +45,13 @@ namespace Microsoft.Quantum.Runtime
         /// <summary>
         /// Cancels the job.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="cancellationToken">The cancellation token for the cancel operation.</param>
         Task CancelAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Refreshes the state of the job.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="cancellationToken">The cancellation token for the refresh operation.</param>
         Task RefreshAsync(CancellationToken cancellationToken = default);
-
     }
 }

--- a/src/Simulation/Core/IQuantumMachineOutput.cs
+++ b/src/Simulation/Core/IQuantumMachineOutput.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Runtime
         /// Gets a histogram of outputs.
         /// The key is the output and the value is its frequency.
         /// </summary>
-        IReadOnlyDictionary<object, TOutput> Histogram { get; }
+        IReadOnlyDictionary<TOutput, double> Histogram { get; }
 
         /// <summary>
         /// Gets the job associated to the output.

--- a/src/Simulation/Core/IQuantumMachineOutput.cs
+++ b/src/Simulation/Core/IQuantumMachineOutput.cs
@@ -7,27 +7,15 @@ namespace Microsoft.Quantum.Runtime
 {
     /// <summary>
     /// Interface to access the results of a program executed in a quantum machine.
+    /// <typeparam name="TOutput">Type of output the quantum program returns.</typeparam>
     /// </summary>
-    public interface IQuantumMachineOutput
+    public interface IQuantumMachineOutput<TOutput>
     {
-
-        /// <summary>
-        /// Gets an output probabilistically.
-        /// Calls to this method are not deterministic, each call can return a different output.
-        /// </summary>
-        object GetOutput();
-
-        /// <summary>
-        /// Gets the most frequent output.
-        /// If multiple outputs have the same frequency, it gets the first one in ascending order.
-        /// </summary>
-        object GetMostFrequentOutput();
-
         /// <summary>
         /// Gets a histogram of outputs.
         /// The key is the output and the value is its frequency.
         /// </summary>
-        IDictionary<object, double> Histogram { get; }
+        IReadOnlyDictionary<object, TOutput> Histogram { get; }
 
         /// <summary>
         /// Gets the job associated to the output.

--- a/src/Simulation/Core/IQuantumMachineOutput.cs
+++ b/src/Simulation/Core/IQuantumMachineOutput.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Quantum.Runtime
+{
+    /// <summary>
+    /// Interface to access the results of a program executed in a quantum machine.
+    /// </summary>
+    public interface IQuantumMachineOutput
+    {
+
+        /// <summary>
+        /// Gets an output probabilistically.
+        /// Calls to this method are not deterministic, each call can return a different output.
+        /// </summary>
+        object GetOutput();
+
+        /// <summary>
+        /// Gets the most frequent output.
+        /// If multiple outputs have the same frequency, it gets the first one in ascending order.
+        /// </summary>
+        object GetMostFrequentOutput();
+
+        /// <summary>
+        /// Gets a histogram of outputs.
+        /// The key is the output and the value is its frequency.
+        /// </summary>
+        IDictionary<object, double> Histogram { get; }
+
+        /// <summary>
+        /// Gets the job associated to the output.
+        /// </summary>
+        IQuantumMachineJob Job { get; }
+
+        /// <summary>
+        /// Gets the number of times the program was executed.
+        /// </summary>
+        int Shots { get; }
+    }
+}


### PR DESCRIPTION
This change removes type parameters from the IQuantumMachine interface and replaces them with the IQuantumMachineJob and the IQuantumMachineOutput interfaces.