### PR TITLE
Test case for compatible rotations in ToffoliSimulator

### DIFF
--- a/src/Simulation/Simulators.Tests/Circuits/ClassicalRotationsTest.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/ClassicalRotationsTest.qs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Math;
+    
+    
+    operation IncrementWithRotationsTest (start : Int) : Int {
+        
+        
+        using (qubits = Qubit[3]) {
+            for (shift in 0..2) {
+                if (((start >>> shift) &&& 1) == 1) {
+                    R(PauliX, PI(), qubits[shift]);
+                }
+            }
+
+            CCNOT(qubits[0], qubits[1], qubits[2]);
+            CNOT(qubits[0], qubits[1]);
+            //Rx(PI(), qubits[0]);
+            RFrac(PauliX, 1, 1, qubits[0]);
+
+            let b0 = M(qubits[0]) == One ? 1 | 0;
+            let b1 = M(qubits[1]) == One ? 1 | 0;
+            let b2 = M(qubits[2]) == One ? 1 | 0;
+
+            ResetAll(qubits);
+
+            return b2 * 4 + b1 * 2 + b0;
+        }
+    }
+    
+}
+
+

--- a/src/Simulation/Simulators.Tests/ToffoliSimulatorTests.cs
+++ b/src/Simulation/Simulators.Tests/ToffoliSimulatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Xunit;
@@ -141,6 +141,15 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var sim = new ToffoliSimulator();
 
             await Circuits.SwapTest.Run(sim);
+        }
+
+        [Fact]
+        public async Task ToffoliRotations()
+        {
+            var sim = new ToffoliSimulator();
+
+            var result = await Circuits.IncrementWithRotationsTest.Run(sim, 4);
+            Assert.Equal(5, result);
         }
 
         [Fact]

--- a/src/Simulation/Simulators/ToffoliSimulator/R.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/R.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
 
                 simulator.CheckQubit(q1, "q1");
 
-                var (isX, safe) = CheckRotation(basis, 2.0 * angle);
+                var (isX, safe) = CheckRotation(basis, angle / 2.0);
                 if (isX)
                 {
                     simulator.DoX(q1);
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
 
                 simulator.CheckControlQubits(ctrls, q1);
 
-                var (isX, safe) = CheckRotation(basis, 2.0 * angle);
+                var (isX, safe) = CheckRotation(basis, angle / 2.0);
                 if (!safe)
                 {
                     throw new InvalidOperationException($"The Toffoli simulator can only perform controlled rotations of multiples of 2*pi.");


### PR DESCRIPTION
This PR

* adds a test case for compatible rotations in ToffoliSimulator (rotations that correspond to `X`)
* fixes a bug in passing the angle in `R` found with the new test case
