### PR TITLE
Add Honeywell to QuantumMachineFactory

### DIFF
--- a/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.Quantum.Runtime;
 
 namespace Microsoft.Azure.Quantum
@@ -23,16 +22,19 @@ namespace Microsoft.Azure.Quantum
                 return null;
             }
 
-            if (targetName.StartsWith("ionq."))
-            {
-                var ionQType = Type.GetType(
-                    "Microsoft.Quantum.Providers.IonQ.Targets.IonQQuantumMachine, Microsoft.Quantum.Providers.IonQ",
-                    throwOnError: true);
-                return (IQuantumMachine)Activator.CreateInstance(
-                    ionQType, targetName, storageAccountConnectionString, workspace);
-            }
-            
-            return null;
+            var machineName =
+                targetName.StartsWith("ionq.")
+                ? "Microsoft.Quantum.Providers.IonQ.Targets.IonQQuantumMachine, Microsoft.Quantum.Providers.IonQ"
+                : targetName.StartsWith("honeywell.")
+                ? "Microsoft.Quantum.Providers.Honeywell.Targets.HoneywellQuantumMachine, Microsoft.Quantum.Providers.Honeywell"
+                : null;
+            return machineName is null
+                ? null
+                : (IQuantumMachine)Activator.CreateInstance(
+                    Type.GetType(machineName, throwOnError: true),
+                    targetName,
+                    storageAccountConnectionString,
+                    workspace);
         }
     }
 }


### PR DESCRIPTION
Keeping `Type.GetType` since that works for the standalone executable, but this will have a merge conflict with #205.