### PR TITLE
Add manifest with qsharp-runtime assemblies requiring signing

### DIFF
--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -22,5 +22,5 @@
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.Simulators.dll",
         ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Xunit.dll"
-    ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
+    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
 } | Write-Output; 

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -1,5 +1,5 @@
-#!/usr/bin/env pwsh
-#Requires -PSEdition Core
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
 & "$PSScriptRoot/set-env.ps1"
 
@@ -22,5 +22,5 @@
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.Simulators.dll",
         ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Xunit.dll"
-    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot ".." $_) };
+    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
 } | Write-Output; 

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -22,5 +22,5 @@
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.Simulators.dll",
         ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Xunit.dll"
-    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
+    ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 } | Write-Output; 

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -1,0 +1,26 @@
+#!/usr/bin/env pwsh
+#Requires -PSEdition Core
+
+& "$PSScriptRoot/set-env.ps1"
+
+@{
+    Packages = @(
+        "Microsoft.Quantum.CsharpGeneration",
+        "Microsoft.Quantum.Development.Kit",
+        "Microsoft.Quantum.QSharp.Core",
+        "Microsoft.Quantum.Runtime.Core",
+        "Microsoft.Quantum.Simulators",
+        "Microsoft.Quantum.Xunit"
+    );
+    Assemblies = @(
+        ".\src\simulation\CsharpGeneration\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.CsharpGeneration.dll",
+        ".\src\simulation\CsharpGeneration.App\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.CsharpGeneration.App.dll",
+        ".\src\simulation\CsharpGeneration.App\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.RoslynWrapper.dll",
+        ".\src\simulation\Core\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Runtime.Core.dll",
+        ".\src\simulation\QsharpCore\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QSharp.Core.dll",
+        ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.Common.dll",
+        ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
+        ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.Simulators.dll",
+        ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Xunit.dll"
+    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot ".." $_) };
+} | Write-Output; 

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -5,15 +5,15 @@ steps:
 - template: steps-init.yml
 
 
+- powershell: ./build.ps1
+  displayName: "Building Q# runtime"
+  workingDirectory: $(System.DefaultWorkingDirectory)/build
+
+
 - powershell: ./manifest.ps1
   displayName: "List built assemblies"
   workingDirectory: $(System.DefaultWorkingDirectory)/build
   condition: succeededOrFailed()
-
-
-- powershell: ./build.ps1
-  displayName: "Building Q# runtime"
-  workingDirectory: $(System.DefaultWorkingDirectory)/build
 
 
 - powershell: ./test.ps1

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -5,6 +5,12 @@ steps:
 - template: steps-init.yml
 
 
+- powershell: ./manifest.ps1
+  displayName: "List built assemblies"
+  workingDirectory: $(System.DefaultWorkingDirectory)/build
+  condition: succeededOrFailed()
+
+
 - powershell: ./build.ps1
   displayName: "Building Q# runtime"
   workingDirectory: $(System.DefaultWorkingDirectory)/build


### PR DESCRIPTION
This PR adds a `build/manifest.ps1` file listing the `qsharp-runtime` assemblies that require signing during the CI build. The corresponding change to remove these from the hard-coded list in the CI build scripts will be a separate PR.

Before merging:
- [x] Ensure that end-to-end CI build succeeds with signing enabled.