### PR TITLE
Automatically assign libraries maintainers on Q# API.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically tag in libraries maintainers on Q# API changes.
+*.qs    @microsoft/quantumlibraries


### PR DESCRIPTION
This PR adds a [`CODEOWNERS` file](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) that automatically tags in the @microsoft/quantumlibraries  team on possible Q# API changes. This should help us manage that the Q# libraries are split between the libraries and runtime repos for build dependency ordering, while still delivering a consistent Q# API across the different places those libraries are built.