### PR TITLE
Implement friendly URI option for Azure quantum machines

### DIFF
--- a/src/Azure/Azure.Quantum.Client/JobManagement/CloudJob.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/CloudJob.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Quantum
         /// <summary>
         /// Gets an URI to access the job.
         /// </summary>
-        public Uri Uri => throw new NotImplementedException();
+        public Uri Uri => GenerateUri();
 
         /// <summary>
         /// Gets the workspace.
@@ -90,6 +90,17 @@ namespace Microsoft.Azure.Quantum
         {
             CloudJob job = (CloudJob)await this.Workspace.CancelJobAsync(this.Details.Id, cancellationToken);
             this.Details = job.Details;
+        }
+
+        private Uri GenerateUri()
+        {
+            if (!(this.Workspace is Workspace cloudWorkspace))
+            {
+                throw new NotSupportedException($"{typeof(CloudJob)}'s Workspace is not of type {typeof(Workspace)} and does not have enough data to generate URI");
+            }
+
+            var uriStr = $"https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/{cloudWorkspace.SubscriptionId}/resourceGroups/{cloudWorkspace.ResourceGroupName}/providers/Microsoft.Quantum/Workspaces/{cloudWorkspace.WorkspaceName}/job_management?microsoft_azure_quantum_jobid={Id}";
+            return new Uri(uriStr);
         }
     }
 }

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -114,6 +114,12 @@ namespace Microsoft.Azure.Quantum
             }
         }
 
+        public string ResourceGroupName { get => resourceGroupName; }
+
+        public string SubscriptionId { get => subscriptionId; }
+
+        public string WorkspaceName { get => workspaceName; }
+
         /// <summary>
         /// Gets or sets the jobs client.
         /// Internal only.

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -549,11 +549,7 @@ let ``Submit can show only the ID`` () =
 let ``Submit uses default values`` () =
     let given = test 1
     given (submitWithNothingTarget @ ["--verbose"])
-<<<<<<< HEAD
-    |> yields "Target: test.nothing
-=======
-    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               Subscription: mySubscription
+    |> yields "Subscription: mySubscription
                Resource Group: myResourceGroup
                Workspace: myWorkspace
                Target: test.nothing
@@ -566,15 +562,13 @@ let ``Submit uses default values`` () =
                Dry Run: False
                Verbose: True
 
-               00000000-0000-0000-0000-0000000000000"
+               https://www.example.com/00000000-0000-0000-0000-0000000000000"
 
 [<Fact>]
 let ``Submit uses default values with default target`` () =
     let given = testWithTarget "test.nothing" 1
     given (submitWithoutTarget @ ["--verbose"])
-    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
->>>>>>> master
-               Subscription: mySubscription
+    |> yields "Subscription: mySubscription
                Resource Group: myResourceGroup
                Workspace: myWorkspace
                Target: test.nothing
@@ -605,8 +599,7 @@ let ``Submit allows overriding default values`` () =
         "--shots"
         "750"
     ])
-    |> yields "Target: test.nothing
-               Subscription: mySubscription
+    |> yields "Subscription: mySubscription
                Resource Group: myResourceGroup
                Workspace: myWorkspace
                Target: test.nothing
@@ -619,7 +612,7 @@ let ``Submit allows overriding default values`` () =
                Dry Run: False
                Verbose: True
 
-               00000000-0000-0000-0000-0000000000000"
+               https://www.example.com/00000000-0000-0000-0000-0000000000000"
 
 [<Fact>]
 let ``Submit allows overriding default values with default target`` () =
@@ -637,8 +630,7 @@ let ``Submit allows overriding default values with default target`` () =
         "--shots"
         "750"
     ])
-    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               Subscription: mySubscription
+    |> yields "Subscription: mySubscription
                Resource Group: myResourceGroup
                Workspace: myWorkspace
                Target: test.nothing

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -466,8 +466,7 @@ let ``Shadows --shots`` () =
     given ["--shots"; "7"] |> yields "7"
     given (submitWithNothingTarget @ ["--shots"; "7"])
     |> yields "Warning: Option --shots is overridden by an entry point parameter name. Using default value 500.
-               The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               00000000-0000-0000-0000-0000000000000"
+               https://www.example.com/00000000-0000-0000-0000-0000000000000"
 
 
 // Simulators
@@ -534,8 +533,7 @@ let ``Supports default custom simulator`` () =
 let ``Submit can submit a job`` () =
     let given = test 1
     given submitWithNothingTarget
-    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               00000000-0000-0000-0000-0000000000000"
+    |> yields "https://www.example.com/00000000-0000-0000-0000-0000000000000"
 
 [<Fact>]
 let ``Submit can show only the ID`` () =
@@ -546,8 +544,7 @@ let ``Submit can show only the ID`` () =
 let ``Submit uses default values`` () =
     let given = test 1
     given (submitWithNothingTarget @ ["--verbose"])
-    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               Target: test.nothing
+    |> yields "Target: test.nothing
                Subscription: mySubscription
                Resource Group: myResourceGroup
                Workspace: myWorkspace
@@ -560,7 +557,7 @@ let ``Submit uses default values`` () =
                Dry Run: False
                Verbose: True
 
-               00000000-0000-0000-0000-0000000000000"
+               https://www.example.com/00000000-0000-0000-0000-0000000000000"
 
 [<Fact>]
 let ``Submit allows overriding default values`` () =
@@ -578,8 +575,7 @@ let ``Submit allows overriding default values`` () =
         "--shots"
         "750"
     ])
-    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               Target: test.nothing
+    |> yields "Target: test.nothing
                Subscription: mySubscription
                Resource Group: myResourceGroup
                Workspace: myWorkspace
@@ -592,14 +588,13 @@ let ``Submit allows overriding default values`` () =
                Dry Run: False
                Verbose: True
 
-               00000000-0000-0000-0000-0000000000000"
+               https://www.example.com/00000000-0000-0000-0000-0000000000000"
 
 [<Fact>]
 let ``Submit requires a positive number of shots`` () =
     let given = test 1
     given (submitWithNothingTarget @ ["--shots"; "1"])
-    |> yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-               00000000-0000-0000-0000-0000000000000"
+    |> yields "https://www.example.com/00000000-0000-0000-0000-0000000000000"
     given (submitWithNothingTarget @ ["--shots"; "0"]) |> fails
     given (submitWithNothingTarget @ ["--shots"; "-1"]) |> fails
 
@@ -634,8 +629,7 @@ let ``Submit has required options`` () =
     for args in powerSet allArgs do
         given (commandName :: List.concat args)
         |> if List.length args = List.length allArgs
-           then yields "The friendly URI for viewing job results is not available yet. Showing the job ID instead.
-                        00000000-0000-0000-0000-0000000000000"
+           then yields "https://www.example.com/00000000-0000-0000-0000-0000000000000"
            else fails
 
 [<Fact>]

--- a/src/Simulation/EntryPointDriver/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure.cs
@@ -121,10 +121,21 @@ namespace Microsoft.Quantum.EntryPointDriver
             switch (format)
             {
                 case OutputFormat.FriendlyUri:
-                    // TODO:
-                    DisplayWithColor(ConsoleColor.Yellow, Console.Error,
-                        "The friendly URI for viewing job results is not available yet. Showing the job ID instead.");
-                    Console.WriteLine(job.Id);
+                    try
+                    {
+                        Console.WriteLine(job.Uri);
+                    }
+                    catch (Exception ex)
+                    {
+                        DisplayWithColor(
+                            ConsoleColor.Yellow,
+                            Console.Error,
+                            $"The friendly URI for viewing job results could not be obtained.{System.Environment.NewLine}" +
+                            $"Error details: {ex.Message}" +
+                            $"Showing the job ID instead.");
+
+                        Console.WriteLine(job.Id);
+                    }
                     break;
                 case OutputFormat.Id:
                     Console.WriteLine(job.Id);


### PR DESCRIPTION
This change implements the friendly URI property in the `CloudJob` class, which is used by Azure quantum machines.

Additionally, it enables the friendly URI option in the entry point driver for standalone executables.