### PR TITLE
added .vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Visual Studio Code cache/options directory
+.vscode/
+
 # Visual Studio Code Ionide-FSharp extension cache directory
 .ionide/
 


### PR DESCRIPTION
Even though we don't recommend VS Code as the editor for working with the repo, some people might still prefer to use it. In this case it's annoying that git tracks .vscode files.