### PR TITLE
Add --dry-run option and implement --shots option

### DIFF
--- a/src/Simulation/EntryPointDriver/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure.cs
@@ -6,6 +6,7 @@ using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 using Microsoft.Azure.Quantum;
 using Microsoft.Quantum.Runtime;
+using static Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Driver;
 
 namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
 {
@@ -28,7 +29,8 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             var machine = CreateMachine(settings);
             if (machine is null)
             {
-                DisplayUnknownTargetError(settings.Target);
+                DisplayWithColor(ConsoleColor.Red, Console.Error,
+                    $"The target '{settings.Target}' was not recognized.");
                 return 1;
             }
 
@@ -64,7 +66,11 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             switch (format)
             {
                 case OutputFormat.FriendlyUri:
-                    // TODO: Show the friendly URI. The friendly URI is not yet available from the job.
+                    // TODO:
+                    DisplayWithColor(ConsoleColor.Yellow, Console.Error,
+                        "The friendly URI for viewing job results is not available yet. Showing the job ID instead.");
+                    Console.WriteLine(job.Id);
+                    break;
                 case OutputFormat.Id:
                     Console.WriteLine(job.Id);
                     break;
@@ -82,18 +88,6 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             settings.Target == "nothing"
                 ? new NothingMachine()
                 : QuantumMachineFactory.CreateMachine(settings.CreateWorkspace(), settings.Target, settings.Storage);
-
-        /// <summary>
-        /// Displays an error message for attempting to use an unknown target machine.
-        /// </summary>
-        /// <param name="target">The target machine.</param>
-        private static void DisplayUnknownTargetError(string? target)
-        {
-            var originalForeground = Console.ForegroundColor;
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.Error.WriteLine($"The target '{target}' was not recognized.");
-            Console.ForegroundColor = originalForeground;
-        }
 
         /// <summary>
         /// The quantum machine submission context.

--- a/src/Simulation/EntryPointDriver/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
                 Console.WriteLine(isValid ? "✔️  The program is valid!" : "❌  The program is invalid.");
                 if (!string.IsNullOrWhiteSpace(message))
                 {
+                    Console.WriteLine();
                     Console.WriteLine(message);
                 }
                 return isValid ? 0 : 1;

--- a/src/Simulation/EntryPointDriver/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             }
             else
             {
-                // TODO: Specify the number of shots.
-                var job = await machine.SubmitAsync(entryPoint.Info, input);
+                var job = await machine.SubmitAsync(
+                    entryPoint.Info, input, new SubmissionContext { Shots = settings.Shots });
                 DisplayJob(job, settings.Output);
                 return 0;
             }
@@ -92,6 +92,16 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             Console.ForegroundColor = ConsoleColor.Red;
             Console.Error.WriteLine($"The target '{target}' was not recognized.");
             Console.ForegroundColor = originalForeground;
+        }
+
+        /// <summary>
+        /// The quantum machine submission context.
+        /// </summary>
+        private sealed class SubmissionContext : IQuantumMachineSubmissionContext
+        {
+            public string? FriendlyName { get; set; }
+
+            public int Shots { get; set; }
         }
     }
 

--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -7,6 +7,7 @@ using System.CommandLine.Builder;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -162,12 +163,9 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             }
             else
             {
-                var originalForeground = Console.ForegroundColor;
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.Error.WriteLine(
+                DisplayWithColor(ConsoleColor.Yellow, Console.Error,
                     $"Warning: Option {option.Aliases.First()} is overridden by an entry point parameter name. " +
                     $"Using default value {option.DefaultValue}.");
-                Console.ForegroundColor = originalForeground;
                 return option.DefaultValue;
             }
         }
@@ -269,6 +267,20 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             new[] { "--dry-run" },
             false,
             "Validate the program and options, but do not submit to Azure Quantum.");
+
+        /// <summary>
+        /// Displays a message to the console using the given color and text writer.
+        /// </summary>
+        /// <param name="color">The text color.</param>
+        /// <param name="writer">The text writer for the console output stream.</param>
+        /// <param name="message">The message to display.</param>
+        internal static void DisplayWithColor(ConsoleColor color, TextWriter writer, string message)
+        {
+            var originalForeground = Console.ForegroundColor;
+            Console.ForegroundColor = color;
+            writer.WriteLine(message);
+            Console.ForegroundColor = originalForeground;
+        }
     }
 
     /// <summary>

--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -8,6 +8,7 @@ using System.CommandLine.Help;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.Simulation.Core;
@@ -84,6 +85,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             AddOptionIfAvailable(submit, BaseUriOption);
             AddOptionIfAvailable(submit, OutputOption);
             AddOptionIfAvailable(submit, ShotsOption);
+            AddOptionIfAvailable(submit, DryRunOption);
 
             var root = new RootCommand(entryPoint.Summary) { simulate, submit };
             foreach (var option in entryPoint.Options)
@@ -98,6 +100,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             }
             root.Handler = simulate.Handler;
 
+            Console.OutputEncoding = Encoding.UTF8;
             return await new CommandLineBuilder(root)
                 .UseDefaults()
                 .UseHelpBuilder(context => new QsHelpBuilder(context.Console))
@@ -131,9 +134,10 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
                 AadToken = DefaultIfShadowed(AadTokenOption, settings.AadToken),
                 BaseUri = DefaultIfShadowed(BaseUriOption, settings.BaseUri),
                 Shots = DefaultIfShadowed(ShotsOption, settings.Shots),
-                Output = DefaultIfShadowed(OutputOption, settings.Output)
+                Output = DefaultIfShadowed(OutputOption, settings.Output),
+                DryRun = DefaultIfShadowed(DryRunOption, settings.DryRun)
             });
-        
+
         /// <summary>
         /// Returns true if the alias is not already used by an entry point option.
         /// </summary>
@@ -257,6 +261,14 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             new[] { "--output" },
             OutputFormat.FriendlyUri,
             "The information to show in the output after the job is submitted.");
+
+        /// <summary>
+        /// The dry run option.
+        /// </summary>
+        internal static readonly OptionInfo<bool> DryRunOption = new OptionInfo<bool>(
+            new[] { "--dry-run" },
+            false,
+            "Validate the program and options, but do not submit to Azure Quantum.");
     }
 
     /// <summary>

--- a/src/Simulation/EntryPointDriver/NothingMachine.cs
+++ b/src/Simulation/EntryPointDriver/NothingMachine.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
     /// </summary>
     internal class NothingMachine : IQuantumMachine
     {
-        public string ProviderId => nameof(NothingMachine);
+        public string ProviderId { get; } = nameof(NothingMachine);
 
-        public string Target => "Nothing";
+        public string Target { get; } = "Nothing";
 
         public Task<IQuantumMachineOutput<TOutput>> ExecuteAsync<TInput, TOutput>(
                 EntryPointInfo<TInput, TOutput> info, TInput input) =>
@@ -81,8 +81,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
             throw new NotSupportedException();
 
         public (bool IsValid, string Message) Validate<TInput, TOutput>(
-                EntryPointInfo<TInput, TOutput> info, TInput input) => 
-            throw new NotSupportedException();
+            EntryPointInfo<TInput, TOutput> info, TInput input) => (true, string.Empty);
 
         /// <summary>
         /// A quantum machine job with default properties.
@@ -99,7 +98,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
 
             public bool Failed { get; } = true;
 
-            public Uri Uri => new Uri("https://example.com/" + Id);
+            public Uri Uri => new Uri($"https://www.example.com/{Id}");
 
             public Task CancelAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
 

--- a/src/Simulation/EntryPointDriver/NothingMachine.cs
+++ b/src/Simulation/EntryPointDriver/NothingMachine.cs
@@ -71,14 +71,14 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
                 EntryPointInfo<TInput, TOutput> info,
                 TInput input,
                 IQuantumMachineSubmissionContext submissionContext) =>
-            throw new NotSupportedException();
+            SubmitAsync(info, input);
 
         public Task<IQuantumMachineJob> SubmitAsync<TInput, TOutput>(
                 EntryPointInfo<TInput, TOutput> info,
                 TInput input, 
                 IQuantumMachineSubmissionContext submissionContext, 
                 IQuantumMachine.ConfigureJob configureJobCallback) =>
-            throw new NotSupportedException();
+            SubmitAsync(info, input);
 
         public (bool IsValid, string Message) Validate<TInput, TOutput>(
             EntryPointInfo<TInput, TOutput> info, TInput input) => (true, string.Empty);

--- a/src/Simulation/EntryPointDriver/Simulation.cs
+++ b/src/Simulation/EntryPointDriver/Simulation.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.Simulation.Core;
 using Microsoft.Quantum.Simulation.Simulators;
+using static Microsoft.Quantum.CsharpGeneration.EntryPointDriver.Driver;
 
 namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
 {
@@ -85,10 +86,7 @@ namespace Microsoft.Quantum.CsharpGeneration.EntryPointDriver
         /// <param name="name">The name of the custom simulator.</param>
         private static void DisplayCustomSimulatorError(string name)
         {
-            var originalForeground = Console.ForegroundColor;
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.Error.WriteLine($"The simulator '{name}' could not be found.");
-            Console.ForegroundColor = originalForeground;
+            DisplayWithColor(ConsoleColor.Red, Console.Error, $"The simulator '{name}' could not be found.");
             Console.Error.WriteLine();
             Console.Error.WriteLine(
                 $"If '{name}' is a custom simulator, it must be set in the DefaultSimulator project property:");


### PR DESCRIPTION
I decided to use `submit --dry-run` since:

* With `submit --validate`, it looks like it is validating *and* submitting, rather than validating *instead of* submitting.
* I considered making a separate `validate` command, but it would have all the same options as the `submit` command, so that seemed like unnecessarily duplication.

I'll add the tests to #204.