### PR TITLE
Make ResetAll a composite operation

### DIFF
--- a/src/Simulation/QsharpCore/Intrinsic.cs
+++ b/src/Simulation/QsharpCore/Intrinsic.cs
@@ -76,4 +76,16 @@ namespace Microsoft.Quantum.Intrinsic
             return null;
         }
     }
+
+    public partial class ResetAll
+    {
+        /// <inheritdoc/>
+        public override RuntimeMetadata? GetRuntimeMetadata(IApplyData args)
+        {
+            var metadata = base.GetRuntimeMetadata(args);
+            if (metadata == null) throw new NullReferenceException($"Null RuntimeMetadata found for {this.ToString()}.");
+            metadata.IsComposite = true;
+            return metadata;
+        }
+    }
 }

--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -298,6 +298,28 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         }
 
         [Fact]
+        public void Reset()
+        {
+            var target = new FreeQubit(0);
+            var op = new QuantumSimulator().Get<Intrinsic.Reset>();
+            var args = op.__dataIn(target);
+            var expected = new RuntimeMetadata()
+            {
+                Label = "Reset",
+                FormattedNonQubitArgs = "",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = new List<Qubit>() { target },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
+
+        [Fact]
         public void ResetAll()
         {
             IQArray<Qubit> targets = new QArray<Qubit>(new[] { new FreeQubit(0) });
@@ -310,7 +332,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 IsAdjoint = false,
                 IsControlled = false,
                 IsMeasurement = false,
-                IsComposite = false,
+                IsComposite = true,
                 Children = null,
                 Controls = new List<Qubit>() { },
                 Targets = targets,


### PR DESCRIPTION
This PR makes `ResetAll` a composite operation so that the ExecutionPathTracer treats it as a composite operation.