### PR TITLE
Missing project properties for entry point driver

### DIFF
--- a/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <RootNamespace>Microsoft.Quantum.EntryPointDriver.Tests</RootNamespace>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Simulation/EntryPointDriver/Microsoft.Quantum.EntryPointDriver.csproj
+++ b/src/Simulation/EntryPointDriver/Microsoft.Quantum.EntryPointDriver.csproj
@@ -7,6 +7,18 @@
     <Nullable>enable</Nullable>
     <PackageId>Microsoft.Quantum.EntryPointDriver</PackageId>
     <Description>The standard command-line interface for standalone Q# console applications.</Description>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Microsoft</Authors>
+    <Description>Entry point driver for Q# command line applications.</Description>
+    <PackageReleaseNotes>See: https://docs.microsoft.com/en-us/quantum/relnotes/</PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/microsoft/qsharp-runtime</PackageProjectUrl>
+    <PackageIconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</PackageIconUrl>
+    <PackageTags>Quantum Q# Qsharp</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds project properties for the NuGet package to the entry point driver, specifically the license url. 