### PR TITLE
Use new position type in C# generation

### DIFF
--- a/src/Simulation/CsharpGeneration/Context.fs
+++ b/src/Simulation/CsharpGeneration/Context.fs
@@ -19,7 +19,7 @@ module internal DeclarationLocations =
     type TransformationState() = 
 
         member val internal CurrentSource = null with get, set
-        member val internal DeclarationLocations = new List<NonNullable<string> * (int * int)>()
+        member val internal DeclarationLocations = new List<NonNullable<string> * Position>()
 
     type NamespaceTransformation(parent : SyntaxTreeTransformation<TransformationState>) = 
         inherit NamespaceTransformation<TransformationState>(parent)
@@ -60,7 +60,7 @@ type CodegenContext = {
     allQsElements           : IEnumerable<QsNamespace>
     allUdts                 : ImmutableDictionary<QsQualifiedName,QsCustomType>
     allCallables            : ImmutableDictionary<QsQualifiedName,QsCallable>
-    declarationPositions    : ImmutableDictionary<NonNullable<string>, ImmutableSortedSet<int * int>>
+    declarationPositions    : ImmutableDictionary<NonNullable<string>, ImmutableSortedSet<Position>>
     byName                  : ImmutableDictionary<NonNullable<string>,(NonNullable<string>*QsCallable) list>
     current                 : QsQualifiedName option
     signature               : ResolvedSignature option

--- a/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
+++ b/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.3017-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.2007.1708-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
+++ b/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.2007.1708-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.2007.1709-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -274,7 +274,7 @@ module SimulationCode =
         override this.OnStatement (node:QsStatement) =
             match node.Location with
             | Value loc ->
-                let (current, _) = loc.Offset
+                let current = loc.Offset.Line
                 parent.LineNumber <- parent.StartLine |> Option.map (fun start -> start + current + 1) // The Q# compiler reports 0-based line numbers.
             | Null ->
                 parent.LineNumber <- None // auto-generated statement; the line number will be set to the specialization declaration
@@ -839,7 +839,7 @@ module SimulationCode =
         override this.OnSpecializationDeclaration (sp : QsSpecialization) =
             count <- 0
             match sp.Location with
-            | Value location -> parent.StartLine <- Some (location.Offset |> fst)
+            | Value location -> parent.StartLine <- Some location.Offset.Line
             | Null -> parent.StartLine <- None // TODO: we may need to have the means to know which original declaration the code came from
             base.OnSpecializationDeclaration sp
 
@@ -1003,12 +1003,12 @@ module SimulationCode =
             | Null -> []
             | Value location -> [
                 // since the line numbers throughout the generated code are 1-based, let's also choose them 1-based here
-                let startLine = fst location.Offset + 1
+                let startLine = location.Offset.Line + 1
                 let endLine =
                     match context.declarationPositions.TryGetValue sp.SourceFile with
                     | true, startPositions ->
                         let index = startPositions.IndexOf location.Offset
-                        if index + 1 >= startPositions.Count then -1 else fst startPositions.[index + 1] + 1
+                        if index + 1 >= startPositions.Count then -1 else startPositions.[index + 1].Line + 1
 //TODO: diagnostics.
                     | false, _ -> startLine
                 ``attribute`` None (``ident`` "SourceLocation") [
@@ -1328,7 +1328,7 @@ module SimulationCode =
         let properties = buildOutput ()
         let methods =
             match op.Location with
-            | Value location -> [ buildUnitTest targetName opName (fst location.Offset) op.SourceFile.Value ]
+            | Value location -> [ buildUnitTest targetName opName location.Offset.Line op.SourceFile.Value ]
 // TODO: diagnostics
             | Null -> failwith "missing location for unit test"
 

--- a/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\Simulators.Dev.props" />

--- a/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\Simulators.Dev.props" />

--- a/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
+++ b/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
+++ b/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CsharpGeneration>false</CsharpGeneration>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CsharpGeneration>false</CsharpGeneration>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1709-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.3017-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.2007.1708-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />


### PR DESCRIPTION
This is the sister PR for microsoft/qsharp-compiler#523, updating the position type in the Q# syntax tree from `int * int` to `Position`.