### PR TITLE
Fix NUGET_VERSION issues

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -46,7 +46,8 @@ function Pack-Dotnet() {
         -c $Env:BUILD_CONFIGURATION `
         -v detailed `
         @args `
-        /property:Version=$Env:NUGET_VERSION `
+        /property:Version=$Env:ASSEMBLY_VERSION `
+        /property:PackageVersion=$Env:NUGET_VERSION `
         $option1 `
         $option2 `
         $option3

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\..\..\Simulators\Microsoft.Quantum.Simulators.csproj" />
     <ProjectReference Include="..\Library1\Library1.csproj" />
     <ProjectReference Include="..\Library2\Library2.csproj" />
-    <ProjectReference Include="..\..\..\..\Xunit\Microsoft.Quantum.Xunit.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -15,10 +15,10 @@
     <ProjectReference Include="..\..\..\Simulators\Microsoft.Quantum.Simulators.csproj" />
     <ProjectReference Include="..\Library1\Library1.csproj" />
     <ProjectReference Include="..\Library2\Library2.csproj" />
+    <ProjectReference Include="..\..\..\..\Xunit\Microsoft.Quantum.Xunit.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.602-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
This PR fixes two places where NUGET_VERSION was accidentally being ignored, causing outdated packages to be used during CI builds via NuGet's nearest version matching logic.