### PR TITLE
Make sure tests can run without  build.

### DIFF
--- a/build/test.ps1
+++ b/build/test.ps1
@@ -6,6 +6,7 @@ $all_ok = $True
 
 Write-Host "##[info]Test Native simulator"
 pushd (Join-Path $PSScriptRoot "../src/Simulation/Native/build")
+cmake --build . --config $Env:BUILD_CONFIGURATION
 ctest -C $Env:BUILD_CONFIGURATION
 if  ($LastExitCode -ne 0) {
     Write-Host "##vso[task.logissue type=error;]Failed to test Native Simulator"


### PR DESCRIPTION
Adding the step to explicitly build the native binaries before their unittests as it doesn't happen automatically.