### PR TITLE
Use a default target when submitting to Azure Quantum

### DIFF
--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -4,6 +4,7 @@
 module Microsoft.Quantum.EntryPointDriver.Tests
 
 open System
+open System.Collections.Generic
 open System.Collections.Immutable
 open System.Globalization
 open System.IO
@@ -61,12 +62,8 @@ let private compileQsharp source =
 
 /// Generates C# source code from the compiled Q# syntax tree. The given default simulator is set as an assembly
 /// constant.
-let private generateCsharp defaultSimulator (compilation : QsCompilation) =
-    let assemblyConstants =
-        match defaultSimulator with
-        | Some simulator -> ImmutableDictionary.Empty.Add (AssemblyConstants.DefaultSimulator, simulator)
-        | None -> ImmutableDictionary.Empty
-    let context = CodegenContext.Create (compilation, assemblyConstants)
+let private generateCsharp constants (compilation : QsCompilation) =
+    let context = CodegenContext.Create (compilation, constants)
     let entryPoint = context.allCallables.[Seq.exactlyOne compilation.EntryPoints]
     [
         SimulationCode.generate (NonNullable<_>.New testFile) context
@@ -113,11 +110,11 @@ let private compileCsharp (sources : string seq) =
     Assembly.Load (stream.ToArray ())
 
 /// The assembly for the given test case and default simulator.
-let private testAssembly testNum defaultSimulator =
+let private testAssembly testNum constants =
     testNum
     |> testCase
     |> compileQsharp
-    |> generateCsharp defaultSimulator
+    |> generateCsharp constants
     |> compileCsharp
 
 /// Runs the entry point in the assembly with the given command-line arguments, and returns the output, errors, and exit
@@ -164,17 +161,26 @@ let private failsWith expected (assembly, args) =
     Assert.True (0 <> exitCode, sprintf "Expected non-zero exit code, but got 0 with:\n\n%s\n\n%s" error out)
     Assert.StartsWith (normalize expected, normalize (error + out))
 
-/// A tuple of the test assembly and arguments using the standard default simulator. The tuple can be passed to yields
-/// or fails.
-let private test testNum =
-    let assembly = testAssembly testNum None
+/// A tuple of the test assembly and arguments using the given assembly constants. The tuple can be passed to yields or
+/// fails.
+let private testWithConstants constants testNum =
+    let assembly = testAssembly testNum constants
     fun args -> assembly, Array.ofList args
+
+/// A tuple of the test assembly and arguments with no assembly constants. The tuple can be passed to yields or fails.
+let private test = testWithConstants ImmutableDictionary.Empty
 
 /// A tuple of the test assembly and arguments using the given default simulator. The tuple can be passed to yields or
 /// fails.
-let private testWith testNum defaultSimulator =
-    let assembly = testAssembly testNum (Some defaultSimulator)
-    fun args -> assembly, Array.ofList args
+let private testWithSim defaultSimulator =
+    ImmutableDictionary.CreateRange [KeyValuePair (AssemblyConstants.DefaultSimulator, defaultSimulator)]
+    |> testWithConstants
+
+/// A tuple of the test assembly and arguments using the given default target. The tuple can be passed to yields or
+/// fails.
+let private testWithTarget defaultTarget =
+    ImmutableDictionary.CreateRange [KeyValuePair (AssemblyConstants.ExecutionTarget, defaultTarget)]
+    |> testWithConstants
 
 /// Standard command-line arguments for the "submit" command without specifying a target.
 let private submitWithoutTarget = 
@@ -509,7 +515,7 @@ let ``Rejects unknown simulator`` () =
 
 [<Fact>]
 let ``Supports default standard simulator`` () =
-    let given = testWith 32 AssemblyConstants.ResourcesEstimator
+    let given = testWithSim AssemblyConstants.ResourcesEstimator 32
     given ["--use-h"; "false"] |> yields resourceSummary
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "false"] |> yields "Hello, World!"
 
@@ -517,7 +523,7 @@ let ``Supports default standard simulator`` () =
 let ``Supports default custom simulator`` () =
     // This is not really a "custom" simulator, but the driver does not recognize the fully-qualified name of the
     // standard simulators, so it is treated as one.
-    let given = testWith 32 typeof<ToffoliSimulator>.FullName
+    let given = testWithSim typeof<ToffoliSimulator>.FullName 32
     given ["--use-h"; "false"] |> yields "Hello, World!"
     given ["--use-h"; "true"] |> fails
     given ["--simulator"; typeof<ToffoliSimulator>.FullName; "--use-h"; "false"] |> yields "Hello, World!"
@@ -547,10 +553,30 @@ let ``Submit uses default values`` () =
     let given = test 1
     given (submitWithNothingTarget @ ["--verbose"])
     |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               Target: test.nothing
                Subscription: mySubscription
                Resource Group: myResourceGroup
                Workspace: myWorkspace
+               Target: test.nothing
+               Storage:
+               AAD Token:
+               Base URI:
+               Job Name:
+               Shots: 500
+               Output: FriendlyUri
+               Dry Run: False
+               Verbose: True
+
+               00000000-0000-0000-0000-0000000000000"
+
+[<Fact>]
+let ``Submit uses default values with default target`` () =
+    let given = testWithTarget "test.nothing" 1
+    given (submitWithoutTarget @ ["--verbose"])
+    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
+               Subscription: mySubscription
+               Resource Group: myResourceGroup
+               Workspace: myWorkspace
+               Target: test.nothing
                Storage:
                AAD Token:
                Base URI:
@@ -579,10 +605,42 @@ let ``Submit allows overriding default values`` () =
         "750"
     ])
     |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               Target: test.nothing
                Subscription: mySubscription
                Resource Group: myResourceGroup
                Workspace: myWorkspace
+               Target: test.nothing
+               Storage: myStorage
+               AAD Token: myToken
+               Base URI: myBaseUri
+               Job Name: myJobName
+               Shots: 750
+               Output: FriendlyUri
+               Dry Run: False
+               Verbose: True
+
+               00000000-0000-0000-0000-0000000000000"
+
+[<Fact>]
+let ``Submit allows overriding default values with default target`` () =
+    let given = testWithTarget "foo.target" 1
+    given (submitWithNothingTarget @ [
+        "--verbose"
+        "--storage"
+        "myStorage"
+        "--aad-token"
+        "myToken"
+        "--base-uri"
+        "myBaseUri"
+        "--job-name"
+        "myJobName"
+        "--shots"
+        "750"
+    ])
+    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
+               Subscription: mySubscription
+               Resource Group: myResourceGroup
+               Workspace: myWorkspace
+               Target: test.nothing
                Storage: myStorage
                AAD Token: myToken
                Base URI: myBaseUri
@@ -685,10 +743,10 @@ let ``Shows help text for submit command`` () =
                       %s submit [options]
 
                     Options:
-                      --target <target> (REQUIRED)                        The target device ID.
                       --subscription <subscription> (REQUIRED)            The subscription ID.
                       --resource-group <resource-group> (REQUIRED)        The resource group name.
                       --workspace <workspace> (REQUIRED)                  The workspace name.
+                      --target <target> (REQUIRED)                        The target device ID.
                       --storage <storage>                                 The storage account connection string.
                       --aad-token <aad-token>                             The Azure Active Directory authentication token.
                       --base-uri <base-uri>                               The base URI of the Azure Quantum endpoint.
@@ -701,6 +759,33 @@ let ``Shows help text for submit command`` () =
                       --pauli <PauliI|PauliX|PauliY|PauliZ> (REQUIRED)    The name of a Pauli matrix.
                       --my-cool-bool (REQUIRED)                           A neat bit.
                       -?, -h, --help                                      Show help and usage information"
-
     let given = test 33
+    given ["submit"; "--help"] |> yields message
+
+[<Fact>]
+let ``Shows help text for submit command with default target`` () =
+    let name = Path.GetFileNameWithoutExtension (Assembly.GetEntryAssembly().Location)
+    let message =
+        name
+        |> sprintf "Usage:
+                      %s submit [options]
+
+                    Options:
+                      --subscription <subscription> (REQUIRED)            The subscription ID.
+                      --resource-group <resource-group> (REQUIRED)        The resource group name.
+                      --workspace <workspace> (REQUIRED)                  The workspace name.
+                      --target <target>                                   The target device ID.
+                      --storage <storage>                                 The storage account connection string.
+                      --aad-token <aad-token>                             The Azure Active Directory authentication token.
+                      --base-uri <base-uri>                               The base URI of the Azure Quantum endpoint.
+                      --job-name <job-name>                               The name of the submitted job.
+                      --shots <shots>                                     The number of times the program is executed on the target machine.
+                      --output <FriendlyUri|Id>                           The information to show in the output after the job is submitted.
+                      --dry-run                                           Validate the program and options, but do not submit to Azure Quantum.
+                      --verbose                                           Show additional information about the submission.
+                      -n <n> (REQUIRED)                                   A number.
+                      --pauli <PauliI|PauliX|PauliY|PauliZ> (REQUIRED)    The name of a Pauli matrix.
+                      --my-cool-bool (REQUIRED)                           A neat bit.
+                      -?, -h, --help                                      Show help and usage information"
+    let given = testWithTarget "foo.target" 33
     given ["submit"; "--help"] |> yields message

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -60,8 +60,7 @@ let private compileQsharp source =
     Assert.Empty errors
     compilation.BuiltCompilation
 
-/// Generates C# source code from the compiled Q# syntax tree. The given default simulator is set as an assembly
-/// constant.
+/// Generates C# source code from the compiled Q# syntax tree using the given assembly constants.
 let private generateCsharp constants (compilation : QsCompilation) =
     let context = CodegenContext.Create (compilation, constants)
     let entryPoint = context.allCallables.[Seq.exactlyOne compilation.EntryPoints]
@@ -109,7 +108,7 @@ let private compileCsharp (sources : string seq) =
     Assert.Equal (0L, stream.Seek (0L, SeekOrigin.Begin))
     Assembly.Load (stream.ToArray ())
 
-/// The assembly for the given test case and default simulator.
+/// The assembly for the given test case assembly constants.
 let private testAssembly testNum constants =
     testNum
     |> testCase

--- a/src/Simulation/EntryPointDriver/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure.cs
@@ -150,12 +150,16 @@ namespace Microsoft.Quantum.EntryPointDriver
         /// Creates a quantum machine based on the Azure Quantum submission settings.
         /// </summary>
         /// <param name="settings">The Azure Quantum submission settings.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="settings"/>.Target is null.</exception>
         /// <returns>A quantum machine.</returns>
         private static IQuantumMachine? CreateMachine(AzureSettings settings) => settings.Target switch
         {
             NothingMachine.TargetId => new NothingMachine(),
             ErrorMachine.TargetId => new ErrorMachine(),
-            _ => QuantumMachineFactory.CreateMachine(settings.CreateWorkspace(), settings.Target, settings.Storage)
+            _ => QuantumMachineFactory.CreateMachine(
+                settings.CreateWorkspace(),
+                settings.Target ?? throw new ArgumentNullException(nameof(settings), "Target is null."),
+                settings.Storage)
         };
 
         /// <summary>
@@ -191,11 +195,6 @@ namespace Microsoft.Quantum.EntryPointDriver
     internal sealed class AzureSettings
     {
         /// <summary>
-        /// The target device ID.
-        /// </summary>
-        public string? Target { get; set; }
-
-        /// <summary>
         /// The subscription ID.
         /// </summary>
         public string? Subscription { get; set; }
@@ -209,6 +208,11 @@ namespace Microsoft.Quantum.EntryPointDriver
         /// The workspace name.
         /// </summary>
         public string? Workspace { get; set; }
+
+        /// <summary>
+        /// The target device ID.
+        /// </summary>
+        public string? Target { get; set; }
 
         /// <summary>
         /// The storage account connection string.
@@ -261,10 +265,10 @@ namespace Microsoft.Quantum.EntryPointDriver
 
         public override string ToString() =>
             string.Join(System.Environment.NewLine,
-                $"Target: {Target}",
                 $"Subscription: {Subscription}",
                 $"Resource Group: {ResourceGroup}",
                 $"Workspace: {Workspace}",
+                $"Target: {Target}",
                 $"Storage: {Storage}",
                 $"AAD Token: {AadToken}",
                 $"Base URI: {BaseUri}",

--- a/src/Simulation/EntryPointDriver/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure.cs
@@ -154,12 +154,10 @@ namespace Microsoft.Quantum.EntryPointDriver
         /// <returns>A quantum machine.</returns>
         private static IQuantumMachine? CreateMachine(AzureSettings settings) => settings.Target switch
         {
+            null => throw new ArgumentNullException(nameof(settings), "Target is null."),
             NothingMachine.TargetId => new NothingMachine(),
             ErrorMachine.TargetId => new ErrorMachine(),
-            _ => QuantumMachineFactory.CreateMachine(
-                settings.CreateWorkspace(),
-                settings.Target ?? throw new ArgumentNullException(nameof(settings), "Target is null."),
-                settings.Storage)
+            _ => QuantumMachineFactory.CreateMachine(settings.CreateWorkspace(), settings.Target, settings.Storage)
         };
 
         /// <summary>

--- a/src/Simulation/EntryPointDriver/DriverSettings.cs
+++ b/src/Simulation/EntryPointDriver/DriverSettings.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.Quantum.EntryPointDriver
 {
     /// <summary>
-    /// Settings for the entry point driver.
+    /// General settings for the entry point driver that do not depend on the entry point or compilation target.
     /// </summary>
     public sealed class DriverSettings
     {

--- a/src/Simulation/EntryPointDriver/IEntryPoint.cs
+++ b/src/Simulation/EntryPointDriver/IEntryPoint.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Quantum.EntryPointDriver
         string DefaultSimulatorName { get; }
 
         /// <summary>
+        /// The default execution target when to use when submitting the entry point to Azure Quantum.
+        /// </summary>
+        string DefaultExecutionTarget { get; }
+
+        /// <summary>
         /// Additional information about the entry point.
         /// </summary>
         EntryPointInfo<TIn, TOut> Info { get; }


### PR DESCRIPTION
If the `ExecutionTarget` assembly constant is blank, `--target` is required. Otherwise, `--target` is optional and uses the value of `ExecutionTarget` as its default value.

This is possible because microsoft/qsharp-compiler#503 changed the value of `ExecutionTarget` to be the original string specified in the project file, e.g. "ionq.qpu", instead of "IonQProcessor".