### PR TITLE
Fix stack overflow bug for Qubit array types

### DIFF
--- a/src/Simulation/Core/Operations/Operation.cs
+++ b/src/Simulation/Core/Operations/Operation.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Quantum.Simulation.Core
             {
                 Label = ((ICallable)this).Name,
                 FormattedNonQubitArgs = args.GetNonQubitArgumentsAsString() ?? "",
-                Targets = args.GetQubits(),
+                Targets = args.GetQubits() ?? new List<Qubit>(),
             };
 
         public O Apply(I a)

--- a/src/Simulation/Core/RuntimeMetadata.cs
+++ b/src/Simulation/Core/RuntimeMetadata.cs
@@ -44,8 +44,7 @@ namespace Microsoft.Quantum.Simulation.Core
         /// </summary>
         /// </summary>
         /// <remarks>
-        /// Currently not used as this is intended for composite operations,
-        /// such as <c>ApplyToEach</c>.
+        /// This is used in composite operations, such as <c>ApplyToEach</c>.
         /// </remarks>
         public bool IsComposite { get; set; }
 
@@ -53,7 +52,7 @@ namespace Microsoft.Quantum.Simulation.Core
         /// Group of operations for each classical branch (<c>true</c> and <c>false</c>).
         /// </summary>
         /// <remarks>
-        /// Currently not used as this is intended for classically-controlled operations.
+        /// This is used in classically-controlled operations.
         /// </remarks>
         public IEnumerable<IEnumerable<RuntimeMetadata>>? Children { get; set; }
 

--- a/src/Simulation/Core/TypeExtensions.cs
+++ b/src/Simulation/Core/TypeExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
@@ -155,15 +156,13 @@ namespace Microsoft.Quantum.Simulation.Core
         {
             var t = o.GetType();
 
-            // If object is a Qubit, ignore it (i.e. return null)
-            if (o is Qubit) return null;
+            // If object is a Qubit or array of Qubits, ignore it (i.e. return null)
+            if (o is Qubit || o is IEnumerable<Qubit>) return null;
 
-            // If object is an IApplyData, recursively extract nested fields
-            // and stringify them
+            // If object is an IApplyData, recursively extract arguments
             if (o is IApplyData data)
             {
-                var argsString = data.Value.GetNonQubitArgumentsAsString();
-                return argsString.Any() ? argsString : null;
+                return data.Value.GetNonQubitArgumentsAsString();
             }
 
             // If object is a string, enclose it in quotations

--- a/src/Simulation/Core/TypeExtensions.cs
+++ b/src/Simulation/Core/TypeExtensions.cs
@@ -156,8 +156,8 @@ namespace Microsoft.Quantum.Simulation.Core
         {
             var t = o.GetType();
 
-            // If object is a Qubit or array of Qubits, ignore it (i.e. return null)
-            if (o is Qubit || o is IEnumerable<Qubit>) return null;
+            // If object is a Qubit, QVoid, or array of Qubits, ignore it (i.e. return null)
+            if (o is Qubit || o is QVoid || o is IEnumerable<Qubit>) return null;
 
             // If object is an IApplyData, recursively extract arguments
             if (o is IApplyData data)

--- a/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
@@ -2,9 +2,24 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
-    
+
+    open Microsoft.Quantum.Intrinsic;
+
     newtype FooUDT = (String, (Qubit, Double));
 
     operation FooUDTOp (foo : FooUDT) : Unit is Ctl + Adj { }
+
+    operation Empty () : Unit is Ctl + Adj { }
+
+    operation HOp (q : Qubit) : Unit {
+        H(q);
+        Reset(q);
+    }
+
+    operation NestedOp () : Unit {
+        using (q = Qubit()) {
+            HOp(q);
+        }
+    }
     
 }

--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -387,6 +387,50 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             Assert.Equal(op.GetRuntimeMetadata(args), expected);
         }
+
+        [Fact]
+        public void EmptyOperation()
+        {
+            var measureQubit = new FreeQubit(0);
+            var op = new QuantumSimulator().Get<Circuits.Empty>();
+            var args = op.__dataIn(QVoid.Instance);
+            var expected = new RuntimeMetadata()
+            {
+                Label = "Empty",
+                FormattedNonQubitArgs = "",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = new List<Qubit>() { },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
+
+        [Fact]
+        public void NestedOperation()
+        {
+            var measureQubit = new FreeQubit(0);
+            var op = new QuantumSimulator().Get<Circuits.NestedOp>();
+            var args = op.__dataIn(QVoid.Instance);
+            var expected = new RuntimeMetadata()
+            {
+                Label = "NestedOp",
+                FormattedNonQubitArgs = "",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = new List<Qubit>() { },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
     }
 
     public class UDTTests

--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -231,6 +231,29 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         }
 
         [Fact]
+        public void Swap()
+        {
+            var q1 = new FreeQubit(0);
+            var q2 = new FreeQubit(1);
+            var op = new QuantumSimulator().Get<Intrinsic.SWAP>();
+            var args = op.__dataIn((q1, q2));
+            var expected = new RuntimeMetadata()
+            {
+                Label = "SWAP",
+                FormattedNonQubitArgs = "",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = new List<Qubit>() { q1, q2 },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
+
+        [Fact]
         public void Ry()
         {
             var target = new FreeQubit(0);
@@ -269,6 +292,28 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 Children = null,
                 Controls = new List<Qubit>() { },
                 Targets = new List<Qubit>() { measureQubit },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
+
+        [Fact]
+        public void ResetAll()
+        {
+            IQArray<Qubit> targets = new QArray<Qubit>(new[] { new FreeQubit(0) });
+            var op = new QuantumSimulator().Get<Intrinsic.ResetAll>();
+            var args = op.__dataIn(targets);
+            var expected = new RuntimeMetadata()
+            {
+                Label = "ResetAll",
+                FormattedNonQubitArgs = "",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = targets,
             };
 
             Assert.Equal(op.GetRuntimeMetadata(args), expected);

--- a/src/Simulation/Simulators.Tests/TypeExtensionsTest.cs
+++ b/src/Simulation/Simulators.Tests/TypeExtensionsTest.cs
@@ -34,6 +34,22 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         }
 
         [Fact]
+        public void QubitTypes()
+        {
+            var q = new FreeQubit(0);
+            Assert.Null(q.GetNonQubitArgumentsAsString());
+
+            var qs = new QArray<Qubit>(new[] { new FreeQubit(0) });
+            Assert.Null(qs.GetNonQubitArgumentsAsString());
+
+            qs = new QArray<Qubit>(new[] { new FreeQubit(0), new FreeQubit(1) });
+            Assert.Null(qs.GetNonQubitArgumentsAsString());
+
+            var qtuple = new QTuple<Qubit>(q);
+            Assert.Null(qtuple.GetNonQubitArgumentsAsString());
+        }
+
+        [Fact]
         public void TupleTypes()
         {
             Assert.Equal("(1, 2)", (1, 2).GetNonQubitArgumentsAsString());
@@ -41,6 +57,9 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.Equal("(\"foo\", \"bar\", \"\")", ("foo", "bar", "").GetNonQubitArgumentsAsString());
             Assert.Equal("(\"foo\", (\"bar\", \"car\"))", ("foo", ("bar", "car")).GetNonQubitArgumentsAsString());
             Assert.Equal("((\"foo\"), (\"bar\", \"car\"))", (("foo", new FreeQubit(0)), ("bar", "car")).GetNonQubitArgumentsAsString());
+
+            var qtuple = new QTuple<(Qubit, string)>((new FreeQubit(0), "foo"));
+            Assert.Equal("(\"foo\")", qtuple.GetNonQubitArgumentsAsString());
         }
 
         [Fact]
@@ -54,19 +73,6 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 (new FreeQubit(1), "bar"),
             };
             Assert.Equal("[(\"foo\"), (\"bar\")]", arr.GetNonQubitArgumentsAsString());
-        }
-
-        [Fact]
-        public void QubitTypes()
-        {
-            var q = new FreeQubit(0);
-            Assert.Null(q.GetNonQubitArgumentsAsString());
-
-            var qs = new QArray<Qubit>(new[] { new FreeQubit(0) });
-            Assert.Null(qs.GetNonQubitArgumentsAsString());
-
-            qs = new QArray<Qubit>(new[] { new FreeQubit(0), new FreeQubit(1) });
-            Assert.Null(qs.GetNonQubitArgumentsAsString());
         }
 
         [Fact]
@@ -98,12 +104,20 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             data = new ApplyData<(FreeQubit, string)[]>(arr);
             Assert.Equal("[(\"foo\"), (\"bar\")]", data.GetNonQubitArgumentsAsString());
 
+            var qtupleWithString = new QTuple<(Qubit, string)>((new FreeQubit(0), "foo"));
+            data = new ApplyData<QTuple<(Qubit, string)>>(qtupleWithString);
+            Assert.Equal("(\"foo\")", data.GetNonQubitArgumentsAsString());
+
             var q = new FreeQubit(0);
             data = new ApplyData<Qubit>(q);
             Assert.Null(data.GetNonQubitArgumentsAsString());
 
             var qs = new QArray<Qubit>(new[] { new FreeQubit(0), new FreeQubit(1) });
             data = new ApplyData<IQArray<Qubit>>(qs);
+            Assert.Null(data.GetNonQubitArgumentsAsString());
+
+            var qtuple = new QTuple<Qubit>(q);
+            data = new ApplyData<QTuple<Qubit>>(qtuple);
             Assert.Null(data.GetNonQubitArgumentsAsString());
         }
     }

--- a/src/Simulation/Simulators.Tests/TypeExtensionsTest.cs
+++ b/src/Simulation/Simulators.Tests/TypeExtensionsTest.cs
@@ -57,6 +57,19 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         }
 
         [Fact]
+        public void QubitTypes()
+        {
+            var q = new FreeQubit(0);
+            Assert.Null(q.GetNonQubitArgumentsAsString());
+
+            var qs = new QArray<Qubit>(new[] { new FreeQubit(0) });
+            Assert.Null(qs.GetNonQubitArgumentsAsString());
+
+            qs = new QArray<Qubit>(new[] { new FreeQubit(0), new FreeQubit(1) });
+            Assert.Null(qs.GetNonQubitArgumentsAsString());
+        }
+
+        [Fact]
         public void IApplyDataTypes()
         {
             IApplyData data;
@@ -84,6 +97,14 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             };
             data = new ApplyData<(FreeQubit, string)[]>(arr);
             Assert.Equal("[(\"foo\"), (\"bar\")]", data.GetNonQubitArgumentsAsString());
+
+            var q = new FreeQubit(0);
+            data = new ApplyData<Qubit>(q);
+            Assert.Null(data.GetNonQubitArgumentsAsString());
+
+            var qs = new QArray<Qubit>(new[] { new FreeQubit(0), new FreeQubit(1) });
+            data = new ApplyData<IQArray<Qubit>>(qs);
+            Assert.Null(data.GetNonQubitArgumentsAsString());
         }
     }
 }


### PR DESCRIPTION
There is a bug in `GetNonQubitArgumentsAsString` where arguments of `Qubit` array types (and `QVoid`) produced a stack overflow. That happened because `IQArray` matches `IApplyData` instead of the `Qubit` type. This PR fixes this by adding a check to see if the given arguments is of the type `IEnumerable<Qubit>` (or `QVoid`).