### PR TITLE
Throw an AzureQuantumException (or an exception that derives from it) when there is a failure related to Azure

### DIFF
--- a/src/Azure/Azure.Quantum.Client.Test/WorkspaceTest.cs
+++ b/src/Azure/Azure.Quantum.Client.Test/WorkspaceTest.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using Microsoft.Azure.Quantum.Client;
 using Microsoft.Azure.Quantum.Client.Models;
+using Microsoft.Azure.Quantum.Exceptions;
 using Microsoft.Rest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.Quantum.Test
                 receivedJob = workspace.SubmitJob(job);
                 Assert.Fail();
             }
-            catch (ValidationException)
+            catch (WorkspaceClientException)
             {
                 jobDetails.ContainerUri = "https://uri";
             }
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.Quantum.Test
                 receivedJob = workspace.SubmitJob(job);
                 Assert.Fail();
             }
-            catch (ValidationException)
+            catch (WorkspaceClientException)
             {
                 jobDetails.ProviderId = TestConstants.ProviderId;
             }

--- a/src/Azure/Azure.Quantum.Client/Exceptions/AzureQuantumException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/AzureQuantumException.cs
@@ -5,18 +5,34 @@ using System;
 
 namespace Microsoft.Azure.Quantum.Exceptions
 {
+    /// <summary>
+    /// The exception that is thrown when an error related to Azure quantum occurs.
+    /// </summary>
     public class AzureQuantumException : Exception
     {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureQuantumException"/> class with a default error message.
+        /// </summary>
         public AzureQuantumException()
             : base("An exception related to Azure quantum occurred")
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureQuantumException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">Error message that explains the reason for the exception.</param>
         public AzureQuantumException(string message)
             : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureQuantumException"/> class with a specified error message and a reference to another exception that caused this one.
+        /// </summary>
+        /// <param name="message">Error message that explains the reason for the exception.</param>
+        /// <param name="inner">Exception that is the cause of the current one.</param>
         public AzureQuantumException(string message, Exception inner)
             : base(message, inner)
         {

--- a/src/Azure/Azure.Quantum.Client/Exceptions/AzureQuantumException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/AzureQuantumException.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Quantum.Exceptions
     public class AzureQuantumException : Exception
     {
         public AzureQuantumException()
-            : base("An exception related to the Azure quantum occurred.")
+            : base("An exception related to Azure quantum occurred")
         {
         }
 

--- a/src/Azure/Azure.Quantum.Client/Exceptions/StorageClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/StorageClientException.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Azure.Quantum.Exceptions
+{
+    public class StorageClientException : AzureQuantumException
+    {
+        private const string BaseMessage = "An exception related to the Azure storage client occurred";
+
+        public StorageClientException()
+            : base(BaseMessage)
+        {
+        }
+
+        public StorageClientException(
+            string message)
+            : base($"{BaseMessage}: {message}")
+        {
+        }
+
+        public StorageClientException(
+            string message,
+            Exception inner)
+            : base($"{BaseMessage}: {message}", inner)
+        {
+        }
+
+        public StorageClientException(
+            string message,
+            string connectionString,
+            string containerName,
+            string blobName,
+            Exception inner)
+            : base(
+                  $"{BaseMessage}: {message}{Environment.NewLine}" +
+                  $"ConnectionString: {connectionString}{Environment.NewLine}" +
+                  $"ContainerName: {containerName}{Environment.NewLine}" +
+                  $"BlobName: {blobName}",
+                  inner)
+        {
+        }
+    }
+}

--- a/src/Azure/Azure.Quantum.Client/Exceptions/StorageClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/StorageClientException.cs
@@ -5,21 +5,36 @@ using System;
 
 namespace Microsoft.Azure.Quantum.Exceptions
 {
+    /// <summary>
+    /// The exception that is thrown when an error related to the Azure storage client occurs.
+    /// </summary>
     public class StorageClientException : AzureQuantumException
     {
         private const string BaseMessage = "An exception related to the Azure storage client occurred";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StorageClientException"/> class with a default error message.
+        /// </summary>
         public StorageClientException()
             : base(BaseMessage)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StorageClientException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">Error message that explains the reason for the exception.</param>
         public StorageClientException(
             string message)
             : base($"{BaseMessage}: {message}")
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StorageClientException"/> class with a specified error message and a reference to another exception that caused this one.
+        /// </summary>
+        /// <param name="message">Error message that explains the reason for the exception.</param>
+        /// <param name="inner">Exception that is the cause of the current one.</param>
         public StorageClientException(
             string message,
             Exception inner)
@@ -27,6 +42,14 @@ namespace Microsoft.Azure.Quantum.Exceptions
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StorageClientException"/> class with a specified error message, a reference to another exception that caused this one and more detailes that are specific to the storage client.
+        /// </summary>
+        /// <param name="message">Error message that explains the reason for the exception.</param>
+        /// <param name="connectionString">Connection string used by the storage client.</param>
+        /// <param name="containerName">Name of the container involved in the operation that caused the exception.</param>
+        /// <param name="blobName">Name of the BLOB involved in the operation that caused the exception.</param>
+        /// <param name="inner">Exception that is the cause of the current one.</param>
         public StorageClientException(
             string message,
             string connectionString,

--- a/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.Quantum.Authentication;
 using System;
 
 namespace Microsoft.Azure.Quantum.Exceptions
@@ -38,10 +37,10 @@ namespace Microsoft.Azure.Quantum.Exceptions
             Exception inner)
             : base(
                   $"{BaseMessage}: {message}{Environment.NewLine}" +
-                  $"SubscriptionId: {subscriptionId}" +
-                  $"ResourceGroupName: {resourceGroupName}" +
-                  $"WorkspaceName: {workspaceName}" +
-                  $"BaseUri: {baseUri}" +
+                  $"SubscriptionId: {subscriptionId}{Environment.NewLine}" +
+                  $"ResourceGroupName: {resourceGroupName}{Environment.NewLine}" +
+                  $"WorkspaceName: {workspaceName}{Environment.NewLine}" +
+                  $"BaseUri: {baseUri}{Environment.NewLine}" +
                   $"JobId: {jobId}",
                   inner)
         {

--- a/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Quantum.Authentication;
+using System;
+
+namespace Microsoft.Azure.Quantum.Exceptions
+{
+    public class WorkspaceClientException : AzureQuantumException
+    {
+        private const string BaseMessage = "An exception related to the Azure workspace client occurred";
+
+        public WorkspaceClientException()
+            : base(BaseMessage)
+        {
+        }
+
+        public WorkspaceClientException(
+            string message)
+            : base($"{BaseMessage}: {message}")
+        {
+        }
+
+        public WorkspaceClientException(
+            string message,
+            Exception inner)
+            : base($"{BaseMessage}: {message}", inner)
+        {
+        }
+
+        public WorkspaceClientException(
+            string message,
+            string subscriptionId,
+            string resourceGroupName,
+            string workspaceName,
+            Uri baseUri,
+            string jobId,
+            Exception inner)
+            : base(
+                  $"{BaseMessage}: {message}{Environment.NewLine}" +
+                  $"SubscriptionId: {subscriptionId}" +
+                  $"ResourceGroupName: {resourceGroupName}" +
+                  $"WorkspaceName: {workspaceName}" +
+                  $"BaseUri: {baseUri}" +
+                  $"JobId: {jobId}",
+                  inner)
+        {
+        }
+    }
+}

--- a/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
@@ -5,21 +5,36 @@ using System;
 
 namespace Microsoft.Azure.Quantum.Exceptions
 {
+    /// <summary>
+    /// The exception that is thrown when an error related to the Azure workspace client occurs.
+    /// </summary>
     public class WorkspaceClientException : AzureQuantumException
     {
         private const string BaseMessage = "An exception related to the Azure workspace client occurred";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkspaceClientException"/> class with a default error message.
+        /// </summary>
         public WorkspaceClientException()
             : base(BaseMessage)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkspaceClientException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">Error message that explains the reason for the exception.</param>
         public WorkspaceClientException(
             string message)
             : base($"{BaseMessage}: {message}")
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkspaceClientException"/> class with a specified error message and a reference to another exception that caused this one.
+        /// </summary>
+        /// <param name="message">Error message that explains the reason for the exception.</param>
+        /// <param name="inner">Exception that is the cause of the current one.</param>
         public WorkspaceClientException(
             string message,
             Exception inner)
@@ -27,6 +42,16 @@ namespace Microsoft.Azure.Quantum.Exceptions
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkspaceClientException"/> class with a specified error message, a reference to another exception that caused this one and details about the Azure workspace client.
+        /// </summary>
+        /// <param name="message">Error message that explains the reason for the exception.</param>
+        /// <param name="subscriptionId">ID of the subscription used by the Azure workspace client.</param>
+        /// <param name="resourceGroupName">Name of the resource group used by the Azure workspace client.</param>
+        /// <param name="workspaceName">Name of the workspace used by the Azure workspace client.</param>
+        /// <param name="baseUri">URI used by the Azure workspace client.</param>
+        /// <param name="jobId">ID of the job involved in the operation that caused the exception.</param>
+        /// <param name="inner">Exception that is the cause of the current one.</param>
         public WorkspaceClientException(
             string message,
             string subscriptionId,

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.Quantum
             catch (Exception ex)
             {
                 throw new WorkspaceClientException(
-                    $"Could not cancel job",
+                    "Could not cancel job",
                     SubscriptionId,
                     ResourceGroupName,
                     WorkspaceName,

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Quantum
             catch (Exception ex)
             {
                 throw new WorkspaceClientException(
-                    $"Could not create an access token provider",
+                    "Could not create an access token provider",
                     SubscriptionId,
                     ResourceGroupName,
                     WorkspaceName,

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -93,14 +93,7 @@ namespace Microsoft.Azure.Quantum
             }
             catch (Exception ex)
             {
-                throw new WorkspaceClientException(
-                    "Could not create an access token provider",
-                    SubscriptionId,
-                    ResourceGroupName,
-                    WorkspaceName,
-                    BaseUri,
-                    string.Empty,
-                    ex);
+                throw CreateException(ex, "Could not create an access token provider");
             }
 
             Ensure.NotNull(accessTokenProvider, nameof(accessTokenProvider));
@@ -117,14 +110,7 @@ namespace Microsoft.Azure.Quantum
             }
             catch (Exception ex)
             {
-                throw new WorkspaceClientException(
-                    "Could not create an Azure quantum service client",
-                    SubscriptionId,
-                    ResourceGroupName,
-                    WorkspaceName,
-                    BaseUri,
-                    string.Empty,
-                    ex);
+                throw CreateException(ex, "Could not create an Azure quantum service client");
             }
         }
 
@@ -163,14 +149,7 @@ namespace Microsoft.Azure.Quantum
             }
             catch (Exception ex)
             {
-                throw new WorkspaceClientException(
-                    "Could not submit job",
-                    SubscriptionId,
-                    ResourceGroupName,
-                    WorkspaceName,
-                    BaseUri,
-                    jobDefinition.Details.Id,
-                    ex);
+                throw CreateException(ex, "Could not submit job", jobDefinition.Details.Id);
             }
         }
 
@@ -194,14 +173,7 @@ namespace Microsoft.Azure.Quantum
             }
             catch (Exception ex)
             {
-                throw new WorkspaceClientException(
-                    "Could not cancel job",
-                    SubscriptionId,
-                    ResourceGroupName,
-                    WorkspaceName,
-                    BaseUri,
-                    jobId,
-                    ex);
+                throw CreateException(ex, "Could not cancel job", jobId);
             }
         }
 
@@ -227,14 +199,7 @@ namespace Microsoft.Azure.Quantum
             }
             catch (Exception ex)
             {
-                throw new WorkspaceClientException(
-                    "Could not get job",
-                    SubscriptionId,
-                    ResourceGroupName,
-                    WorkspaceName,
-                    BaseUri,
-                    jobId,
-                    ex);
+                throw CreateException(ex, "Could not get job", jobId);
             }
         }
 
@@ -257,15 +222,23 @@ namespace Microsoft.Azure.Quantum
             }
             catch (Exception ex)
             {
-                throw new WorkspaceClientException(
-                    "Could not list jobs",
-                    SubscriptionId,
-                    ResourceGroupName,
-                    WorkspaceName,
-                    BaseUri,
-                    string.Empty,
-                    ex);
+                throw CreateException(ex, "Could not list jobs");
             }
+        }
+
+        private WorkspaceClientException CreateException(
+            Exception inner,
+            string message,
+            string jobId = "")
+        {
+            return new WorkspaceClientException(
+                message,
+                SubscriptionId,
+                ResourceGroupName,
+                WorkspaceName,
+                BaseUri,
+                jobId,
+                inner);
         }
     }
 }

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Quantum
             catch (Exception ex)
             {
                 throw new WorkspaceClientException(
-                    $"Could not submit job",
+                    "Could not submit job",
                     SubscriptionId,
                     ResourceGroupName,
                     WorkspaceName,

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Quantum
             catch (Exception ex)
             {
                 throw new WorkspaceClientException(
-                    $"Could not create an Azure quantum service client",
+                    "Could not create an Azure quantum service client",
                     SubscriptionId,
                     ResourceGroupName,
                     WorkspaceName,

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -4,16 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Azure.Quantum.Authentication;
 using Microsoft.Azure.Quantum.Client;
 using Microsoft.Azure.Quantum.Client.Models;
-using Microsoft.Azure.Quantum.Storage;
+using Microsoft.Azure.Quantum.Exceptions;
 using Microsoft.Azure.Quantum.Utility;
-using Microsoft.Quantum.Runtime;
 
 namespace Microsoft.Azure.Quantum
 {
@@ -23,6 +21,11 @@ namespace Microsoft.Azure.Quantum
     /// <seealso cref="Microsoft.Azure.Quantum.Client.IWorkspace" />
     public class Workspace : IWorkspace
     {
+        private readonly Uri BaseUri;
+        private readonly string ResourceGroupName;
+        private readonly string SubscriptionId;
+        private readonly string WorkspaceName;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Workspace"/> class.
         /// </summary>
@@ -76,21 +79,53 @@ namespace Microsoft.Azure.Quantum
             IAccessTokenProvider accessTokenProvider,
             Uri baseUri = null)
         {
+            BaseUri = baseUri ?? new Uri(Constants.DefaultBaseUri);
             Ensure.NotNullOrWhiteSpace(subscriptionId, nameof(subscriptionId));
+            SubscriptionId = subscriptionId;
             Ensure.NotNullOrWhiteSpace(resourceGroupName, nameof(resourceGroupName));
+            ResourceGroupName = resourceGroupName;
             Ensure.NotNullOrWhiteSpace(workspaceName, nameof(workspaceName));
+            WorkspaceName = workspaceName;
 
-            accessTokenProvider = accessTokenProvider ?? new CustomAccessTokenProvider(subscriptionId);
+            try
+            {
+                accessTokenProvider = accessTokenProvider ?? new CustomAccessTokenProvider(subscriptionId);
+            }
+            catch (Exception ex)
+            {
+                throw new WorkspaceClientException(
+                    $"Could not create an access token provider",
+                    SubscriptionId,
+                    ResourceGroupName,
+                    WorkspaceName,
+                    BaseUri,
+                    string.Empty,
+                    ex);
+            }
 
             Ensure.NotNull(accessTokenProvider, nameof(accessTokenProvider));
 
-            this.JobsClient = new QuantumClient(new AuthorizationClientHandler(accessTokenProvider))
+            try
             {
-                BaseUri = baseUri ?? new Uri(Constants.DefaultBaseUri),
-                SubscriptionId = subscriptionId,
-                ResourceGroupName = resourceGroupName,
-                WorkspaceName = workspaceName,
-            }.Jobs;
+                this.JobsClient = new QuantumClient(new AuthorizationClientHandler(accessTokenProvider))
+                {
+                    BaseUri = BaseUri,
+                    SubscriptionId = subscriptionId,
+                    ResourceGroupName = resourceGroupName,
+                    WorkspaceName = workspaceName,
+                }.Jobs;
+            }
+            catch (Exception ex)
+            {
+                throw new WorkspaceClientException(
+                    $"Could not create an Azure quantum service client",
+                    SubscriptionId,
+                    ResourceGroupName,
+                    WorkspaceName,
+                    BaseUri,
+                    string.Empty,
+                    ex);
+            }
         }
 
         /// <summary>
@@ -117,12 +152,26 @@ namespace Microsoft.Azure.Quantum
             Ensure.NotNull(jobDefinition, nameof(jobDefinition));
             Ensure.NotNullOrWhiteSpace(jobDefinition.Details.Id, nameof(jobDefinition.Details.Id));
 
-            JobDetails jobDetails = await this.JobsClient.PutAsync(
-                jobId: jobDefinition.Details.Id,
-                jobDefinition: jobDefinition.Details,
-                cancellationToken: cancellationToken);
+            try
+            {
+                JobDetails jobDetails = await this.JobsClient.PutAsync(
+                    jobId: jobDefinition.Details.Id,
+                    jobDefinition: jobDefinition.Details,
+                    cancellationToken: cancellationToken);
 
-            return new CloudJob(this, jobDetails);
+                return new CloudJob(this, jobDetails);
+            }
+            catch (Exception ex)
+            {
+                throw new WorkspaceClientException(
+                    $"Could not submit job",
+                    SubscriptionId,
+                    ResourceGroupName,
+                    WorkspaceName,
+                    BaseUri,
+                    jobDefinition.Details.Id,
+                    ex);
+            }
         }
 
         /// <summary>
@@ -135,11 +184,25 @@ namespace Microsoft.Azure.Quantum
         {
             Ensure.NotNullOrWhiteSpace(jobId, nameof(jobId));
 
-            JobDetails jobDetails = await this.JobsClient.DeleteAsync(
-                jobId: jobId,
-                cancellationToken: cancellationToken);
+            try
+            {
+                JobDetails jobDetails = await this.JobsClient.DeleteAsync(
+                    jobId: jobId,
+                    cancellationToken: cancellationToken);
 
-            return new CloudJob(this, jobDetails);
+                return new CloudJob(this, jobDetails);
+            }
+            catch (Exception ex)
+            {
+                throw new WorkspaceClientException(
+                    $"Could not cancel job",
+                    SubscriptionId,
+                    ResourceGroupName,
+                    WorkspaceName,
+                    BaseUri,
+                    jobId,
+                    ex);
+            }
         }
 
         /// <summary>
@@ -154,11 +217,25 @@ namespace Microsoft.Azure.Quantum
         {
             Ensure.NotNullOrWhiteSpace(jobId, nameof(jobId));
 
-            JobDetails jobDetails = await this.JobsClient.GetAsync(
-                jobId: jobId,
-                cancellationToken: cancellationToken);
+            try
+            {
+                JobDetails jobDetails = await this.JobsClient.GetAsync(
+                    jobId: jobId,
+                    cancellationToken: cancellationToken);
 
-            return new CloudJob(this, jobDetails);
+                return new CloudJob(this, jobDetails);
+            }
+            catch (Exception ex)
+            {
+                throw new WorkspaceClientException(
+                    $"Could not get job",
+                    SubscriptionId,
+                    ResourceGroupName,
+                    WorkspaceName,
+                    BaseUri,
+                    jobId,
+                    ex);
+            }
         }
 
         /// <summary>
@@ -170,11 +247,25 @@ namespace Microsoft.Azure.Quantum
         /// </returns>
         public async Task<IEnumerable<CloudJob>> ListJobsAsync(CancellationToken cancellationToken = default)
         {
-            var jobs = await this.JobsClient.ListAsync(
-                cancellationToken: cancellationToken);
+            try
+            {
+                var jobs = await this.JobsClient.ListAsync(
+                    cancellationToken: cancellationToken);
 
-            return jobs
-                .Select(details => new CloudJob(this, details));
+                return jobs
+                    .Select(details => new CloudJob(this, details));
+            }
+            catch (Exception ex)
+            {
+                throw new WorkspaceClientException(
+                    $"Could not list jobs",
+                    SubscriptionId,
+                    ResourceGroupName,
+                    WorkspaceName,
+                    BaseUri,
+                    string.Empty,
+                    ex);
+            }
         }
     }
 }

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.Quantum
             catch (Exception ex)
             {
                 throw new WorkspaceClientException(
-                    $"Could not list jobs",
+                    "Could not list jobs",
                     SubscriptionId,
                     ResourceGroupName,
                     WorkspaceName,

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Quantum
             catch (Exception ex)
             {
                 throw new WorkspaceClientException(
-                    $"Could not get job",
+                    "Could not get job",
                     SubscriptionId,
                     ResourceGroupName,
                     WorkspaceName,

--- a/src/Azure/Azure.Quantum.Client/Storage/StorageHelper.cs
+++ b/src/Azure/Azure.Quantum.Client/Storage/StorageHelper.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Quantum.Storage
             catch (Exception ex)
             {
                 throw new StorageClientException(
-                    "Could not get BLOB sas URI",
+                    "Could not get BLOB shared access signature URI",
                     connectionString,
                     containerName,
                     blobName,

--- a/src/Azure/Azure.Quantum.Client/Storage/StorageHelper.cs
+++ b/src/Azure/Azure.Quantum.Client/Storage/StorageHelper.cs
@@ -33,12 +33,7 @@ namespace Microsoft.Azure.Quantum.Storage
             }
             catch (Exception ex)
             {
-                throw new StorageClientException(
-                    "An error related to the cloud storage account occurred",
-                    connectionString,
-                    string.Empty,
-                    string.Empty,
-                    ex);
+                throw CreateException(ex, "An error related to the cloud storage account occurred");
             }
         }
 
@@ -63,12 +58,7 @@ namespace Microsoft.Azure.Quantum.Storage
             }
             catch (Exception ex)
             {
-                throw new StorageClientException(
-                    "Could not download BLOB",
-                    connectionString,
-                    containerName,
-                    blobName,
-                    ex);
+                throw CreateException(ex, "Could not download BLOB", containerName, blobName);
             }
 
             return ProtocolType.COMPACT_PROTOCOL;
@@ -97,12 +87,7 @@ namespace Microsoft.Azure.Quantum.Storage
             }
             catch (Exception ex)
             {
-                throw new StorageClientException(
-                    "Could not upload BLOB",
-                    connectionString,
-                    containerName,
-                    blobName,
-                    ex);
+                throw CreateException(ex, "Could not upload BLOB", containerName, blobName);
             }
         }
 
@@ -133,14 +118,8 @@ namespace Microsoft.Azure.Quantum.Storage
             }
             catch (Exception ex)
             {
-                throw new StorageClientException(
-                    "Could not get BLOB shared access signature URI",
-                    connectionString,
-                    containerName,
-                    blobName,
-                    ex);
+                throw CreateException(ex, "Could not get BLOB shared access signature URI", containerName, blobName);
             }
-
         }
 
         /// <summary>
@@ -165,13 +144,22 @@ namespace Microsoft.Azure.Quantum.Storage
             }
             catch (Exception ex)
             {
-                throw new StorageClientException(
-                    "Could not get BLOB container shared access signature URI",
-                    connectionString,
-                    containerName,
-                    string.Empty,
-                    ex);
+                throw CreateException(ex, "Could not get BLOB container shared access signature URI", containerName);
             }
+        }
+
+        private StorageClientException CreateException (
+            Exception inner,
+            string message,
+            string containerName = "",
+            string blobName = "")
+        {
+            return new StorageClientException(
+                message,
+                connectionString,
+                containerName,
+                blobName,
+                inner);
         }
 
         private async Task<BlobClient> GetBlobClient(

--- a/src/Azure/Azure.Quantum.Client/Storage/StorageHelper.cs
+++ b/src/Azure/Azure.Quantum.Client/Storage/StorageHelper.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Quantum.Storage
             catch (Exception ex)
             {
                 throw new StorageClientException(
-                    "Could not get BLOB container sas URI",
+                    "Could not get BLOB container shared access signature URI",
                     connectionString,
                     containerName,
                     string.Empty,


### PR DESCRIPTION
This change creates two exceptions that derive from `AzureQuantumExecption`:
- `WorkspaceClientException`: used when there is a problem related to job management (e.g. submit, get).
- `StorageClientException`: used when there is a problem related to Azure storage (e.g. upload/download blobs).

These exceptions are used in the workspace and storage clients respectively when a failure occurs.