### PR TITLE
Switch to latest images for build agents

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -10,19 +10,22 @@ variables:
 
 jobs:
 - job: macOS
-  pool: 'Hosted macOS'
+  pool:
+    vmImage: 'macOS-latest'
   steps:
   - template: steps-xplat.yml
 
 
 - job: Linux
-  pool: 'Hosted Ubuntu 1604'
+  pool:
+    vmImage: 'ubuntu-latest'
   steps:
   - template: steps-xplat.yml
 
 
 - job: Windows
-  pool: 'Hosted VS2017'
+  pool:
+    vmImage: 'windows-latest'
   dependsOn:
   - macOS
   - Linux

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
 - job: Windows
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2019'
   dependsOn:
   - macOS
   - Linux


### PR DESCRIPTION
Switching QDK pipeline to use latest images for build agents. There are corresponding PRs in other repos as well.