### PR TITLE
Create separate project for entry point driver tests and clean up references

### DIFF
--- a/Simulation.sln
+++ b/Simulation.sln
@@ -49,6 +49,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QsharpExe", "src\Simulation
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntryPointDriver", "src\Simulation\EntryPointDriver\EntryPointDriver.csproj", "{944FE7EF-9220-4CC6-BB20-CE517195B922}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "EntryPointDriver.Tests", "src\Simulation\EntryPointDriver.Tests\EntryPointDriver.Tests.fsproj", "{E2F30496-19D8-46A8-9BC0-26936FFE70D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -317,6 +319,22 @@ Global
 		{944FE7EF-9220-4CC6-BB20-CE517195B922}.RelWithDebInfo|Any CPU.Build.0 = Debug|Any CPU
 		{944FE7EF-9220-4CC6-BB20-CE517195B922}.RelWithDebInfo|x64.ActiveCfg = Debug|Any CPU
 		{944FE7EF-9220-4CC6-BB20-CE517195B922}.RelWithDebInfo|x64.Build.0 = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.Debug|x64.Build.0 = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.Release|x64.ActiveCfg = Release|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.Release|x64.Build.0 = Release|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.RelWithDebInfo|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.RelWithDebInfo|Any CPU.Build.0 = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.RelWithDebInfo|x64.ActiveCfg = Debug|Any CPU
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2}.RelWithDebInfo|x64.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -340,6 +358,7 @@ Global
 		{A1E878CB-ADF1-457A-9223-06F96ED8F7A6} = {99E234BC-997E-4E63-9F5C-3C3977543404}
 		{DF654202-0008-4CDE-B35E-018CEFD0FC68} = {A1E878CB-ADF1-457A-9223-06F96ED8F7A6}
 		{1467128C-90E4-4723-B5C7-9469B83F54A6} = {A1E878CB-ADF1-457A-9223-06F96ED8F7A6}
+		{E2F30496-19D8-46A8-9BC0-26936FFE70D2} = {A567C185-A429-418B-AFDE-6F1785BA4A77}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {929C0464-86D8-4F70-8835-0A5EAF930821}

--- a/src/Simulation/CsharpGeneration.Tests/Tests.CsharpGeneration.fsproj
+++ b/src/Simulation/CsharpGeneration.Tests/Tests.CsharpGeneration.fsproj
@@ -31,12 +31,8 @@
     <None Include="Circuits\Core.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Circuits\EntryPointTests.qs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <Compile Include="..\Common\DelaySign.fs" Link="DelaySign.fs" />
     <Compile Include="SimulationCodeTests.fs" />
-    <Compile Include="EntryPointTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -46,7 +42,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20214.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
       <PrivateAssets>all</PrivateAssets>
@@ -58,7 +53,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Core\Microsoft.Quantum.Runtime.Core.csproj" />
     <ProjectReference Include="..\CsharpGeneration\Microsoft.Quantum.CsharpGeneration.fsproj" />
-    <ProjectReference Include="..\EntryPointDriver\EntryPointDriver.csproj" />
     <ProjectReference Include="..\QsharpCore\Microsoft.Quantum.QSharp.Core.csproj" />
     <ProjectReference Include="..\Simulators\Microsoft.Quantum.Simulation.Simulators.csproj" />
   </ItemGroup>

--- a/src/Simulation/EntryPointDriver.Tests/Core.qs
+++ b/src/Simulation/EntryPointDriver.Tests/Core.qs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Core {
+    @Attribute()
+    newtype Attribute = Unit;
+
+    @Attribute()
+    newtype EntryPoint = Unit;
+}

--- a/src/Simulation/EntryPointDriver.Tests/EntryPointDriver.Tests.fsproj
+++ b/src/Simulation/EntryPointDriver.Tests/EntryPointDriver.Tests.fsproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="Core.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Intrinsic.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Tests.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CsharpGeneration\Microsoft.Quantum.CsharpGeneration.fsproj" />
+    <ProjectReference Include="..\EntryPointDriver\EntryPointDriver.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Simulation/EntryPointDriver.Tests/Intrinsic.qs
+++ b/src/Simulation/EntryPointDriver.Tests/Intrinsic.qs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Intrinsic {
+    operation H (q : Qubit) : Unit {
+        body intrinsic;
+        adjoint intrinsic;
+        controlled intrinsic;
+        controlled adjoint intrinsic;
+    }
+    
+    operation X (q : Qubit) : Unit {
+        body intrinsic;
+        adjoint intrinsic;
+        controlled intrinsic;
+        controlled adjoint intrinsic;
+    }
+    
+    operation M (q : Qubit) : Result {
+        body intrinsic;
+    }
+}

--- a/src/Simulation/EntryPointDriver.Tests/Program.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Program.fs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+module Program = let [<EntryPoint>] main _ = 0

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-module Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint
+module Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests
 
 open System
 open System.Collections.Immutable
@@ -24,16 +24,16 @@ open Microsoft.Quantum.Simulation.Simulators
 
 
 /// The path to the Q# file that provides the Microsoft.Quantum.Core namespace.
-let private coreFile = Path.Combine ("Circuits", "Core.qs") |> Path.GetFullPath
+let private coreFile = Path.GetFullPath "Core.qs"
 
 /// The path to the Q# file that provides the Microsoft.Quantum.Intrinsic namespace.
-let private intrinsicFile = Path.Combine ("Circuits", "Intrinsic.qs") |> Path.GetFullPath
+let private intrinsicFile = Path.GetFullPath "Intrinsic.qs"
 
 /// The path to the Q# file that contains the test cases.
-let private testFile = Path.Combine ("Circuits", "EntryPointTests.qs") |> Path.GetFullPath
+let private testFile = Path.GetFullPath "Tests.qs"
 
 /// The namespace used for the test cases.
-let private testNamespace = "Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint"
+let private testNamespace = "Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests"
 
 /// The test case for the given test number.
 let private testCase =

--- a/src/Simulation/EntryPointDriver.Tests/Tests.qs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.qs
@@ -5,14 +5,14 @@
 // No Options
 //
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation ReturnUnit() : Unit { }
 }
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation ReturnInt() : Int {
         return 42;
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation ReturnString() : String {
         return "Hello, World!";
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 // Single Option
 //
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptInt(n : Int) : Int {
         return n;
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptBigInt(n : BigInt) : BigInt {
         return n;
@@ -52,7 +52,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptDouble(n : Double) : Double {
         return n;
@@ -61,7 +61,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptBool(b : Bool) : Bool {
         return b;
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptPauli(p : Pauli) : Pauli {
         return p;
@@ -79,7 +79,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptResult(r : Result) : Result {
         return r;
@@ -88,7 +88,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptRange(r : Range) : Range {
         return r;
@@ -97,7 +97,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptString(s : String) : String {
         return s;
@@ -106,7 +106,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptUnit(u : Unit) : Unit {
         return u;
@@ -115,7 +115,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptStringArray(xs : String[]) : String[] {
         return xs;
@@ -124,7 +124,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptBigIntArray(bs : BigInt[]) : BigInt[] {
         return bs;
@@ -133,7 +133,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptPauliArray(ps : Pauli[]) : Pauli[] {
         return ps;
@@ -142,7 +142,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptRangeArray(rs : Range[]) : Range[] {
         return rs;
@@ -151,7 +151,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptResultArray(rs : Result[]) : Result[] {
         return rs;
@@ -160,7 +160,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation AcceptUnitArray(us : Unit[]) : Unit[] {
         return us;
@@ -173,7 +173,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 // Multiple Options
 //
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation TwoOptions(n : Int, b : Bool) : String {
         return $"{n} {b}";
@@ -182,7 +182,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation ThreeOptions(n : Int, b : Bool, xs : String[]) : String {
         return $"{n} {b} {xs}";
@@ -195,7 +195,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 // Tuples
 //
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation RedundantOneTuple((x : Int)) : String {
         return $"{x}";
@@ -204,7 +204,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation RedundantTwoTuple((x : Int, y : Int)) : String {
         return $"{x} {y}";
@@ -213,7 +213,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation OneTuple(x : Int, (y : Int)) : String {
         return $"{x} {y}";
@@ -222,7 +222,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation TwoTuple(x : Int, (y : Int, z : Int)) : String {
         return $"{x} {y} {z}";
@@ -235,7 +235,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 // Name Conversion
 //
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation CamelCase(camelCaseName : String) : String {
         return camelCaseName;
@@ -244,7 +244,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation SingleLetter(x : String) : String {
         return x;
@@ -257,7 +257,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 // Shadowing
 //
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation ShadowSimulator(simulator : String) : String {
         return simulator;
@@ -266,7 +266,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation ShadowS(s : String) : String {
         return s;
@@ -275,7 +275,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 
 // ---
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     @EntryPoint()
     operation ShadowVersion(version : String) : String {
         return version;
@@ -288,7 +288,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 // Simulators
 //
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     open Microsoft.Quantum.Intrinsic;
 
     @EntryPoint()
@@ -314,7 +314,7 @@ namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
 // Help
 //
 
-namespace Microsoft.Quantum.CsharpGeneration.Testing.EntryPoint {
+namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Tests {
     /// # Summary
     /// This test checks that the entry point documentation appears correctly in the command line help message.
     ///

--- a/src/Simulation/EntryPointDriver/EntryPointDriver.csproj
+++ b/src/Simulation/EntryPointDriver/EntryPointDriver.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- We use package references (instead of project references) to projects in this repository so that it is easier
-       - to test the entry point driver with packaged versions of the Azure Quantum providers.
-       -->
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.11.2005.1905-beta" />
     <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2004.1717-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Runtime.Core" Version="0.11.2005.1905-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2005.1905-beta" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20213.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Microsoft.Quantum.Runtime.Core.csproj" />
+    <ProjectReference Include="..\Simulators\Microsoft.Quantum.Simulation.Simulators.csproj" />
+    <ProjectReference Include="..\..\Azure\Azure.Quantum.Client\Microsoft.Azure.Quantum.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Simulation/EntryPointDriver/EntryPointDriver.csproj
+++ b/src/Simulation/EntryPointDriver/EntryPointDriver.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- We use package references (instead of project references) to projects in this repository so that it is easier
+       - to test the entry point driver with packaged versions of the Azure Quantum providers.
+       -->
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.11.2005.1905-beta" />
     <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2004.1717-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Runtime.Core" Version="0.11.2005.1905-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2005.1905-beta" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20213.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Azure\Azure.Quantum.Client\Microsoft.Azure.Quantum.Client.csproj" />
-    <ProjectReference Include="..\Core\Microsoft.Quantum.Runtime.Core.csproj" />
-    <ProjectReference Include="..\Simulators\Microsoft.Quantum.Simulation.Simulators.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
@@ -10,10 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\QsharpCore\Microsoft.Quantum.QSharp.Core.csproj" />
     <ProjectReference Include="..\..\..\CsharpGeneration\Microsoft.Quantum.CsharpGeneration.fsproj" PrivateAssets="All" IsQscReference="true" />
     <ProjectReference Include="..\..\..\EntryPointDriver\EntryPointDriver.csproj" />
-    <ProjectReference Include="..\..\..\Simulators\Microsoft.Quantum.Simulation.Simulators.csproj" />
   </ItemGroup>
 
   <Target Name="BeforeCsharpCompile">


### PR DESCRIPTION
The entry point driver's references to the Q# runtime are now in one place (test projects get them transitively). This makes it easier to update the references to test changes to the entry point driver locally with the Azure Quantum providers without version conflicts (since both the entry point driver and the providers depend on the runtime).