### PR TITLE
Fix asserts in QubitManager

### DIFF
--- a/src/Simulation/Common/QubitManager.cs
+++ b/src/Simulation/Common/QubitManager.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Quantum.Simulation.Common
             {
                 if (oldQubitsArray[i] == oldNone) {
                     // Point to the first new (free) element
-                    Debug.Assert(false,"Why do we extend an array, when we still have available slots?");
+                    Debug.Assert(!EncourageReuse,"Why do we extend an array, when we still have available slots?");
                     this.qubits[i] = oldNumQubits; 
                 } else if (oldQubitsArray[i] == oldAllocated) {
                     // Allocated qubits are marked differently now.
@@ -133,7 +133,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 freeTail = NumQubits - 1;
             } else
             {
-                Debug.Assert(false, "Why do we extend an array, when we still have available slots?");
+                Debug.Assert(!EncourageReuse, "Why do we extend an array, when we still have available slots?");
             }
         }
 

--- a/src/Simulation/Common/QubitManager.cs
+++ b/src/Simulation/Common/QubitManager.cs
@@ -104,7 +104,6 @@ namespace Microsoft.Quantum.Simulation.Common
             {
                 if (oldQubitsArray[i] == oldNone) {
                     // Point to the first new (free) element
-                    Debug.Assert(!EncourageReuse,"Why do we extend an array, when we still have available slots?");
                     this.qubits[i] = oldNumQubits; 
                 } else if (oldQubitsArray[i] == oldAllocated) {
                     // Allocated qubits are marked differently now.
@@ -131,9 +130,6 @@ namespace Microsoft.Quantum.Simulation.Common
             {
                 free = oldNumQubits;
                 freeTail = NumQubits - 1;
-            } else
-            {
-                Debug.Assert(!EncourageReuse, "Why do we extend an array, when we still have available slots?");
             }
         }
 


### PR DESCRIPTION
Removing the asserts from `ExtendQubitArray` that can now be hit during testing due the new flag added in #320 