### PR TITLE
Aggregate results in resource estimator across multiple runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Visual Studio Code cache/options directory
+.vscode/
+
 # Visual Studio Code Ionide-FSharp extension cache directory
 .ionide/
 

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -474,15 +474,15 @@ let ``Shadows --shots`` () =
 
 // The expected output from the resources estimator.
 let private resourceSummary =
-    "Metric          Sum
-     CNOT            0
-     QubitClifford   1
-     R               0
-     Measure         1
-     T               0
-     Depth           0
-     Width           1
-     BorrowedWidth   0"
+    "Metric          Sum Max
+     CNOT            0   0
+     QubitClifford   1   1
+     R               0   0
+     Measure         1   1
+     T               0   0
+     Depth           0   0
+     Width           1   1
+     BorrowedWidth   0   0"
 
 [<Fact>]
 let ``Supports QuantumSimulator`` () =

--- a/src/Simulation/Simulators.Tests/Circuits/ResourcesEstimator.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/ResourcesEstimator.qs
@@ -16,4 +16,25 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             ResetAll([q[1], q[0]]);
         }
     }
+
+    // When multiple operations are traced by resource estimator,
+    // it should report cumulative statistics in the end.
+    operation Operation_1_of_2() : Unit
+    {
+        using ((a, b) = (Qubit(), Qubit())) {
+            H(a);
+            CNOT(a, b);
+            T(b);
+        }
+    }
+    operation Operation_2_of_2() : Result
+    {
+        using ((a, b, c) = (Qubit(), Qubit(), Qubit())) {
+            X(a);
+            CNOT(a, b);
+            Rx(0.42, b);
+            CNOT(b, c);
+            return M(c);
+        }
+    }
 }

--- a/src/Simulation/Simulators.Tests/Circuits/ResourcesEstimator.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/ResourcesEstimator.qs
@@ -35,6 +35,8 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Rx(0.42, b);
             CNOT(b, c);
             return M(c);
+        }
+    }
 
     // Tests for Depth and Width lower bounds
     operation DepthDifferentQubits () : Unit

--- a/src/Simulation/Simulators.Tests/ResourcesEstimatorTests.cs
+++ b/src/Simulation/Simulators.Tests/ResourcesEstimatorTests.cs
@@ -94,10 +94,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             var cols = rows[0].Split('\t');
             Assert.Equal("Metric", cols[0].Trim());
-            Assert.Equal(2, cols.Length);
+            Assert.Equal(3, cols.Length);
 
             var cliffords = rows.First(r => r.StartsWith("QubitClifford")).Split('\t');
-            Assert.Equal(2, cliffords.Length);
+            Assert.Equal(3, cliffords.Length);
             Assert.Equal("2", cliffords[1]);
         }
 

--- a/src/Simulation/Simulators.Tests/ResourcesEstimatorTests.cs
+++ b/src/Simulation/Simulators.Tests/ResourcesEstimatorTests.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Data;
 using Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime;
 using Xunit;
 
@@ -100,6 +99,44 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var cliffords = rows.First(r => r.StartsWith("QubitClifford")).Split('\t');
             Assert.Equal(2, cliffords.Length);
             Assert.Equal("2", cliffords[1]);
+        }
+
+        /// <summary>
+        /// Verifies that for multiple separately traced operations, the final
+        /// statistics are cumulative.
+        /// </summary>
+        [Fact]
+        public void VerifyTracingMultipleOperationsTest()
+        {
+            ResourcesEstimator sim = new ResourcesEstimator();
+
+            Operation_1_of_2.Run(sim).Wait();
+            DataTable data1 = sim.Data;
+
+            Assert.Equal(1.0, data1.Rows.Find("CNOT")["Sum"]);
+            Assert.Equal(1.0, data1.Rows.Find("QubitClifford")["Sum"]);
+            Assert.Equal(1.0, data1.Rows.Find("T")["Sum"]);
+            Assert.Equal(0.0, data1.Rows.Find("R")["Sum"]);
+            Assert.Equal(0.0, data1.Rows.Find("Measure")["Sum"]);
+            Assert.Equal(2.0, data1.Rows.Find("Width")["Sum"]);
+
+            Operation_2_of_2.Run(sim).Wait();
+            DataTable data2 = sim.Data;
+
+            // Aggregated stats for both operations.
+            Assert.Equal(1.0 + 2.0, data2.Rows.Find("CNOT")["Sum"]);
+            Assert.Equal(1.0 + 1.0, data2.Rows.Find("QubitClifford")["Sum"]);
+            Assert.Equal(1.0 + 0.0, data2.Rows.Find("T")["Sum"]);
+            Assert.Equal(0.0 + 1.0, data2.Rows.Find("R")["Sum"]);
+            Assert.Equal(0.0 + 1.0, data2.Rows.Find("Measure")["Sum"]);
+            Assert.Equal(2.0 + 3.0, data2.Rows.Find("Width")["Sum"]);
+            Assert.Equal(System.Math.Max(2.0, 3.0), data2.Rows.Find("Width")["Max"]);
+
+            // Run again to confirm two operations isn't the limit!
+            VerySimpleEstimate.Run(sim).Wait();
+            DataTable data3 = sim.Data;
+            Assert.Equal(2.0 + 3.0 + 3.0, data3.Rows.Find("Width")["Sum"]);
+            Assert.Equal(3.0, data3.Rows.Find("Width")["Max"]);
         }
     }
 }

--- a/src/Simulation/Simulators/ResourcesEstimator/ResourcesEstimator.cs
+++ b/src/Simulation/Simulators/ResourcesEstimator/ResourcesEstimator.cs
@@ -121,7 +121,6 @@ namespace Microsoft.Quantum.Simulation.Simulators
                     if (l is ICallGraphStatistics collector)
                     {
                         var results = collector.Results.ToTable();
-                        //Debug.Assert(results.rows.Count() == 1);
                         Debug.Assert(results.keyColumnNames.Length > 2 && results.keyColumnNames[2] == "Caller");
 
                         var roots = results.rows.Where(r => r.KeyRow[2] == CallGraphEdge.CallGraphRootHashed);


### PR DESCRIPTION
Fixes #189 

I'm not sure what the expected behavior is for the "Width" metric. Personally, I'd expect it to report the max of widths across the runs, not adding the per-run widths. However, I'd rather not have special logic for width in the processing loop because it would have to rely on the label and will be fragile, so I've added the max column to the results for all metrics. Is it useful to know the highest count across operations for gates or measurements? The data can be accessed programmatically, as the new test demonstrates, but I didn't update the ToTSV method to include it -- should I? If we go this route the documentation (https://docs.microsoft.com/en-us/quantum/machines/resources-estimator) also will need to be updated.
