### PR TITLE
Update QubitManagerTests and avoid unnecessary IgnorableAssert

### DIFF
--- a/src/Simulation/Common/QubitManager.cs
+++ b/src/Simulation/Common/QubitManager.cs
@@ -259,7 +259,6 @@ namespace Microsoft.Quantum.Simulation.Common
         /// </summary>
         public virtual IQArray<Qubit> Allocate(long numToAllocate)
         {
-            IgnorableAssert.Assert(numToAllocate >= 0, "Attempt to allocate negative number of qubits.");
             if (numToAllocate < 0)
             {
                 throw new ArgumentException("Attempt to allocate negative number of qubits.");
@@ -297,7 +296,6 @@ namespace Microsoft.Quantum.Simulation.Common
             else
             {
                 long Occupied = (usedOnlyForBorrowing ? AllocatedForBorrowing : Allocated);
-                IgnorableAssert.Assert(qubits[qubit.Id] == Occupied, "Attempt to free qubit that has not been allocated.");
                 if (qubits[qubit.Id] != Occupied)
                 {
                     throw new ArgumentException("Attempt to free qubit that has not been allocated.");
@@ -337,7 +335,7 @@ namespace Microsoft.Quantum.Simulation.Common
         protected virtual void DisableOneQubit(Qubit qubit)
         {
             // Note: Borrowed qubits cannot be disabled.
-            IgnorableAssert.Assert(qubits[qubit.Id] == Allocated, "Attempt to disable qubit that has not been allocated.");
+            Debug.Assert(qubits[qubit.Id] == Allocated);
             qubits[qubit.Id] = Disabled;
             numDisabledQubits++;
 
@@ -416,7 +414,6 @@ namespace Microsoft.Quantum.Simulation.Common
         /// </summary>
         public virtual IQArray<Qubit> Borrow(long numToBorrow, IEnumerable<Qubit> excludedQubitsSortedById) // Note, excluded could be an array of Ids for efficiency, if it is convenient for compiler.
         {
-            IgnorableAssert.Assert(numToBorrow >= 0, "Attempt to borrow negative number of qubits.");
             if (numToBorrow < 0)
             {
                 throw new ArgumentException("Attempt to borrow negative number of qubits.");

--- a/src/Simulation/Simulators.Tests/QubitManagerTests.cs
+++ b/src/Simulation/Simulators.Tests/QubitManagerTests.cs
@@ -123,17 +123,33 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 Assert.True(n_q.Length == 0);
             }
 
-            // Test allocating qubits over capacity
-            OperationsTestHelper.IgnoreDebugAssert(() =>
+            // NOTE: The below tests trigger exceptions, which but the QubitManager into a bad
+            // state where it shouldn't be reused. Creating a separate QubitManager in a small
+            // scope to test the exceptions avoids having one test case pollute the other.
+
+            // Test for over allocating and over borrowing.
             {
+                QubitManager qm_small = new QubitManager(2);
                 IQArray<Qubit> n_q;
+                Assert.Throws<NotEnoughQubits>(() => n_q = qm_small.Allocate(5));
+            }
+            {
+                QubitManager qm_small = new QubitManager(2);
+                IQArray<Qubit> n_q;
+                Assert.Throws<NotEnoughQubits>(() => n_q = qm_small.Borrow(5, null));
+            }
 
-                Assert.Throws<NotEnoughQubits>(() => n_q = qm.Allocate(10));
-                Assert.Throws<NotEnoughQubits>(() => n_q = qm.Borrow(25, exclusion));
-
-                Assert.Throws<ArgumentException>(() => n_q = qm.Allocate(-2));
-                Assert.Throws<ArgumentException>(() => n_q = qm.Borrow(-2, exclusion));
-            });
+            // Test for negative input to allocate and borrow.
+            {
+                QubitManager qm_small = new QubitManager(20);
+                IQArray<Qubit> n_q;
+                Assert.Throws<ArgumentException>(() => n_q = qm_small.Allocate(-2));
+            }
+            {
+                QubitManager qm_small = new QubitManager(20);
+                IQArray<Qubit> n_q;
+                Assert.Throws<ArgumentException>(() => n_q = qm_small.Borrow(-2, null));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION

The use of `Debug.Assert` was causing our tests to fail with an unhandled exception. Switching to `IgnorableAssert.Assert` keeps the debug assert behavior but also allow tests to disable them and test corner cases.