### PR TITLE
Add Microsoft.Azure.Quantum.Client as NuGet dependency to CsharpGeneration package

### DIFF
--- a/src/Simulation/CsharpGeneration/FindNuspecReferences.ps1
+++ b/src/Simulation/CsharpGeneration/FindNuspecReferences.ps1
@@ -65,6 +65,7 @@ Add-PackageReferenceDependencies '..\EntryPointDriver\EntryPointDriver.csproj'
 # $version$ is replaced with the current package version when the package is built.
 Add-Dependency 'Microsoft.Quantum.Runtime.Core' '$version$'
 Add-Dependency 'Microsoft.Quantum.Simulators' '$version$'
+Add-Dependency 'Microsoft.Azure.Quantum.Client' '$version$'
 
 $nuspec.package.metadata.AppendChild($dependencies)
 $nuspec.Save([Path]::Combine((Get-Location), $target))


### PR DESCRIPTION
This is needed since [EntryPointDriver depends on it via a project reference](https://github.com/microsoft/qsharp-runtime/blob/ce60cef65bf2b3f67e6d5ab8fff7b4bc4c836ec6/src/Simulation/EntryPointDriver/EntryPointDriver.csproj#L20), and the FindNuspecReferences.ps1 script does not automatically convert project references to package references.