### PR TITLE
Allow operations in arguments for `GetNonQubitArgumentsAsString`

### DIFF
--- a/src/Simulation/Core/TypeExtensions.cs
+++ b/src/Simulation/Core/TypeExtensions.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Quantum.Simulation.Core
             // If object is an IApplyData, recursively extract arguments
             if (o is IApplyData data)
             {
-                return data.Value.GetNonQubitArgumentsAsString();
+                return data.Value?.GetNonQubitArgumentsAsString();
             }
 
             // If object is a string, enclose it in quotations

--- a/src/Simulation/Core/TypeExtensions.cs
+++ b/src/Simulation/Core/TypeExtensions.cs
@@ -159,6 +159,12 @@ namespace Microsoft.Quantum.Simulation.Core
             // If object is a Qubit, QVoid, or array of Qubits, ignore it (i.e. return null)
             if (o is Qubit || o is QVoid || o is IEnumerable<Qubit>) return null;
 
+            // If object is an ICallable, return its name
+            if (o is ICallable op)
+            {
+                return op.Name;
+            }
+
             // If object is an IApplyData, recursively extract arguments
             if (o is IApplyData data)
             {

--- a/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
@@ -11,6 +11,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
 
     operation Empty () : Unit is Ctl + Adj { }
 
+    operation WrapperOp (op: (Qubit => Unit), q : Qubit) : Unit {
+        op(q);
+        Reset(q);
+    }
+
     operation HOp (q : Qubit) : Unit {
         H(q);
         Reset(q);

--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -411,9 +411,31 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         }
 
         [Fact]
+        public void OperationAsArgument()
+        {
+            var q = new FreeQubit(0);
+            var opArg = new QuantumSimulator().Get<Circuits.HOp>();
+            var op = new QuantumSimulator().Get<Circuits.WrapperOp>();
+            var args = op.__dataIn((opArg, q));
+            var expected = new RuntimeMetadata()
+            {
+                Label = "WrapperOp",
+                FormattedNonQubitArgs = "(HOp)",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = new List<Qubit>() { q },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
+
+        [Fact]
         public void NestedOperation()
         {
-            var measureQubit = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Circuits.NestedOp>();
             var args = op.__dataIn(QVoid.Instance);
             var expected = new RuntimeMetadata()

--- a/src/Simulation/Simulators.Tests/TypeExtensionsTest.cs
+++ b/src/Simulation/Simulators.Tests/TypeExtensionsTest.cs
@@ -34,6 +34,16 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         }
 
         [Fact]
+        public void OperationTypes()
+        {
+            var op = new QuantumSimulator().Get<Intrinsic.H>();
+            Assert.Equal("H", op.GetNonQubitArgumentsAsString());
+
+            var op2 = new QuantumSimulator().Get<Intrinsic.CNOT>();
+            Assert.Equal("CNOT", op2.GetNonQubitArgumentsAsString());
+        }
+
+        [Fact]
         public void QubitTypes()
         {
             var q = new FreeQubit(0);
@@ -58,6 +68,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.Equal("(\"foo\", (\"bar\", \"car\"))", ("foo", ("bar", "car")).GetNonQubitArgumentsAsString());
             Assert.Equal("((\"foo\"), (\"bar\", \"car\"))", (("foo", new FreeQubit(0)), ("bar", "car")).GetNonQubitArgumentsAsString());
 
+            var op = new QuantumSimulator().Get<Intrinsic.H>();
+            var opTuple = new QTuple<(ICallable, string)>((op, "foo"));
+            Assert.Equal("(H, \"foo\")", opTuple.GetNonQubitArgumentsAsString());
+
             var qtuple = new QTuple<(Qubit, string)>((new FreeQubit(0), "foo"));
             Assert.Equal("(\"foo\")", qtuple.GetNonQubitArgumentsAsString());
         }
@@ -68,11 +82,18 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.Equal("[1, 2, 3]", new[] { 1, 2, 3 }.GetNonQubitArgumentsAsString());
             Assert.Equal("[\"foo\", \"bar\"]", new[] { "foo", "bar" }.GetNonQubitArgumentsAsString());
 
-            var arr = new[] {
+            var opArr = new ICallable[] {
+                new QuantumSimulator().Get<Intrinsic.H>(),
+                new QuantumSimulator().Get<Intrinsic.CNOT>(),
+                new QuantumSimulator().Get<Intrinsic.Ry>(),
+            };
+            Assert.Equal("[H, CNOT, Ry]", opArr.GetNonQubitArgumentsAsString());
+
+            var qTupleArr = new[] {
                 (new FreeQubit(0), "foo"),
                 (new FreeQubit(1), "bar"),
             };
-            Assert.Equal("[(\"foo\"), (\"bar\")]", arr.GetNonQubitArgumentsAsString());
+            Assert.Equal("[(\"foo\"), (\"bar\")]", qTupleArr.GetNonQubitArgumentsAsString());
         }
 
         [Fact]
@@ -87,6 +108,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             data = new ApplyData<string>("Foo");
             Assert.Equal("\"Foo\"", data.GetNonQubitArgumentsAsString());
+
+            var op = new QuantumSimulator().Get<Intrinsic.H>();
+            data = new ApplyData<ICallable>(op);
+            Assert.Equal("H", data.GetNonQubitArgumentsAsString());
 
             data = new ApplyData<ValueTuple<int, string>>((1, "foo"));
             Assert.Equal("(1, \"foo\")", data.GetNonQubitArgumentsAsString());


### PR DESCRIPTION
Currently, an `ICallable` in would match the `IApplyData` case in `GetNonQubitArgumentsAsString`. This would throw a `NullException` because its `IApplyData.Value` is `null`. This PR adds a new check for `ICallable`s and returns its name as a string.