### PR TITLE
Update C# generation and tests for file path format change

### DIFF
--- a/Simulation.sln
+++ b/Simulation.sln
@@ -55,6 +55,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library1", "src\Simulation\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library2", "src\Simulation\Simulators.Tests\TestProjects\Library2\Library2.csproj", "{A85277B3-4E07-4E15-8F0C-07CC855A3BCB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library with Spaces", "src\Simulation\Simulators.Tests\TestProjects\Library with Spaces\Library with Spaces.csproj", "{418E79F7-9FCF-4128-AA35-1334A685377D}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "src\Simulation\Simulators.Tests\TestProjects\UnitTests\UnitTests.csproj", "{46278108-D247-4EFC-AC34-23D4A676F62F}"
 EndProject
 Global
@@ -389,6 +391,22 @@ Global
 		{46278108-D247-4EFC-AC34-23D4A676F62F}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{46278108-D247-4EFC-AC34-23D4A676F62F}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{46278108-D247-4EFC-AC34-23D4A676F62F}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.Debug|x64.Build.0 = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.Release|x64.ActiveCfg = Release|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.Release|x64.Build.0 = Release|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.RelWithDebInfo|Any CPU.ActiveCfg = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.RelWithDebInfo|Any CPU.Build.0 = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.RelWithDebInfo|x64.ActiveCfg = Debug|Any CPU
+		{418E79F7-9FCF-4128-AA35-1334A685377D}.RelWithDebInfo|x64.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -416,6 +434,7 @@ Global
 		{7256B986-6705-42FC-9F57-485D72D9DE51} = {09C842CB-930C-4C7D-AD5F-E30DE4A55820}
 		{A85277B3-4E07-4E15-8F0C-07CC855A3BCB} = {09C842CB-930C-4C7D-AD5F-E30DE4A55820}
 		{46278108-D247-4EFC-AC34-23D4A676F62F} = {09C842CB-930C-4C7D-AD5F-E30DE4A55820}
+		{418E79F7-9FCF-4128-AA35-1334A685377D} = {09C842CB-930C-4C7D-AD5F-E30DE4A55820}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {929C0464-86D8-4F70-8835-0A5EAF930821}

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -7,6 +7,7 @@ open System
 open System.Collections.Immutable
 open System.IO
 open System.Globalization
+open System.Web
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.CSharp
@@ -217,10 +218,14 @@ namespace N1
 
 
     let testOneFile fileName (expected:string) =
-        let expected = expected.Replace("%%%", (Uri(Path.GetFullPath fileName)).AbsolutePath)
-        let expected = expected.Replace("%%", (Path.GetFullPath fileName).Replace("\\", "\\\\"))
-        let tree   = parse [(Path.Combine("Circuits","Intrinsic.qs")); fileName]
-        let actual = 
+        let fullPath = Path.GetFullPath fileName
+        let escapeCSharpString (s : string) = SymbolDisplay.FormatLiteral (s, false)
+        let expected =
+            expected
+            |> (fun s -> s.Replace("%%%", fullPath |> HttpUtility.JavaScriptStringEncode |> escapeCSharpString))
+            |> (fun s -> s.Replace("%%", fullPath |> escapeCSharpString))
+        let tree = parse [Path.Combine ("Circuits", "Intrinsic.qs"); fileName]
+        let actual =
             CodegenContext.Create (tree, ImmutableDictionary.Empty)
             |> generate (Path.GetFullPath fileName |> NonNullable<string>.New)
         Assert.Equal(expected |> clearFormatting, actual |> clearFormatting)
@@ -2306,7 +2311,7 @@ namespace N1
         false |> testOne randomOperation
 
     let testOneClass (_,op : QsCallable) executionTarget (expected : string) =
-        let expected = expected.Replace("%%%", op.SourceFile.Value)
+        let expected = expected.Replace("%%%", HttpUtility.JavaScriptStringEncode op.SourceFile.Value)
         let assemblyConstants = 
             new System.Collections.Generic.KeyValuePair<_,_> (AssemblyConstants.ExecutionTarget, executionTarget) 
             |> Seq.singleton
@@ -3369,7 +3374,7 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.Inline
 {
-    [SourceLocation("%%%", OperationFunctor.Body, 7, -1)]
+    [SourceLocation("%%", OperationFunctor.Body, 7, -1)]
     public partial class HelloWorld : Operation<Int64, Int64>, ICallable
     {
         public HelloWorld(IOperationFactory m) : base(m)
@@ -3426,7 +3431,7 @@ using Microsoft.Quantum.Simulation.Core;
 #line hidden
 namespace Microsoft.Quantum.Tests.LineNumbers
 {
-    [SourceLocation("%%%", OperationFunctor.Body, 9, -1)]
+    [SourceLocation("%%", OperationFunctor.Body, 9, -1)]
     public partial class TestLineInBlocks : Operation<Int64, Result>, ICallable
     {
         public TestLineInBlocks(IOperationFactory m) : base(m)
@@ -3600,7 +3605,7 @@ namespace Microsoft.Quantum.Diagnostics
 #line hidden
 namespace Microsoft.Quantum.Tests.UnitTests
 {
-    [SourceLocation("%%%", OperationFunctor.Body, 22, 26)]
+    [SourceLocation("%%", OperationFunctor.Body, 22, 26)]
     public partial class UnitTest1 : Operation<QVoid, QVoid>, ICallable
     {
         public UnitTest1(IOperationFactory m) : base(m)
@@ -3623,7 +3628,7 @@ namespace Microsoft.Quantum.Tests.UnitTests
             [Xunit.Trait("Target", "QuantumSimulator")]
             [Xunit.Trait("Name", "UnitTest1")]
             public void UnitTest1()
-#line 22 "%%%"
+#line 22 "%%"
             {
                 var sim = new Microsoft.Quantum.Simulation.Simulators.QuantumSimulator();
                 if (sim is Microsoft.Quantum.Simulation.Common.SimulatorBase baseSim && this.Output != null)
@@ -3655,7 +3660,7 @@ namespace Microsoft.Quantum.Tests.UnitTests
             [Xunit.Trait("Target", "ToffoliSimulator")]
             [Xunit.Trait("Name", "UnitTest1")]
             public void UnitTest1()
-#line 22 "%%%"
+#line 22 "%%"
             {
                 var sim = new Microsoft.Quantum.Simulation.Simulators.ToffoliSimulator();
                 if (sim is Microsoft.Quantum.Simulation.Common.SimulatorBase baseSim && this.Output != null)
@@ -3693,7 +3698,7 @@ namespace Microsoft.Quantum.Tests.UnitTests
         }
     }
 
-    [SourceLocation("%%%", OperationFunctor.Body, 26, -1)]
+    [SourceLocation("%%", OperationFunctor.Body, 26, -1)]
     public partial class UnitTest2 : Operation<QVoid, QVoid>, ICallable
     {
         public UnitTest2(IOperationFactory m) : base(m)
@@ -3716,7 +3721,7 @@ namespace Microsoft.Quantum.Tests.UnitTests
             [Xunit.Trait("Target", "CustomSimulator")]
             [Xunit.Trait("Name", "UnitTest2")]
             public void UnitTest2()
-#line 26 "%%%"
+#line 26 "%%"
             {
                 var sim = new SomeNamespace.CustomSimulator();
                 if (sim is Microsoft.Quantum.Simulation.Common.SimulatorBase baseSim && this.Output != null)

--- a/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
+++ b/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.602-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.1806-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1566,13 +1566,10 @@ module SimulationCode =
         generator.Apply elements       
 
     // Returns only those namespaces and their elements that are defined for the given file.
-    let findLocalElements selector fileName syntaxTree =
-        let path = 
-            match CompilationBuilder.CompilationUnitManager.TryGetUri fileName with 
-            | true, uri -> uri.AbsolutePath |> NonNullable<string>.New
-            | false, _ -> NonNullable<string>.New ""
+    let findLocalElements selector (fileName : NonNullable<string>) syntaxTree =
         syntaxTree
-        |> Seq.map (fun ns -> (ns.Name, (FilterBySourceFile.Apply (ns, path)).Elements |> Seq.choose selector |> Seq.toList))
+        |> Seq.map (fun ns ->
+            (ns.Name, (FilterBySourceFile.Apply (ns, fileName)).Elements |> Seq.choose selector |> Seq.toList))
         |> Seq.sortBy fst
         |> Seq.filter (fun (_,elements) -> not elements.IsEmpty)
         |> Seq.toList

--- a/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.602-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\Simulators.Dev.props" />

--- a/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
+++ b/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.602-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.2309-alpha">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CsharpGeneration>false</CsharpGeneration>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,15 +1,20 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
-
+<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <!-- we will provide our own -->
     <CsharpGeneration>false</CsharpGeneration>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
+  
+    <!-- Use EmbedAllSources so that the #line annotations in the generated C# are checked by the C# compiler. If the
+       - file paths in the annotations are invalid, the test will fail.
+       -->
+    <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\CsharpGeneration\Microsoft.Quantum.CsharpGeneration.fsproj" PrivateAssets="All" IsQscReference="true" />
     <ProjectReference Include="..\..\..\QsharpCore\Microsoft.Quantum.QSharp.Core.csproj" />
+    <ProjectReference Include="..\..\..\CsharpGeneration\Microsoft.Quantum.CsharpGeneration.fsproj"
+                      PrivateAssets="All"
+                      IsQscReference="true" />
   </ItemGroup>
 
   <Target Name="BeforeCsharpCompile">
@@ -17,5 +22,4 @@
       <Compile Include="$(GeneratedFilesOutputPath)**/*.g.cs" Exclude="@(Compile)" AutoGen="true" />
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library.qs
@@ -1,0 +1,5 @@
+﻿namespace LibraryWithSpaces {
+    function HelloQ() : String {
+        return "Hello quantum world!";
+    }
+}

--- a/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.602-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.602-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/Facts.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/Facts.qs
@@ -1,0 +1,37 @@
+﻿namespace Microsoft.Quantum.Testing {
+    internal function FactI(expected : Int, got : Int) : Unit {
+        if (expected != got) {
+            fail $"Expected: {expected}, got: {got}";
+        }
+    }
+
+    internal function FactS(expected : String, got : String) : Unit {
+        if (expected != got) {
+            fail $"Expected: {expected}, got: {got}";
+        }
+    }
+
+    internal function FactMyInt1(expected : Int, got : Library1.MyInt) : Unit {
+        if (expected != got::Value1) {
+            fail $"Expected: {expected}, got: {got::Value1}";
+        }
+    }
+
+    internal function FactMyInt2(expected : Int, got : Library2.MyInt) : Unit {
+        if (expected != got::Value2) {
+            fail $"Expected: {expected}, got: {got::Value2}";
+        }
+    }
+
+    internal function FactMyString1(expected : String, got : Microsoft.Quantum.Library.MyString) : Unit {
+        if (expected != got::Text) {
+            fail $"Expected: {expected}, got: {got::Text}";
+        }
+    }
+
+    internal function FactMyString2(expected : String, got : Library2.MyString) : Unit {
+        if (expected != got::Text) {
+            fail $"Expected: {expected}, got: {got::Text}";
+        }
+    }
+}

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/SpaceTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/SpaceTests.qs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Quantum.Testing.SpacesInFileName {
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Testing;
+
+    @Test("QuantumSimulator")
+    function LibraryWithSpacesTest() : Unit {
+        FactS("Hello quantum world!", LibraryWithSpaces.HelloQ());
+    }
+}

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/TestNameTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/TestNameTests.qs
@@ -2,43 +2,7 @@
 
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
-
-    internal function FactI(expected : Int, got : Int) : Unit {
-        if (expected != got) {
-            fail $"Expected: {expected}, got: {got}";
-        }
-    }
-
-    internal function FactS(expected : String, got : String) : Unit {
-        if (expected != got) {
-            fail $"Expected: {expected}, got: {got}";
-        }
-    }
-
-    internal function FactMyInt1(expected : Int, got : Library1.MyInt) : Unit {
-        if (expected != got::Value1) {
-            fail $"Expected: {expected}, got: {got::Value1}";
-        }
-    }
-
-    internal function FactMyInt2(expected : Int, got : Library2.MyInt) : Unit {
-        if (expected != got::Value2) {
-            fail $"Expected: {expected}, got: {got::Value2}";
-        }
-    }
-
-    internal function FactMyString1(expected : String, got : Microsoft.Quantum.Library.MyString) : Unit {
-        if (expected != got::Text) {
-            fail $"Expected: {expected}, got: {got::Text}";
-        }
-    }
-
-    internal function FactMyString2(expected : String, got : Library2.MyString) : Unit {
-        if (expected != got::Text) {
-            fail $"Expected: {expected}, got: {got::Text}";
-        }
-    }
-
+    open Microsoft.Quantum.Testing;
 
     @Test("QuantumSimulator")
     operation BothCallables () : Unit {

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.602-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\..\Simulators\Microsoft.Quantum.Simulators.csproj" />
     <ProjectReference Include="..\Library1\Library1.csproj" />
     <ProjectReference Include="..\Library2\Library2.csproj" />
+    <ProjectReference Include="..\Library with Spaces\Library with Spaces.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.602-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.602-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.1806-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />


### PR DESCRIPTION
This goes with microsoft/qsharp-compiler#468. Updated the C# generation to remove the assumption that the file ID is `URI.AbsolutePath`, and added a test for a project with spaces in the path that uses `EmbedAllSources`.