### PR TITLE
Removing unnecessary package references

### DIFF
--- a/src/Simulation/RoslynWrapper/Microsoft.Quantum.RoslynWrapper.fsproj
+++ b/src/Simulation/RoslynWrapper/Microsoft.Quantum.RoslynWrapper.fsproj
@@ -37,15 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="3.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I overlooked a version conflict for the updated packages. It also looks like we don't need to reference most packages explicitly. 