### PR TITLE
Experimental documentation generation tool

### DIFF
--- a/Simulation.sln
+++ b/Simulation.sln
@@ -57,6 +57,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library2", "src\Simulation\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "src\Simulation\Simulators.Tests\TestProjects\UnitTests\UnitTests.csproj", "{46278108-D247-4EFC-AC34-23D4A676F62F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Simulation", "Simulation", "{80FAB019-3E68-4094-8218-4855610ACF99}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocumentationGeneration", "src\Simulation\DocumentationGenerationStep\DocumentationGeneration.csproj", "{D4177102-5553-49D6-851C-E3E3CB3E6C8A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -389,6 +393,22 @@ Global
 		{46278108-D247-4EFC-AC34-23D4A676F62F}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{46278108-D247-4EFC-AC34-23D4A676F62F}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{46278108-D247-4EFC-AC34-23D4A676F62F}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.Release|x64.Build.0 = Release|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.RelWithDebInfo|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.RelWithDebInfo|Any CPU.Build.0 = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.RelWithDebInfo|x64.ActiveCfg = Debug|Any CPU
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A}.RelWithDebInfo|x64.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -416,6 +436,8 @@ Global
 		{7256B986-6705-42FC-9F57-485D72D9DE51} = {09C842CB-930C-4C7D-AD5F-E30DE4A55820}
 		{A85277B3-4E07-4E15-8F0C-07CC855A3BCB} = {09C842CB-930C-4C7D-AD5F-E30DE4A55820}
 		{46278108-D247-4EFC-AC34-23D4A676F62F} = {09C842CB-930C-4C7D-AD5F-E30DE4A55820}
+		{80FAB019-3E68-4094-8218-4855610ACF99} = {99E234BC-997E-4E63-9F5C-3C3977543404}
+		{D4177102-5553-49D6-851C-E3E3CB3E6C8A} = {80FAB019-3E68-4094-8218-4855610ACF99}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {929C0464-86D8-4F70-8835-0A5EAF930821}

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -25,7 +25,7 @@
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.Common.dll",
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulators.dll",
-        ".\src\simulation\DocumentationGenerationStep\bin\$Env:BUILD_CONFIGURATIOND\netstandard2.1\Microsoft.Quantum.Experimental.DocumentationGeneration.dll",
+        ".\src\simulation\DocumentationGenerationStep\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Experimental.DocumentationGeneration.dll",
         ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Xunit.dll"
     ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
 } | Write-Output;

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -25,6 +25,7 @@
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.Common.dll",
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
         ".\src\simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulators.dll",
+        ".\src\simulation\DocumentationGenerationStep\bin\$Env:BUILD_CONFIGURATIOND\netstandard2.1\Microsoft.Quantum.Experimental.DocumentationGeneration.dll",
         ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Xunit.dll"
     ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
 } | Write-Output;

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -67,6 +67,7 @@ Pack-Dotnet '../src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj'
 Pack-One '../src/Simulation/Simulators/Microsoft.Quantum.Simulators.nuspec'
 Pack-One '../src/Quantum.Development.Kit/Microsoft.Quantum.Development.Kit.nuspec'
 Pack-One '../src/Xunit/Microsoft.Quantum.Xunit.csproj'
+Pack-One '../src/Simulation/DocumentationGenerationStep/DocumentationGeneration.csproj'
 
 if (-not $all_ok) {
     throw "At least one project failed to pack. Check the logs."

--- a/src/Simulation/DocumentationGenerationStep/Attributes.qs
+++ b/src/Simulation/DocumentationGenerationStep/Attributes.qs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Documentation {
+
+    /// # Summary
+    /// Used to denote the summary for a callable or type declaration.
+    @Attribute()
+    newtype Summary = String;
+
+    /// # Summary
+    /// Used to denote the description of a callable or type declaration.
+    @Attribute()
+    newtype Description = String;
+
+    /// # Summary
+    /// Used to denote remarks about a callable or type declaration.
+    @Attribute()
+    newtype Remarks = String;
+
+    /// # Summary
+    /// Used to denote a related link for a callable or type declaration.
+    /// May appear multiple times.
+    @Attribute()
+    newtype SeeAlso = String;
+
+    /// # Summary
+    /// Used to denote references and citations for a callable or type declaration.
+    @Attribute()
+    newtype References = String;
+
+    /// # Summary
+    /// Used to denote a usage example for a callable or type declaration.
+    /// May appear multiple times.
+    @Attribute()
+    newtype Example = String;
+
+    /// # Summary
+    /// Used to denote a single input to a function or operation.
+    /// May appear once for each input.
+    @Attribute()
+    newtype Input = (
+        Name: String,
+        Summary: String
+    );
+
+    /// # Summary
+    /// Used to denote the output returned from a function or operation.
+    @Attribute()
+    newtype Output = (
+        Name: String,
+        Summary: String
+    );
+
+    /// # Summary
+    /// Used to denote a single type parameter to a function or operation.
+    /// May appear once for each type parameter.
+    @Attribute()
+    newtype TypeParameter = (
+        Name: String,
+        Summary: String
+    );
+
+}

--- a/src/Simulation/DocumentationGenerationStep/DocgenStep.cs
+++ b/src/Simulation/DocumentationGenerationStep/DocgenStep.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.Quantum.QsCompiler;
+using Microsoft.Quantum.QsCompiler.Experimental;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+
+
+namespace Microsoft.Quantum.Documentation
+{
+    public class DocumentationGenerationStep : IRewriteStep
+    {
+        private readonly List<IRewriteStep.Diagnostic> Diagnostics;
+
+        public DocumentationGenerationStep()
+        {
+            this.AssemblyConstants = new Dictionary<string, string>(); // will be populated by the Q# compiler
+            this.Diagnostics = new List<IRewriteStep.Diagnostic>(); // collects diagnostics that will be displayed to the user
+        }
+
+        public string Name => "DocumentationGeneration";
+        public int Priority => 0; // only compared within this dll
+
+        public IDictionary<string, string> AssemblyConstants { get; }
+        public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => this.Diagnostics;
+
+        public bool ImplementsPreconditionVerification => true;
+        public bool ImplementsTransformation => true;
+        public bool ImplementsPostconditionVerification => false;
+
+
+        public bool PreconditionVerification(QsCompilation compilation)
+        {
+            var preconditionPassed = true; // nothing to check
+            if (preconditionPassed)
+            {
+                // Diagnostics with severity Info or lower usually won't be displayed to the user.
+                // If the severity is Error or Warning the diagnostic is shown to the user like any other compiler diagnostic,
+                // and if the Source property is set to the absolute path of an existing file,
+                // the user will be directed to the file when double clicking the diagnostics.
+                this.Diagnostics.Add(new IRewriteStep.Diagnostic
+                {
+                    Severity = DiagnosticSeverity.Info,
+                    Message = $"Precondition for {this.Name} was {(preconditionPassed ? "satisfied" : "not satisfied")}.",
+                    Stage = IRewriteStep.Stage.PreconditionVerification
+                });
+
+                foreach (var item in AssemblyConstants)
+                {
+                    this.Diagnostics.Add(new IRewriteStep.Diagnostic
+                    {
+                        Severity = DiagnosticSeverity.Info,
+                        Message = $"Got assembly constant \"{item.Key}\" = \"{item.Value}\".",
+                        Stage = IRewriteStep.Stage.PreconditionVerification
+                    });
+                }
+            }
+            return preconditionPassed;
+        }
+
+        public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
+        {
+            transformed = new ProcessDocComments(
+                AssemblyConstants.TryGetValue("OutputPath", out var path)
+                ? path
+                : null
+            ).OnCompilation(compilation);
+            return true;
+        }
+
+        public bool PostconditionVerification(QsCompilation compilation) =>
+            throw new NotImplementedException();
+    }
+}

--- a/src/Simulation/DocumentationGenerationStep/DocumentationGeneration.csproj
+++ b/src/Simulation/DocumentationGenerationStep/DocumentationGeneration.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Simulation/DocumentationGenerationStep/DocumentationGeneration.csproj
+++ b/src/Simulation/DocumentationGenerationStep/DocumentationGeneration.csproj
@@ -1,7 +1,27 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
 
+  <Import Project="..\Common\AssemblyCommon.props" />
+  <Import Project="..\Common\DebugSymbols.props" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-  </PropertyGroup>
+    <AssemblyName>Microsoft.Quantum.Experimental.DocumentationGeneration</AssemblyName>
+  </PropertyGroup>  
+
+  <PropertyGroup>
+    <Authors>Microsoft</Authors>
+    <Description>Experimental documentation generation tool for Q#.</Description>
+    <PackageName>Microsoft.Quantum.Experimental.DocumentationGeneration</PackageName>
+    <PackageReleaseNotes>See: https://docs.microsoft.com/en-us/quantum/relnotes/</PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/microsoft/qsharp-runtime</PackageProjectUrl>
+    <PackageIconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</PackageIconUrl>
+    <PackageTags>Quantum Q# Qsharp</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>  
+  
+  <ItemGroup>
+    <Compile Include="..\Common\DelaySign.cs" Link="Properties\DelaySign.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/Simulation/DocumentationGenerationStep/Extensions.cs
+++ b/src/Simulation/DocumentationGenerationStep/Extensions.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.Quantum.QsCompiler;
+using Microsoft.Quantum.QsCompiler.DataTypes;
+using Microsoft.Quantum.QsCompiler.SyntaxTokens;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using Microsoft.Quantum.QsCompiler.Transformations.Core;
+using Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput;
+using YamlDotNet.Serialization;
+
+#nullable enable
+
+namespace Microsoft.Quantum.Documentation
+{
+    internal interface IAttributeBuilder<T>
+    {
+        public IAttributeBuilder<T> AddAttribute(QsDeclarationAttribute attribute);
+        public QsNullable<QsLocation> Location { get; }
+
+        public T Build();
+    }
+
+    internal class Callable : IAttributeBuilder<QsCallable>
+    {
+        private QsCallable callable;
+        internal Callable(QsCallable callable)
+        {
+            this.callable = callable;
+        }
+
+        public QsNullable<QsLocation> Location => callable.Location;
+
+        public IAttributeBuilder<QsCallable> AddAttribute(QsDeclarationAttribute attribute) =>
+            new Callable(callable.AddAttribute(attribute));
+
+        public QsCallable Build() => callable;
+    }
+
+    internal class Udt : IAttributeBuilder<QsCustomType>
+    {
+        private QsCustomType type;
+        internal Udt(QsCustomType type)
+        {
+            this.type = type;
+        }
+
+        public QsNullable<QsLocation> Location => type.Location;
+
+        public IAttributeBuilder<QsCustomType> AddAttribute(QsDeclarationAttribute attribute) =>
+            new Udt(type.AddAttribute(attribute));
+
+        public QsCustomType Build() => type;
+    }
+
+    internal static class Extensions
+    {
+        internal static IAttributeBuilder<QsCallable> AttributeBuilder(
+            this QsCallable callable
+        ) => new Callable(callable);
+        internal static IAttributeBuilder<QsCustomType> AttributeBuilder(
+            this QsCustomType type
+        ) => new Udt(type);
+
+        internal static IAttributeBuilder<T> WithAttribute<T>(
+            this IAttributeBuilder<T> builder, string @namespace, string name,
+            TypedExpression input
+        ) =>
+            builder.AddAttribute(
+                new QsDeclarationAttribute(
+                    QsNullable<UserDefinedType>.NewValue(
+                        new UserDefinedType(
+                            NonNullable<string>.New(@namespace),
+                            NonNullable<string>.New(name),
+                            QsNullable<Tuple<QsPositionInfo, QsPositionInfo>>.Null
+                        )
+                    ),
+                    input,
+                    builder.Location.Item.Offset,
+                    QsComments.Empty
+                )
+            );
+
+        private static IAttributeBuilder<T> WithDocumentationAttribute<T>(
+            this IAttributeBuilder<T> builder, string attributeName,
+            TypedExpression input
+        ) => builder.WithAttribute("Microsoft.Quantum.Documentation", attributeName, input);
+
+        private static TypedExpression AsLiteralExpression(this string literal) =>
+            SyntaxGenerator.StringLiteral(
+                NonNullable<string>.New(literal),
+                ImmutableArray<TypedExpression>.Empty
+            );
+
+        internal static IAttributeBuilder<T> MaybeWithSimpleDocumentationAttribute<T>(
+            this IAttributeBuilder<T> builder, string attributeName, string? value
+        ) =>
+            value == null || value.Trim().Length == 0
+            ? builder
+            : builder.WithDocumentationAttribute(
+                attributeName, value.AsLiteralExpression()
+            );
+
+        internal static IAttributeBuilder<T> WithListOfDocumentationAttributes<T>(
+            this IAttributeBuilder<T> builder, string attributeName, IEnumerable<string> items
+        ) =>
+            items
+            .Aggregate(
+                builder,
+                (acc, item) => acc.WithDocumentationAttribute(
+                    attributeName, item.AsLiteralExpression()
+                )
+            );
+
+        internal static IAttributeBuilder<T> WithDocumentationAttributesFromDictionary<T>(
+            this IAttributeBuilder<T> builder, string attributeName, IDictionary<string, string> items
+        ) =>
+            items
+            .Aggregate(
+                builder,
+                (acc, item) => acc.WithDocumentationAttribute(
+                    attributeName,
+                    // The following populates all of the metadata needed for a
+                    // Q# literal of type (String, String).
+                    new TypedExpression(
+                        QsExpressionKind<TypedExpression, Identifier, ResolvedType>.NewValueTuple(
+                            ImmutableArray.Create(
+                                item.Key.AsLiteralExpression(),
+                                item.Value.AsLiteralExpression()
+                            )
+                        ),
+                        ImmutableArray<Tuple<QsQualifiedName, NonNullable<string>, ResolvedType>>.Empty,
+                        ResolvedType.New(
+                            QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>.NewTupleType(
+                                ImmutableArray.Create(
+                                    ResolvedType.New(QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>.String),
+                                    ResolvedType.New(QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>.String)
+                                )
+                            )
+                        ),
+                        new InferredExpressionInformation(false, false),
+                        QsNullable<Tuple<QsPositionInfo, QsPositionInfo>>.Null
+                    )
+                )
+            );
+
+        internal static string ToSyntax(this ResolvedType type) =>
+            SyntaxTreeToQsharp.Default.ToCode(type);
+
+        internal static string ToSyntax(this QsTypeItem item) =>
+            item switch
+            {
+                QsTypeItem.Anonymous anon => anon.Item.ToSyntax(),
+                QsTypeItem.Named named => $"{named.Item.VariableName.Value} : {named.Item.Type.ToSyntax()}"
+            };
+        
+        internal static string ToSyntax(this QsTuple<QsTypeItem> items) =>
+            items switch
+            {
+                QsTuple<QsTypeItem>.QsTuple tuple => $@"({
+                    String.Join(", ", tuple.Item.Select(innerItem => innerItem.ToSyntax()))
+                })",
+                QsTuple<QsTypeItem>.QsTupleItem item => item.Item.ToSyntax()
+            };
+
+        internal static string ToSyntax(this QsTuple<LocalVariableDeclaration<QsLocalSymbol>> items) =>
+            items switch
+            {
+                QsTuple<LocalVariableDeclaration<QsLocalSymbol>>.QsTuple tuple => $@"({
+                    String.Join(", ", tuple.Item.Select(innerItem => innerItem.ToSyntax()))
+                })",
+                QsTuple<LocalVariableDeclaration<QsLocalSymbol>>.QsTupleItem item => item.Item.ToSyntax()
+            };
+
+        internal static string ToSyntax(this LocalVariableDeclaration<QsLocalSymbol> symbol) =>
+            $@"{symbol.VariableName switch
+            {
+                QsLocalSymbol.ValidName name => name.Item.Value,
+                _ => "{{invalid}}"
+            }} : {symbol.Type.ToSyntax()}";
+
+        internal static string ToSyntax(this QsCustomType type) =>
+            $@"newtype {type.FullName.Name.Value} = {
+                String.Join(",", type.TypeItems.ToSyntax())
+            };";
+
+        internal static string ToSyntax(this ResolvedCharacteristics characteristics) =>
+            characteristics.SupportedFunctors.ValueOr(null) switch
+            {
+                null => "",
+                { Count: 0 } => "",
+                var functors => $@" is {String.Join(" + ", 
+                    functors.Select(functor => functor.Tag switch
+                    {
+                        QsFunctor.Tags.Adjoint => "Adj",
+                        QsFunctor.Tags.Controlled => "Ctl"
+                    })
+                )}"
+            };
+
+        internal static string ToSyntax(this QsCallable callable)
+        {
+            var kind = callable.Kind.Tag switch
+            {
+                QsCallableKind.Tags.Function => "function",
+                QsCallableKind.Tags.Operation => "operation",
+                QsCallableKind.Tags.TypeConstructor => "function"
+            };
+            var modifiers = callable.Modifiers.Access.Tag switch
+            {
+                AccessModifier.Tags.DefaultAccess => "",
+                AccessModifier.Tags.Internal => "internal "
+            };
+            var typeParameters = callable.Signature.TypeParameters switch
+            {
+                { Length: 0 } => "",
+                var typeParams => $@"<{
+                    String.Join(", ", typeParams.Select(
+                        param => param switch
+                        {
+                            QsLocalSymbol.ValidName name => $"'{name.Item.Value}",
+                            _ => "{invalid}"
+                        }
+                    ))
+                }>"
+            };
+            var input = callable.ArgumentTuple.ToSyntax();
+            var output = callable.Signature.ReturnType.ToSyntax();
+            var characteristics = callable.Signature.Information.Characteristics.ToSyntax();
+            return $"{modifiers}{kind} {callable.FullName.Name.Value}{typeParameters}{input} : {output}{characteristics}";
+        }
+
+        internal static string MaybeWithSection(this string document, string name, string? contents) =>
+            contents == null || contents.Trim().Length == 0
+            ? document
+            : $"{document}\n\n## {name}\n\n{contents}";
+
+        internal static string WithYamlHeader(this string document, object header) =>
+            $"---\n{new SerializerBuilder().Build().Serialize(header)}---\n{document}";
+    }
+
+}

--- a/src/Simulation/DocumentationGenerationStep/ProcessDocComments.cs
+++ b/src/Simulation/DocumentationGenerationStep/ProcessDocComments.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Quantum.QsCompiler;
+using Microsoft.Quantum.QsCompiler.DataTypes;
+using Microsoft.Quantum.QsCompiler.Documentation;
+using Microsoft.Quantum.QsCompiler.SyntaxTokens;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using Microsoft.Quantum.QsCompiler.Transformations.Core;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+
+namespace Microsoft.Quantum.Demos.CompilerExtensions.Demo
+{
+    public class ProcessDocComments
+    : SyntaxTreeTransformation<ProcessDocComments.TransformationState>
+    {
+        public class TransformationState
+        { }
+
+        private string? OutputPath;
+
+        public ProcessDocComments(
+            string? outputPath = null
+        )
+        : base(new TransformationState())
+        {
+            OutputPath = outputPath;
+            // If the output path is not null, make sure the directory exists.
+            if (outputPath != null && !Directory.Exists(outputPath))
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+
+            // We provide our own custom namespace transformation, and expression kind transformation.
+            this.Namespaces = new ProcessDocComments.NamespaceTransformation(this, outputPath);
+        }
+
+        public QsCompilation OnCompilation(QsCompilation compilation) =>
+            new QsCompilation(
+                compilation.Namespaces
+                    .Select(this.Namespaces.OnNamespace)
+                    .ToImmutableArray(),
+                compilation.EntryPoints
+            );
+
+        private class NamespaceTransformation
+        : NamespaceTransformation<TransformationState>
+        {
+            private string? outputPath;
+            internal NamespaceTransformation(ProcessDocComments parent, string? outputPath)
+            : base(parent)
+            { this.outputPath = outputPath; }
+            
+            private static QsCallable AddSummaryAttribute(QsCallable callable, string summary) =>
+                callable.AddAttribute(
+                    new QsDeclarationAttribute(
+                        QsNullable<UserDefinedType>.NewValue(
+                            new UserDefinedType(
+                                NonNullable<string>.New("Microsoft.Quantum.Documentation"),
+                                NonNullable<string>.New("Summary"),
+                                QsNullable<Tuple<QsPositionInfo, QsPositionInfo>>.Null
+                            )
+                        ),
+                        SyntaxGenerator.StringLiteral(NonNullable<string>.New(summary), ImmutableArray<TypedExpression>.Empty),
+                        callable.Location.Item.Offset,
+                        QsComments.Empty
+                    )
+                );
+
+            private async Task MaybeWriteOutput(QsCustomType type, DocComment docComment)
+            {
+                if (outputPath == null) return;
+
+                // Make a new Markdown document for the type declaration.
+                var title = $"{type.FullName.Name.Value} user defined type";
+                var header = new Dictionary<string, object>
+                {
+                    ["uid"] = type.FullName.ToString(),
+                    ["title"] = title,
+                    ["ms.date"] = DateTime.Today.ToString(),
+                    ["ms.topic"] = "article"
+                };
+                var document = $@"
+Namespace: [{type.FullName.Namespace.Value}](xref:{type.FullName.Namespace.Value})
+
+# {title}
+
+{docComment.Summary}
+
+```Q#
+{type.ToSyntax()}
+```
+
+"
+                .MaybeWithSection("Description", docComment.Description)
+                .MaybeWithSection("Remarks", docComment.Remarks)
+                .MaybeWithSection("References", docComment.References)
+                .MaybeWithSection(
+                    "See Also",
+                    String.Join("\n", docComment.SeeAlso.Select(
+                        seeAlso => $"- {seeAlso}"
+                    ))
+                )
+                .WithYamlHeader(header);
+
+                // Open a file to write the new doc to.
+                await File.WriteAllTextAsync(
+                    Path.Join(outputPath, $"{type.FullName.Namespace.Value.ToLowerInvariant()}.{type.FullName.Name.Value.ToLowerInvariant()}.md"),
+                    document
+                );
+            }
+
+            private async Task MaybeWriteOutput(QsCallable callable, DocComment docComment)
+            {
+                if (outputPath == null) return;
+
+                // Make a new Markdown document for the type declaration.
+                var title = $@"{callable.FullName.Name.Value} {
+                    callable.Kind.Tag switch
+                    {
+                        QsCallableKind.Tags.Function => "function",
+                        QsCallableKind.Tags.Operation => "operation",
+                        QsCallableKind.Tags.TypeConstructor => "type constructor"
+                    }
+                }";
+                var header = new Dictionary<string, object>
+                {
+                    ["uid"] = callable.FullName.ToString(),
+                    ["title"] = title,
+                    ["ms.date"] = DateTime.Today.ToString(),
+                    ["ms.topic"] = "article"
+                };
+                var document = $@"
+Namespace: [{callable.FullName.Namespace.Value}](xref:{callable.FullName.Namespace.Value})
+
+# {title}
+
+{docComment.Summary}
+
+```Q#
+{callable.ToSyntax()}
+```
+"
+                .MaybeWithSection("Description", docComment.Description)
+                .MaybeWithSection("Remarks", docComment.Remarks)
+                .MaybeWithSection("References", docComment.References)
+                .MaybeWithSection(
+                    "See Also",
+                    String.Join("\n", docComment.SeeAlso.Select(
+                        seeAlso => $"- {seeAlso}"
+                    ))
+                )
+                .MaybeWithSection(
+                    "Input",
+                    String.Join("\n", docComment.Input.Select(
+                        item => $"### {item.Key}\n\n{item.Value}\n\n"
+                    ))
+                )
+                .MaybeWithSection("Output", docComment.Output)
+                .MaybeWithSection("Type Parameters",
+                    String.Join("\n", docComment.TypeParameters.Select(
+                        item => $"### {item.Key}\n\n{item.Value}\n\n"
+                    ))
+                )
+                .WithYamlHeader(header);
+
+                // Open a file to write the new doc to.
+                await File.WriteAllTextAsync(
+                    Path.Join(outputPath, $"{callable.FullName.Namespace.Value.ToLowerInvariant()}.{callable.FullName.Name.Value.ToLowerInvariant()}.md"),
+                    document
+                );
+            }
+
+            public override QsCustomType OnTypeDeclaration(QsCustomType type)
+            {
+                type = base.OnTypeDeclaration(type);
+                var docComment = new DocComment(
+                    type.Documentation, type.FullName.Name.Value,
+                    deprecated: false, // FIXME: support deprecated attributes
+                    replacement: null // FIXME
+                );
+
+                MaybeWriteOutput(type, docComment).Wait();
+
+                return type
+                    .AttributeBuilder()
+                        .MaybeWithSimpleDocumentationAttribute("Summary", docComment.Summary)
+                        .MaybeWithSimpleDocumentationAttribute("Description", docComment.Description)
+                        .MaybeWithSimpleDocumentationAttribute("Remarks", docComment.Remarks)
+                        .MaybeWithSimpleDocumentationAttribute("References", docComment.References)
+                        .WithListOfDocumentationAttributes("See Also", docComment.SeeAlso)
+                    .Build();
+            }
+
+            public override QsCallable OnCallableDeclaration(QsCallable callable)
+            {
+                callable = base.OnCallableDeclaration(callable);
+                var docComment = new DocComment(
+                    callable.Documentation, callable.FullName.Name.Value,
+                    deprecated: false, // FIXME: support deprecated attributes
+                    replacement: null // FIXME
+                );
+
+                MaybeWriteOutput(callable, docComment).Wait();
+
+                return callable
+                    .AttributeBuilder()
+                        .MaybeWithSimpleDocumentationAttribute("Summary", docComment.Summary)
+                        .MaybeWithSimpleDocumentationAttribute("Description", docComment.Description)
+                        .MaybeWithSimpleDocumentationAttribute("Remarks", docComment.Remarks)
+                        .MaybeWithSimpleDocumentationAttribute("References", docComment.References)
+                        .WithListOfDocumentationAttributes("See Also", docComment.SeeAlso)
+                        .MaybeWithSimpleDocumentationAttribute("Output", docComment.Output)
+                        .WithDocumentationAttributesFromDictionary("Input", docComment.Input)
+                        .WithDocumentationAttributesFromDictionary("TypeParameter", docComment.TypeParameters)
+                    .Build();
+            }
+        }
+    }
+}

--- a/src/Simulation/DocumentationGenerationStep/ProcessDocComments.cs
+++ b/src/Simulation/DocumentationGenerationStep/ProcessDocComments.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json.Linq;
 
 #nullable enable
 
-namespace Microsoft.Quantum.Demos.CompilerExtensions.Demo
+namespace Microsoft.Quantum.Documentation
 {
     public class ProcessDocComments
     : SyntaxTreeTransformation<ProcessDocComments.TransformationState>


### PR DESCRIPTION
This PR opens for early feedback a possible path towards solving microsoft/qsharp-compiler#277, namely outputting documentation Markdown directly rather than as YAML. This PR packages that effort as an IRewriteStep that can be controlled by the `IRewriteStep.AssemblyConstants` property, and that can be included as an `IsQscReference`. The step also attaches documentation information as attributes that can be used by other parts of the Quantum Development Kit, such as IQ#.

Improvements over the existing approach:
- Can display Q# syntax for UDT named items.
- Extensible with new Q# features.
- Can be used more easily by third-party libraries.
- Attaches documentation data to the AST for reuse by other tools.

Remaining work:
- [ ] Currently does not filter by the current compilation unit, such that all symbols included from references are documented as well.
- [ ] Does not yet provide special support for `@Deprecated()`; this is currently supported by the non-experimental documentation generator.
- [ ] Does not yet provide special support for `@Attribute()`, making it hard to learn how attributes should be used.
- [ ] Missing unit tests.
- [ ] Missing explanatory comments.
- [ ] Named items don't yet have a dedicated Markdown section; this will require additions to the DocumentationParser in the qsharp-compiler repo.
- [ ] Need to add comments to output Markdown files indicating that they are auto-generated.
- [ ] Does not yet support making or merging toc.yml and index.md files.
- [ ] Does not yet resolve unqualified names in `/// # See Also` blocks.
