### PR TITLE
Generic Parameter Bug Fix

### DIFF
--- a/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
+++ b/src/Simulation/CsharpGeneration.Tests/Circuits/CodegenTests.qs
@@ -1262,6 +1262,11 @@ namespace Microsoft.Quantum.Compiler.Generics {
         genIter(genU1<Result>, a);
     }
 
+    operation genericWithMultipleTypeParams<'A, 'B, 'C>() : Unit { }
+
+    operation callsGenericWithMultipleTypeParams () : Unit {
+        genericWithMultipleTypeParams<Double, Int, Int>();
+    }
 
     operation composeImpl<'A, 'B> (second : ('A => Unit), first : ('B => 'A), arg : 'B) : Unit {
 

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -167,6 +167,7 @@ namespace N1
     let genMapper                               = findCallable @"genMapper"
     let genIter                                 = findCallable @"genIter"
     let usesGenerics                            = findCallable @"usesGenerics"
+    let callsGenericWithMultipleTypeParams      = findCallable @"callsGenericWithMultipleTypeParams"
     let duplicatedDefinitionsCaller             = findCallable @"duplicatedDefinitionsCaller"
     let nestedArgTuple1                         = findCallable @"nestedArgTuple1"
     let nestedArgTuple2                         = findCallable @"nestedArgTuple2"
@@ -452,6 +453,11 @@ namespace N1
             ((NS1, "noOpResult"     ), "IUnitary<Result>")
         ]
         |> testOne usesGenerics
+
+        [
+            ((NSG, "genericWithMultipleTypeParams"), "ICallable")
+        ]
+        |> testOne callsGenericWithMultipleTypeParams
 
         [
             ((NS2, "Allocate"       ), "Allocate")
@@ -897,13 +903,18 @@ namespace N1
         |> testOne usesGenerics
 
         [
-            template "Z"                                      "IUnitary<Qubit>"                 "Microsoft.Quantum.Intrinsic.Z"
+            template "genericWithMultipleTypeParams"        "ICallable"                         "genericWithMultipleTypeParams<,,>"
+        ]
+        |> testOne callsGenericWithMultipleTypeParams
+
+        [
+            template "Z"                                    "IUnitary<Qubit>"                   "Microsoft.Quantum.Intrinsic.Z"
             "this.self = this;"
         ]
         |> testOne selfInvokingOperation
 
         [
-            template "self"                                 "ICallable"                       "genRecursion<>"
+            template "self"                                 "ICallable"                         "genRecursion<>"
         ]
         |> testOne genRecursion
 
@@ -933,6 +944,11 @@ namespace N1
         ]
         |> List.sort
         |> testOne usesGenerics
+
+        [
+            template "genericWithMultipleTypeParams<,,>"
+        ]
+        |> testOne callsGenericWithMultipleTypeParams
 
         [
             template "composeImpl<,>"
@@ -978,6 +994,11 @@ namespace N1
             template "IUnitary<Result>"             "MicrosoftQuantumTestingnoOpResult"
         ]
         |> testOne usesGenerics
+
+        [
+            template "ICallable"                    "genericWithMultipleTypeParams"
+        ]
+        |> testOne callsGenericWithMultipleTypeParams
 
         [
             template "IUnitary<Qubit>"              "Z"
@@ -2502,7 +2523,7 @@ namespace N1
         |> testOneClass genCtrl3 AssemblyConstants.HoneywellProcessor
 
         """
-    [SourceLocation("%%%", OperationFunctor.Body, 1266, 1272)]
+    [SourceLocation("%%%", OperationFunctor.Body, 1271, 1277)]
     public partial class composeImpl<__A__, __B__> : Operation<(ICallable,ICallable,__B__), QVoid>, ICallable
     {
         public composeImpl(IOperationFactory m) : base(m)
@@ -2579,7 +2600,7 @@ namespace N1
     [<Fact>]
     let ``buildOperationClass - access modifiers`` () =
         """
-[SourceLocation("%%%", OperationFunctor.Body, 1314, 1316)]
+[SourceLocation("%%%", OperationFunctor.Body, 1319, 1321)]
 internal partial class EmptyInternalFunction : Function<QVoid, QVoid>, ICallable
 {
     public EmptyInternalFunction(IOperationFactory m) : base(m)
@@ -2613,7 +2634,7 @@ internal partial class EmptyInternalFunction : Function<QVoid, QVoid>, ICallable
         |> testOneClass emptyInternalFunction null
 
         """
-[SourceLocation("%%%", OperationFunctor.Body, 1316, 1318)]
+[SourceLocation("%%%", OperationFunctor.Body, 1321, 1323)]
 internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallable
 {
     public EmptyInternalOperation(IOperationFactory m) : base(m)
@@ -2730,7 +2751,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
     [<Fact>]
     let ``buildOperationClass - concrete functions`` () =
         """
-    [SourceLocation("%%%", OperationFunctor.Body, 1301,1310)]
+    [SourceLocation("%%%", OperationFunctor.Body, 1306,1315)]
     public partial class UpdateUdtItems : Function<MyType2, MyType2>, ICallable
     {
         public UpdateUdtItems(IOperationFactorym) : base(m)

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -93,9 +93,7 @@ module SimulationCode =
     let isGeneric context (n: QsQualifiedName) =
         if context.allCallables.ContainsKey n then
             let signature = context.allCallables.[n].Signature
-            let tIn = signature.ArgumentType
-            let tOut = signature.ReturnType
-            hasTypeParameters [tIn;tOut]
+            not signature.TypeParameters.IsEmpty
         else
             false
 
@@ -861,9 +859,7 @@ module SimulationCode =
             let opName = if sameNamespace then n.Name.Value else n.Namespace.Value + "." + n.Name.Value
             if isGeneric context n then
                 let signature = context.allCallables.[n].Signature
-                let tIn = signature.ArgumentType
-                let tOut = signature.ReturnType
-                let count = (getTypeParameters [tIn;tOut]).Length
+                let count = signature.TypeParameters.Length
                 sprintf "%s<%s>" opName (String.replicate (count - 1) ",")
             else
                 opName

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/ClassicallyControlledSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/ClassicallyControlledSupportTests.qs
@@ -246,7 +246,6 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSu
         }
     }
 
-    // ToDo: Uncomment once #17245 is fixed.
     operation GenericsSupport<'A, 'B, 'C>() : Unit {
         let r = Zero;
 

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/ClassicallyControlledSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/ClassicallyControlledSupportTests.qs
@@ -13,7 +13,7 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSu
     operation SubOpCA1() : Unit is Ctl + Adj { }
     operation SubOpCA2() : Unit is Ctl + Adj { }
     operation SubOpCA3() : Unit is Ctl + Adj { }
-    
+
     operation BranchOnMeasurement() : Unit {
         using (q = Qubit()) {
             H(q);
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSu
             }
         }
     }
-    
+
     operation LiftSingleNonCall() : Unit {
         let r = Zero;
         if (r == Zero) {
@@ -112,7 +112,7 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSu
             SubOp3();
         }
     }
-    
+
     operation ApplyIfZero_Test() : Unit {
         let r = Zero;
         if (r == Zero) {
@@ -249,7 +249,7 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSu
     // ToDo: Uncomment once #17245 is fixed.
     operation GenericsSupport<'A, 'B, 'C>() : Unit {
         let r = Zero;
-    
+
         if (r == Zero) {
             SubOp1();
             SubOp2();

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/ClassicallyControlledSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/ClassicallyControlledSupportTests.qs
@@ -247,14 +247,14 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSu
     }
 
     // ToDo: Uncomment once #17245 is fixed.
-    //operation GenericsSupport<'A, 'B, 'C>() : Unit {
-    //    let r = Zero;
-    //
-    //    if (r == Zero) {
-    //        SubOp1();
-    //        SubOp2();
-    //    }
-    //}
+    operation GenericsSupport<'A, 'B, 'C>() : Unit {
+        let r = Zero;
+    
+        if (r == Zero) {
+            SubOp1();
+            SubOp2();
+        }
+    }
 
     operation WithinBlockSupport() : Unit {
         let r = One;

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/MeasurementSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/MeasurementSupportTests.qs
@@ -5,7 +5,7 @@
 namespace Microsoft.Quantum.Simulation.Testing.Honeywell.MeasurementSupportTests {
 
     open Microsoft.Quantum.Intrinsic;
-    
+
     operation MeasureInMiddle() : Unit {
         using (qs = Qubit[2]) {
             H(qs[0]);

--- a/src/Simulation/Simulators.Tests/TestProjects/IonQExe/MeasurementSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/IonQExe/MeasurementSupportTests.qs
@@ -5,7 +5,7 @@
 namespace Microsoft.Quantum.Simulation.Testing.IonQ.MeasurementSupportTests {
 
     open Microsoft.Quantum.Intrinsic;
-    
+
     operation MeasureInMiddle() : Unit {
         using (qs = Qubit[2]) {
             H(qs[0]);

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/ClassicallyControlledSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/ClassicallyControlledSupportTests.qs
@@ -13,7 +13,7 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportT
     operation SubOpCA1() : Unit is Ctl + Adj { }
     operation SubOpCA2() : Unit is Ctl + Adj { }
     operation SubOpCA3() : Unit is Ctl + Adj { }
-    
+
     operation BranchOnMeasurement() : Unit {
         using (q = Qubit()) {
             H(q);
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportT
             Reset(q);
         }
     }
-    
+
     operation BasicLift() : Unit {
         let r = Zero;
         if (r == Zero) {
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportT
             }
         }
     }
-    
+
     operation LiftSingleNonCall() : Unit {
         let r = Zero;
         if (r == Zero) {
@@ -112,7 +112,7 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportT
             SubOp3();
         }
     }
-    
+
     operation ApplyIfZero_Test() : Unit {
         let r = Zero;
         if (r == Zero) {
@@ -248,7 +248,7 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportT
 
     operation GenericsSupport<'A, 'B, 'C>() : Unit {
         let r = Zero;
-    
+
         if (r == Zero) {
             SubOp1();
             SubOp2();

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/ClassicallyControlledSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/ClassicallyControlledSupportTests.qs
@@ -246,15 +246,14 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportT
         }
     }
 
-    // ToDo: Uncomment once #17245 is fixed.
-    //operation GenericsSupport<'A, 'B, 'C>() : Unit {
-    //    let r = Zero;
-    //
-    //    if (r == Zero) {
-    //        SubOp1();
-    //        SubOp2();
-    //    }
-    //}
+    operation GenericsSupport<'A, 'B, 'C>() : Unit {
+        let r = Zero;
+    
+        if (r == Zero) {
+            SubOp1();
+            SubOp2();
+        }
+    }
 
     operation WithinBlockSupport() : Unit {
         let r = One;

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/MeasurementSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/MeasurementSupportTests.qs
@@ -5,7 +5,7 @@
 namespace Microsoft.Quantum.Simulation.Testing.QCI.MeasurementSupportTests {
 
     open Microsoft.Quantum.Intrinsic;
-    
+
     operation MeasureInMiddle() : Unit {
         using (qs = Qubit[2]) {
             H(qs[0]);

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/HoneywellSimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/HoneywellSimulation.qs
@@ -6,13 +6,13 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSupportTests;
     open Microsoft.Quantum.Simulation.Testing.Honeywell.MeasurementSupportTests;
-    
+
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
     operation MeasureInMiddleTest() : Unit {
         MeasureInMiddle();
     }
-    
+
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
     operation QubitAfterMeasurementTest() : Unit {

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/HoneywellSimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/HoneywellSimulation.qs
@@ -169,12 +169,11 @@ namespace Microsoft.Quantum.Simulation.Testing.Honeywell {
         LiteralOnTheLeft();
     }
 
-    // ToDo: Uncomment once #17245 is fixed.
-    //@Test("QuantumSimulator")
-    //@Test("ResourcesEstimator")
-    //operation GenericsSupportTest() : Unit {
-    //    GenericsSupport<Int, Int, Int>();
-    //}
+    @Test("QuantumSimulator")
+    @Test("ResourcesEstimator")
+    operation GenericsSupportTest() : Unit {
+        GenericsSupport<Int, Int, Int>();
+    }
 
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/IonQSimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/IonQSimulation.qs
@@ -5,13 +5,13 @@
 namespace Microsoft.Quantum.Simulation.Testing.IonQ {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Simulation.Testing.IonQ.MeasurementSupportTests;
-    
+
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
     operation MeasureInMiddleTest() : Unit {
         MeasureInMiddle();
     }
-    
+
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
     operation QubitAfterMeasurementTest() : Unit {

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/QCISimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/QCISimulation.qs
@@ -169,12 +169,11 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI {
         LiteralOnTheLeft();
     }
 
-    // ToDo: Uncomment once #17245 is fixed.
-    //@Test("QuantumSimulator")
-    //@Test("ResourcesEstimator")
-    //operation GenericsSupportTest() : Unit {
-    //    GenericsSupport<Int, Int, Int>();
-    //}
+    @Test("QuantumSimulator")
+    @Test("ResourcesEstimator")
+    operation GenericsSupportTest() : Unit {
+        GenericsSupport<Int, Int, Int>();
+    }
 
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/QCISimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/QCISimulation.qs
@@ -6,13 +6,13 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportTests;
     open Microsoft.Quantum.Simulation.Testing.QCI.MeasurementSupportTests;
-    
+
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
     operation MeasureInMiddleTest() : Unit {
         MeasureInMiddle();
     }
-    
+
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")
     operation QubitAfterMeasurementTest() : Unit {


### PR DESCRIPTION
Changes the method in the C# generation for determining if a callable is a generic callable. The old behavior counts the number of type parameters referenced in the types of the regular parameter list and the return type. This causes a bug to occur when type parameters are listed for a callable that are not used in their parameter list or return type. The new behavior simply counts the length of the type parameters list for the callable. See issue #299.