### PR TITLE
Remove Negative Tests from Execution Testing

### DIFF
--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/ClassicallyControlledSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/ClassicallyControlledSupportTests.qs
@@ -60,40 +60,11 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSu
             let temp = 2;
         }
     }
-    
-    operation DontLiftReturnStatements() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubOp1();
-            return ();
-        }
-    }
-
-    function SubFunc1() : Unit { }
-    function SubFunc2() : Unit { }
-    function SubFunc3() : Unit { }
-
-    function DontLiftFunctions() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubFunc1();
-            SubFunc2();
-            SubFunc3();
-        }
-    }
 
     operation LiftSelfContainedMutable() : Unit {
         let r = Zero;
         if (r == Zero) {
             mutable temp = 3;
-            set temp = 4;
-        }
-    }
-
-    operation DontLiftGeneralMutable() : Unit {
-        let r = Zero;
-        mutable temp = 3;
-        if (r == Zero) {
             set temp = 4;
         }
     }
@@ -139,43 +110,6 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSu
         }
         else {
             SubOp3();
-        }
-    }
-
-    operation IfInvalid() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubOp1();
-            SubOp2();
-            return ();
-        } else {
-            SubOp2();
-            SubOp3();
-        }
-    }
-
-    operation ElseInvalid() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubOp1();
-            SubOp2();
-        } else {
-            SubOp2();
-            SubOp3();
-            return ();
-        }
-    }
-
-    operation BothInvalid() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubOp1();
-            SubOp2();
-            return ();
-        } else {
-            SubOp2();
-            SubOp3();
-            return ();
         }
     }
     

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/ClassicallyControlledSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/ClassicallyControlledSupportTests.qs
@@ -60,40 +60,11 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportT
             let temp = 2;
         }
     }
-    
-    operation DontLiftReturnStatements() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubOp1();
-            return ();
-        }
-    }
-
-    function SubFunc1() : Unit { }
-    function SubFunc2() : Unit { }
-    function SubFunc3() : Unit { }
-
-    function DontLiftFunctions() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubFunc1();
-            SubFunc2();
-            SubFunc3();
-        }
-    }
 
     operation LiftSelfContainedMutable() : Unit {
         let r = Zero;
         if (r == Zero) {
             mutable temp = 3;
-            set temp = 4;
-        }
-    }
-
-    operation DontLiftGeneralMutable() : Unit {
-        let r = Zero;
-        mutable temp = 3;
-        if (r == Zero) {
             set temp = 4;
         }
     }
@@ -139,43 +110,6 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportT
         }
         else {
             SubOp3();
-        }
-    }
-
-    operation IfInvalid() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubOp1();
-            SubOp2();
-            return ();
-        } else {
-            SubOp2();
-            SubOp3();
-        }
-    }
-
-    operation ElseInvalid() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubOp1();
-            SubOp2();
-        } else {
-            SubOp2();
-            SubOp3();
-            return ();
-        }
-    }
-
-    operation BothInvalid() : Unit {
-        let r = Zero;
-        if (r == Zero) {
-            SubOp1();
-            SubOp2();
-            return ();
-        } else {
-            SubOp2();
-            SubOp3();
-            return ();
         }
     }
     

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/HoneywellSimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/HoneywellSimulation.qs
@@ -45,26 +45,8 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell {
 
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
-    operation DontLiftReturnStatementsTest() : Unit {
-        DontLiftReturnStatements();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation DontLiftFunctionsTest() : Unit {
-        DontLiftFunctions();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     operation LiftSelfContainedMutableTest() : Unit {
         LiftSelfContainedMutable();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation DontLiftGeneralMutableTest() : Unit {
-        DontLiftGeneralMutable();
     }
 
     @Test("QuantumSimulator")
@@ -95,24 +77,6 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell {
     @Test("ResourcesEstimator")
     operation LiftOneNotBothTest() : Unit {
         LiftOneNotBoth();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation IfInvalidTest() : Unit {
-        IfInvalid();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation ElseInvalidTest() : Unit {
-        ElseInvalid();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation BothInvalidTest() : Unit {
-        BothInvalid();
     }
 
     @Test("QuantumSimulator")

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/QCISimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/QCISimulation.qs
@@ -45,26 +45,8 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI {
 
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
-    operation DontLiftReturnStatementsTest() : Unit {
-        DontLiftReturnStatements();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation DontLiftFunctionsTest() : Unit {
-        DontLiftFunctions();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     operation LiftSelfContainedMutableTest() : Unit {
         LiftSelfContainedMutable();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation DontLiftGeneralMutableTest() : Unit {
-        DontLiftGeneralMutable();
     }
 
     @Test("QuantumSimulator")
@@ -95,24 +77,6 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI {
     @Test("ResourcesEstimator")
     operation LiftOneNotBothTest() : Unit {
         LiftOneNotBoth();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation IfInvalidTest() : Unit {
-        IfInvalid();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation ElseInvalidTest() : Unit {
-        ElseInvalid();
-    }
-
-    @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
-    operation BothInvalidTest() : Unit {
-        BothInvalid();
     }
 
     @Test("QuantumSimulator")


### PR DESCRIPTION
Removing the negative execution tests from the classically controlled execution testing. These tests contain behavior that is not supported by their targets, by definition, and so cause the builds to fail.