### PR TITLE
Fixing scripts to not undefine all build constants

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -21,12 +21,17 @@ function Build-One {
     );
 
     Write-Host "##[info]Building $project ($action)..."
-    Invoke-Expression ("dotnet $action $(Join-Path $PSScriptRoot $project) " +
-        "-c $Env:BUILD_CONFIGURATION " +
-        "-v $Env:BUILD_VERBOSITY " +
-        "$(if ($Env:ASSEMBLY_CONSTANTS) { "/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS" }) " +
-        "/property:Version=$Env:ASSEMBLY_VERSION " +
-        "/property:QsharpDocsOutputPath=$Env:DOCS_OUTDIR")
+    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+    }  else {
+        $args = @();
+    }
+    dotnet $action $(Join-Path $PSScriptRoot $project) `
+        -c $Env:BUILD_CONFIGURATION `
+        -v $Env:BUILD_VERBOSITY  `
+        @args `
+        /property:Version=$Env:ASSEMBLY_VERSION `
+        /property:QsharpDocsOutputPath=$Env:DOCS_OUTDIR;
 
     if ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to build $project."
@@ -41,4 +46,3 @@ Build-One 'build' '../Simulation.sln'
 if (-not $all_ok) {
     throw "At least one project failed to compile. Check the logs."
 }
-

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -21,12 +21,12 @@ function Build-One {
     );
 
     Write-Host "##[info]Building $project ($action)..."
-    dotnet $action (Join-Path $PSScriptRoot $project) `
-        -c $Env:BUILD_CONFIGURATION `
-        -v $Env:BUILD_VERBOSITY `
-        /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
-        /property:Version=$Env:ASSEMBLY_VERSION `
-        /property:QsharpDocsOutputPath=$Env:DOCS_OUTDIR
+    Invoke-Expression ("dotnet $action $(Join-Path $PSScriptRoot $project) " +
+        "-c $Env:BUILD_CONFIGURATION " +
+        "-v $Env:BUILD_VERBOSITY " +
+        "$(if ($Env:ASSEMBLY_CONSTANTS){"/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS"}) " +
+        "/property:Version=$Env:ASSEMBLY_VERSION " +
+        "/property:QsharpDocsOutputPath=$Env:DOCS_OUTDIR")
 
     if  ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to build $project."

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -8,7 +8,7 @@ $all_ok = $True
 
 Write-Host "##[info]Build Native simulator"
 cmake --build (Join-Path $PSScriptRoot "../src/Simulation/Native/build") --config $Env:BUILD_CONFIGURATION
-if  ($LastExitCode -ne 0) {
+if ($LastExitCode -ne 0) {
     Write-Host "##vso[task.logissue type=error;]Failed to build Native simulator."
     $script:all_ok = $False
 }
@@ -24,11 +24,11 @@ function Build-One {
     Invoke-Expression ("dotnet $action $(Join-Path $PSScriptRoot $project) " +
         "-c $Env:BUILD_CONFIGURATION " +
         "-v $Env:BUILD_VERBOSITY " +
-        "$(if ($Env:ASSEMBLY_CONSTANTS){"/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS"}) " +
+        "$(if ($Env:ASSEMBLY_CONSTANTS) { "/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS" }) " +
         "/property:Version=$Env:ASSEMBLY_VERSION " +
         "/property:QsharpDocsOutputPath=$Env:DOCS_OUTDIR")
 
-    if  ($LastExitCode -ne 0) {
+    if ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to build $project."
         $script:all_ok = $False
     }
@@ -38,8 +38,7 @@ Build-One 'publish' '../src/Simulation/CsharpGeneration.App'
 
 Build-One 'build' '../Simulation.sln'
 
-if (-not $all_ok) 
-{
+if (-not $all_ok) {
     throw "At least one project failed to compile. Check the logs."
 }
 

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -36,15 +36,20 @@ function Pack-One() {
 
 function Pack-Dotnet() {
     Param($project, $option1 = "", $option2 = "", $option3 = "")
-    Invoke-Expression ("dotnet pack $project " +
-        "-o $Env:NUGET_OUTDIR " +
-        "-c $Env:BUILD_CONFIGURATION " +
-        "-v detailed " +
-        "$(if ($Env:ASSEMBLY_CONSTANTS) { "/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS" }) " +
-        "/property:Version=$Env:NUGET_VERSION " +
-        "$option1 " +
-        "$option2 " +
-        "$option3")
+    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+    }  else {
+        $args = @();
+    }
+    dotnet pack $project `
+        -o $Env:NUGET_OUTDIR `
+        -c $Env:BUILD_CONFIGURATION `
+        -v detailed `
+        @args `
+        /property:Version=$Env:NUGET_VERSION `
+        $option1 `
+        $option2 `
+        $option3
 
     if ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to pack $project."

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -10,14 +10,14 @@ Write-Host "##[info]Copy Native simulator xplat binaries"
 pushd ../src/Simulation/Native
 If (-not (Test-Path 'osx')) { mkdir 'osx' }
 If (-not (Test-Path 'linux')) { mkdir 'linux' }
-$DROP="$Env:DROP_NATIVE/src/Simulation/Native/build"
+$DROP = "$Env:DROP_NATIVE/src/Simulation/Native/build"
 If (Test-Path "$DROP/libMicrosoft.Quantum.Simulator.Runtime.dylib") { copy "$DROP/libMicrosoft.Quantum.Simulator.Runtime.dylib" "osx/Microsoft.Quantum.Simulator.Runtime.dll" }
 If (Test-Path "$DROP/libMicrosoft.Quantum.Simulator.Runtime.so") { copy "$DROP/libMicrosoft.Quantum.Simulator.Runtime.so"  "linux/Microsoft.Quantum.Simulator.Runtime.dll" }
 popd
 
 
 function Pack-One() {
-    Param($project, $option1="", $option2="", $option3="")
+    Param($project, $option1 = "", $option2 = "", $option3 = "")
     nuget pack $project `
         -OutputDirectory $Env:NUGET_OUTDIR `
         -Properties Configuration=$Env:BUILD_CONFIGURATION `
@@ -28,25 +28,25 @@ function Pack-One() {
         $option2 `
         $option3
 
-    if  ($LastExitCode -ne 0) {
+    if ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to pack $project"
         $script:all_ok = $False
     }
 }
 
 function Pack-Dotnet() {
-    Param($project, $option1="", $option2="", $option3="")
+    Param($project, $option1 = "", $option2 = "", $option3 = "")
     Invoke-Expression ("dotnet pack $project " +
         "-o $Env:NUGET_OUTDIR " +
         "-c $Env:BUILD_CONFIGURATION " +
         "-v detailed " +
-        "$(if ($Env:ASSEMBLY_CONSTANTS){"/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS"}) " +
+        "$(if ($Env:ASSEMBLY_CONSTANTS) { "/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS" }) " +
         "/property:Version=$Env:NUGET_VERSION " +
         "$option1 " +
         "$option2 " +
         "$option3")
 
-    if  ($LastExitCode -ne 0) {
+    if ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to pack $project."
         $script:all_ok = $False
     }
@@ -62,7 +62,6 @@ Pack-One '../src/Simulation/Simulators/Microsoft.Quantum.Simulators.nuspec'
 Pack-One '../src/Quantum.Development.Kit/Microsoft.Quantum.Development.Kit.nuspec'
 Pack-One '../src/Xunit/Microsoft.Quantum.Xunit.csproj'
 
-if (-not $all_ok) 
-{
+if (-not $all_ok) {
     throw "At least one project failed to pack. Check the logs."
 }

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -36,15 +36,15 @@ function Pack-One() {
 
 function Pack-Dotnet() {
     Param($project, $option1="", $option2="", $option3="")
-    dotnet pack $project `
-        -o $Env:NUGET_OUTDIR `
-        -c $Env:BUILD_CONFIGURATION `
-        -v detailed `
-        /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
-        /property:Version=$Env:NUGET_VERSION `
-        $option1 `
-        $option2 `
-        $option3
+    Invoke-Expression ("dotnet pack $project " +
+        "-o $Env:NUGET_OUTDIR " +
+        "-c $Env:BUILD_CONFIGURATION " +
+        "-v detailed " +
+        "$(if ($Env:ASSEMBLY_CONSTANTS){"/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS"}) " +
+        "/property:Version=$Env:NUGET_VERSION " +
+        "$option1 " +
+        "$option2 " +
+        "$option3")
 
     if  ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to pack $project."

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -19,12 +19,17 @@ function Test-One {
     Param($project)
 
     Write-Host "##[info]Testing $project..."
-    Invoke-Expression ("dotnet test (Join-Path $PSScriptRoot $project) " +
-        "-c $Env:BUILD_CONFIGURATION " +
-        "-v $Env:BUILD_VERBOSITY " +
-        "--logger trx " +
-        "$(if ($Env:ASSEMBLY_CONSTANTS) { "/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS" }) " +
-        "/property:Version=$Env:ASSEMBLY_VERSION")
+    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+    }  else {
+        $args = @();
+    }
+    dotnet test $(Join-Path $PSScriptRoot $project) `
+        -c $Env:BUILD_CONFIGURATION `
+        -v $Env:BUILD_VERBOSITY `
+        --logger trx `
+        @args `
+        /property:Version=$Env:ASSEMBLY_VERSION
 
     if ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to test $project"

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -19,12 +19,12 @@ function Test-One {
     Param($project)
 
     Write-Host "##[info]Testing $project..."
-    dotnet test (Join-Path $PSScriptRoot $project) `
-        -c $Env:BUILD_CONFIGURATION `
-        -v $Env:BUILD_VERBOSITY `
-        --logger trx `
-        /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
-        /property:Version=$Env:ASSEMBLY_VERSION
+    Invoke-Expression ("dotnet test (Join-Path $PSScriptRoot $project) " +
+        "-c $Env:BUILD_CONFIGURATION " +
+        "-v $Env:BUILD_VERBOSITY " +
+        "--logger trx " +
+        "$(if ($Env:ASSEMBLY_CONSTANTS){"/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS"}) " +
+        "/property:Version=$Env:ASSEMBLY_VERSION")
 
     if  ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to test $project"
@@ -36,5 +36,5 @@ Test-One '../Simulation.sln'
 
 if (-not $all_ok) 
 {
-    throw "At least one project failed to compile. Check the logs."
+    throw "At least one project failed during testing. Check the logs."
 }

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -8,7 +8,7 @@ Write-Host "##[info]Test Native simulator"
 pushd (Join-Path $PSScriptRoot "../src/Simulation/Native/build")
 cmake --build . --config $Env:BUILD_CONFIGURATION
 ctest -C $Env:BUILD_CONFIGURATION
-if  ($LastExitCode -ne 0) {
+if ($LastExitCode -ne 0) {
     Write-Host "##vso[task.logissue type=error;]Failed to test Native Simulator"
     $script:all_ok = $False
 }
@@ -23,10 +23,10 @@ function Test-One {
         "-c $Env:BUILD_CONFIGURATION " +
         "-v $Env:BUILD_VERBOSITY " +
         "--logger trx " +
-        "$(if ($Env:ASSEMBLY_CONSTANTS){"/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS"}) " +
+        "$(if ($Env:ASSEMBLY_CONSTANTS) { "/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS" }) " +
         "/property:Version=$Env:ASSEMBLY_VERSION")
 
-    if  ($LastExitCode -ne 0) {
+    if ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to test $project"
         $script:all_ok = $False
     }
@@ -34,7 +34,6 @@ function Test-One {
 
 Test-One '../Simulation.sln'
 
-if (-not $all_ok) 
-{
+if (-not $all_ok) {
     throw "At least one project failed during testing. Check the logs."
 }


### PR DESCRIPTION
This updates the build.ps1, test.ps1, and pack.ps1 scripts to only provide the `DefineConstants` property to dotnet cli when there is an actual value in the environment variable. This ensures that it won't end up clearing all of the defined build constants, possibly hiding build or test failures due to the missing DEBUG constant.

This fixes https://github.com/microsoft/qsharp-runtime/issues/232