### PR TITLE
Use quotes around variables in shell commands for old QDK projects

### DIFF
--- a/src/Quantum.Development.Kit/Props/QSharp.targets
+++ b/src/Quantum.Development.Kit/Props/QSharp.targets
@@ -7,25 +7,25 @@
   -->
   <Target Name="QsharpCompile"
       Inputs="@(QsharpFiles)"
-      Outputs="$(QsharpOutDir)\$(QsharpTree).bson"
+      Outputs="$(QsharpOutDir)/$(QsharpTree).bson"
       DependsOnTargets="QsharpPrepare"
       BeforeTargets="CheckForDuplicateItems;CoreCompile"
       Condition="$(RunQsc)">
     <PropertyGroup>
-      <QscCommand>$(QscExe) $(QsharpDocsGen) --qst $(QsharpTree) --input &quot;@(QsharpFiles,'&quot; &quot;')&quot; --references &quot;@(QsReferences,'&quot; &quot;')&quot; --output $(QsharpOutDir)</QscCommand>
+      <QscCommand>$(QscExe) $(QsharpDocsGen) --qst "$(QsharpTree)" --input "@(QsharpFiles,'" "')" --references "@(QsReferences,'" "')" --output "$(QsharpOutDir)"</QscCommand>
     </PropertyGroup>
     <MakeDir Directories="$(QsharpSrcOutDir)" />
     <MakeDir Condition="$(RunQDocGen)" Directories="$(QsharpDocsOutDir)" />
     <WriteLinesToFile File="$(QsharpOutDir)qsc-command.txt" Lines=":: files ::;@(QsharpFiles);:: qsim ::;$(QSimDll);;:: references ::;@(QsReferences);:: command ::;$(QscCommand)" Overwrite="true"/>
     <!-- Remove all existing codegen files first: -->
     <ItemGroup>
-      <QsharpCodegenFiles Include="$(QsharpSrcOutDir)**\*.*" />
+      <QsharpCodegenFiles Include="$(QsharpSrcOutDir)**/*.*" />
     </ItemGroup>
     <Delete Files="@(QsharpCodegenFiles)" />
     <Exec Command="$(QscCommand)" />
     <ItemGroup>
-      <EmbeddedResource Include="$(QsharpOutDir)\$(QsharpTree).bson" LogicalName="__qsharp_data__.bson" Visible="false" />
-      <Compile Include="$(QsharpSrcOutDir)**\*.g.cs" Visible="false" AutoGen="true" />
+      <EmbeddedResource Include="$(QsharpOutDir)/$(QsharpTree).bson" LogicalName="__qsharp_data__.bson" Visible="false" />
+      <Compile Include="$(QsharpSrcOutDir)**/*.g.cs" Visible="false" AutoGen="true" />
     </ItemGroup>
   </Target>
 
@@ -36,7 +36,7 @@
       DependsOnTargets="QsharpPrepare" 
       BeforeTargets="Clean">
     <ItemGroup>
-      <QsharpBuiltFiles Include="$(QsharpOutDir)**\*.*" />
+      <QsharpBuiltFiles Include="$(QsharpOutDir)**/*.*" />
     </ItemGroup>
     <Delete Files="@(QsharpBuiltFiles)" />
   </Target>
@@ -52,17 +52,19 @@
       <QsharpFiles Include="@(QsharpCompile)">
         <Visible>false</Visible>
       </QsharpFiles>
-      <SkippedQsharpFiles Include="**\*.qs" Exclude="@(QsharpFiles);@(QsharpIgnore)">
+      <SkippedQsharpFiles Include="**/*.qs" Exclude="@(QsharpFiles);@(QsharpIgnore)">
         <Visible>false</Visible>
       </SkippedQsharpFiles>
     </ItemGroup>
     <PropertyGroup>
       <QsharpOutDir Condition="'$(QsharpOutDir)' == ''">$(BaseIntermediateOutputPath)qsharp</QsharpOutDir>
-      <QsharpOutDir Condition="!HasTrailingSlash('$(QsharpOutDir)')">$(QsharpOutDir)\</QsharpOutDir>
-      <QsharpSrcOutDir Condition="'$(QsharpSrcOutDir)' == ''">$(QsharpOutDir)src\</QsharpSrcOutDir>
+      <QsharpOutDir>$([MSBuild]::Unescape('$(QsharpOutDir)').Replace('\', '/'))</QsharpOutDir>
+      <QsharpOutDir Condition="!HasTrailingSlash('$(QsharpOutDir)')">$(QsharpOutDir)/</QsharpOutDir>
+      <QsharpSrcOutDir Condition="'$(QsharpSrcOutDir)' == ''">$(QsharpOutDir)src/</QsharpSrcOutDir>
       <QsharpFormatBackupDir Condition="'$(QsharpFormatBackupDir)' == ''">$(QsharpOutDir).backup.$([System.DateTime]::Now.ToString(`yyyyMMddhhmmss`))</QsharpFormatBackupDir>
-      <QsharpDocsOutDir Condition="'$(QsharpDocsOutDir)' == ''">$(QsharpOutDir)docs\</QsharpDocsOutDir>
-      <QsharpDocsGen Condition="$(RunQDocGen)">--doc $(QsharpDocsOutDir)</QsharpDocsGen>
+      <QsharpDocsOutDir Condition="'$(QsharpDocsOutDir)' == ''">$(QsharpOutDir)docs/</QsharpDocsOutDir>
+      <QsharpDocsOutDir>$([MSBuild]::Unescape('$(QsharpDocsOutDir)').Replace('\', '/'))</QsharpDocsOutDir>
+      <QsharpDocsGen Condition="$(RunQDocGen)">--doc "$(QsharpDocsOutDir)"</QsharpDocsGen>
       <QsharpTree Condition="'$(QsharpTree)' == ''">$([System.String]::Copy('$(AssemblyName)').Replace(' ',''))</QsharpTree>
     </PropertyGroup>
     <Warning


### PR DESCRIPTION
A couple (related) changes:

* The --output argument to qsc was not quoted, so Q# projects that had spaces in the file path were not building correctly.
* Quoting `$(QsharpOutDir)` did not work because the directory path ends in `\`, so the final quote was escaped. Thus, I replaced all `\`s with `/`s.

This should fix []() microsoft/Quantum#316 (after updating the package reference to Microsoft.Quantum.Development.Kit in that project).