### PR TITLE
Remove duplicate qubits from RuntimeMetadata.Targets

### DIFF
--- a/src/Simulation/Core/Operations/Operation.cs
+++ b/src/Simulation/Core/Operations/Operation.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.Simulation.Core
     {
         O Apply(I args);
 
-        ICallable<P,O> Partial<P>(Func<P, I> mapper);
+        ICallable<P, O> Partial<P>(Func<P, I> mapper);
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Simulation.Core
     /// </summary>
     /// <typeparam name="I">Type of input parameters.</typeparam>
     /// <typeparam name="O">Type of return values.</typeparam>
-    [DebuggerTypeProxy(typeof(Operation<,>.DebuggerProxy))]  
+    [DebuggerTypeProxy(typeof(Operation<,>.DebuggerProxy))]
     public abstract class Operation<I, O> : AbstractCallable, ICallable<I, O>
     {
         private Lazy<AdjointedOperation<I, O>> _adjoint;
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
 
         public virtual IApplyData __dataIn(I data) => new QTuple<I>(data);
-                                               
+
         public virtual IApplyData __dataOut(O data) => new QTuple<O>(data);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -78,13 +78,18 @@ namespace Microsoft.Quantum.Simulation.Core
         public ControlledOperation<I, O> Controlled => _controlled.Value;
 
         /// <inheritdoc/>
-        public override RuntimeMetadata? GetRuntimeMetadata(IApplyData args) =>
-            new RuntimeMetadata()
+        public override RuntimeMetadata? GetRuntimeMetadata(IApplyData args)
+        {
+            var targets = args.GetQubits() ?? new List<Qubit>();
+            // Remove duplicate qubits
+            targets = new HashSet<Qubit>(targets).ToList();
+            return new RuntimeMetadata()
             {
                 Label = ((ICallable)this).Name,
                 FormattedNonQubitArgs = args.GetNonQubitArgumentsAsString() ?? "",
-                Targets = args.GetQubits() ?? new List<Qubit>(),
+                Targets = targets,
             };
+        }
 
         public O Apply(I a)
         {
@@ -95,7 +100,7 @@ namespace Microsoft.Quantum.Simulation.Core
                 this.Factory?.StartOperation(this, __dataIn(a));
                 __result__ = this.Body(a);
             }
-            catch( Exception e)
+            catch (Exception e)
             {
                 this.Factory?.Fail(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e));
                 throw;
@@ -105,7 +110,7 @@ namespace Microsoft.Quantum.Simulation.Core
                 this.Factory?.EndOperation(this, __dataOut(__result__));
             }
 
-            return __result__; 
+            return __result__;
         }
 
         public T Partial<T>(object partialInfo)
@@ -212,7 +217,7 @@ namespace Microsoft.Quantum.Simulation.Core
         {
             private Operation<I, O> op;
 
-            public DebuggerProxy(Operation<I,O> op)
+            public DebuggerProxy(Operation<I, O> op)
             {
                 this.op = op;
             }

--- a/src/Simulation/Core/Operations/Operation.cs
+++ b/src/Simulation/Core/Operations/Operation.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Quantum.Simulation.Core
             {
                 Label = ((ICallable)this).Name,
                 FormattedNonQubitArgs = args.GetNonQubitArgumentsAsString() ?? "",
-                Targets = args.GetQubits().Distinct() ?? new List<Qubit>(),
+                Targets = args.GetQubits()?.Distinct() ?? new List<Qubit>(),
             };
 
         public O Apply(I a)

--- a/src/Simulation/Core/Operations/Operation.cs
+++ b/src/Simulation/Core/Operations/Operation.cs
@@ -78,18 +78,13 @@ namespace Microsoft.Quantum.Simulation.Core
         public ControlledOperation<I, O> Controlled => _controlled.Value;
 
         /// <inheritdoc/>
-        public override RuntimeMetadata? GetRuntimeMetadata(IApplyData args)
-        {
-            var targets = args.GetQubits() ?? new List<Qubit>();
-            // Remove duplicate qubits
-            targets = new HashSet<Qubit>(targets).ToList();
-            return new RuntimeMetadata()
+        public override RuntimeMetadata? GetRuntimeMetadata(IApplyData args) =>
+            new RuntimeMetadata()
             {
                 Label = ((ICallable)this).Name,
                 FormattedNonQubitArgs = args.GetNonQubitArgumentsAsString() ?? "",
-                Targets = targets,
+                Targets = args.GetQubits().Distinct() ?? new List<Qubit>(),
             };
-        }
 
         public O Apply(I a)
         {

--- a/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
@@ -26,5 +26,9 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
             HOp(q);
         }
     }
+
+    operation TwoQubitOp (q1 : Qubit, q2 : Qubit) : Unit {
+        // ...
+    }
     
 }

--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -409,7 +409,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             Assert.Equal(op.GetRuntimeMetadata(args), expected);
         }
+    }
 
+    public class CustomCircuitTests
+    {
         [Fact]
         public void EmptyOperation()
         {
@@ -471,6 +474,28 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 Children = null,
                 Controls = new List<Qubit>() { },
                 Targets = new List<Qubit>() { },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
+
+        [Fact]
+        public void DuplicateQubitArgs()
+        {
+            var q = new FreeQubit(0);
+            var op = new QuantumSimulator().Get<Circuits.TwoQubitOp>();
+            var args = op.__dataIn((q, q));
+            var expected = new RuntimeMetadata()
+            {
+                Label = "TwoQubitOp",
+                FormattedNonQubitArgs = "",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = new List<Qubit>() { q },
             };
 
             Assert.Equal(op.GetRuntimeMetadata(args), expected);


### PR DESCRIPTION
This PR fixes a bug where there can be duplicate qubits in `RuntimeMetadata.Targets` if the same qubit is passed in to an operation multiple times.