### PR TITLE
Allow reflection to find type in loaded assembly

### DIFF
--- a/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
@@ -26,12 +26,21 @@ namespace Microsoft.Azure.Quantum
                 ? "Microsoft.Quantum.Providers.Honeywell.Targets.HoneywellQuantumMachine, Microsoft.Quantum.Providers.Honeywell"
                 : null;
 
-            // First try to load the signed assembly with the correct version, then try the unsigned one.
-            var machineType =
-                machineName is null
-                ? null
-                : Type.GetType($"{machineName}, Version={typeof(IWorkspace).Assembly.GetName().Version}, Culture=neutral, PublicKeyToken=40866b40fd95c7f5")
-                ?? Type.GetType(machineName, throwOnError: true);
+            Type machineType = null;
+            if (machineName != null)
+            {
+                // First try to load the signed assembly with the correct version, then try the unsigned one.
+                try
+                {
+                    machineType = Type.GetType($"{machineName}, Version={typeof(IWorkspace).Assembly.GetName().Version}, Culture=neutral, PublicKeyToken=40866b40fd95c7f5");
+                }
+                catch
+                {
+                    machineType = null;
+                }
+
+                machineType ??= Type.GetType(machineName, throwOnError: true);
+            }
 
             return machineType is null
                 ? null

--- a/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
-using System.Threading.Tasks;
+using System.Linq;
 using Microsoft.Quantum.Runtime;
 
 namespace Microsoft.Azure.Quantum
@@ -16,7 +18,7 @@ namespace Microsoft.Azure.Quantum
         /// <param name="targetName">The execution target for job submission.</param>
         /// <param name="storageAccountConnectionString">The connection string for the Azure storage account.</param>
         /// <returns>A quantum machine for job submission targeting <c>targetName</c>.</returns>
-        public static IQuantumMachine? CreateMachine(Workspace workspace, string targetName, string storageAccountConnectionString)
+        public static IQuantumMachine? CreateMachine(IWorkspace workspace, string targetName, string storageAccountConnectionString)
         {
             if (string.IsNullOrEmpty(targetName))
             {
@@ -25,13 +27,13 @@ namespace Microsoft.Azure.Quantum
 
             if (targetName.StartsWith("ionq."))
             {
-                var ionQType = Type.GetType(
-                    "Microsoft.Quantum.Providers.IonQ.Targets.IonQQuantumMachine, Microsoft.Quantum.Providers.IonQ",
-                    throwOnError: true);
+                var ionQType = AppDomain.CurrentDomain.GetAssemblies()
+                    .First(a => a.FullName.StartsWith("Microsoft.Quantum.Providers.IonQ,"))
+                    .GetType("Microsoft.Quantum.Providers.IonQ.Targets.IonQQuantumMachine", throwOnError: true);
                 return (IQuantumMachine)Activator.CreateInstance(
                     ionQType, targetName, storageAccountConnectionString, workspace);
             }
-            
+
             return null;
         }
     }

--- a/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Quantum
         /// <param name="targetName">The execution target for job submission.</param>
         /// <param name="storageAccountConnectionString">The connection string for the Azure storage account.</param>
         /// <returns>A quantum machine for job submission targeting <c>targetName</c>.</returns>
-        public static IQuantumMachine? CreateMachine(Workspace workspace, string targetName, string storageAccountConnectionString)
+        public static IQuantumMachine? CreateMachine(IWorkspace workspace, string targetName, string storageAccountConnectionString)
         {
             var machineName =
                 targetName is null
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Quantum
             var machineType =
                 machineName is null
                 ? null
-                : Type.GetType($"{machineName}, Version={typeof(Workspace).Assembly.GetName().Version}, Culture=neutral, PublicKeyToken=40866b40fd95c7f5")
+                : Type.GetType($"{machineName}, Version={typeof(IWorkspace).Assembly.GetName().Version}, Culture=neutral, PublicKeyToken=40866b40fd95c7f5")
                 ?? Type.GetType(machineName, throwOnError: true);
 
             return machineType is null

--- a/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable enable
-
 using System;
-using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Quantum.Runtime;
 
 namespace Microsoft.Azure.Quantum
@@ -18,7 +16,7 @@ namespace Microsoft.Azure.Quantum
         /// <param name="targetName">The execution target for job submission.</param>
         /// <param name="storageAccountConnectionString">The connection string for the Azure storage account.</param>
         /// <returns>A quantum machine for job submission targeting <c>targetName</c>.</returns>
-        public static IQuantumMachine? CreateMachine(IWorkspace workspace, string targetName, string storageAccountConnectionString)
+        public static IQuantumMachine? CreateMachine(Workspace workspace, string targetName, string storageAccountConnectionString)
         {
             if (string.IsNullOrEmpty(targetName))
             {
@@ -27,13 +25,13 @@ namespace Microsoft.Azure.Quantum
 
             if (targetName.StartsWith("ionq."))
             {
-                var ionQType = AppDomain.CurrentDomain.GetAssemblies()
-                    .First(a => a.FullName.StartsWith("Microsoft.Quantum.Providers.IonQ,"))
-                    .GetType("Microsoft.Quantum.Providers.IonQ.Targets.IonQQuantumMachine", throwOnError: true);
+                var ionQType = Type.GetType(
+                    "Microsoft.Quantum.Providers.IonQ.Targets.IonQQuantumMachine, Microsoft.Quantum.Providers.IonQ",
+                    throwOnError: true);
                 return (IQuantumMachine)Activator.CreateInstance(
                     ionQType, targetName, storageAccountConnectionString, workspace);
             }
-
+            
             return null;
         }
     }


### PR DESCRIPTION
Two changes to `QuantumMachineFactory` here, to address issues I found while consuming this from IQ#:
- Take an `IWorkspace` parameter instead of a `Workspace` parameter.
- Load the type directly from the already-loaded assembly with the expected name, rather than using `Type.GetType()`, which seems to sometimes require an `AssemblyQualifiedName` including version number and public key token in order to load the type successfully. (Open to suggestions here, in case there's a simpler way of doing this, but this seems to work.)