### PR TITLE
Wrap generated callable member names with __

### DIFF
--- a/src/Simulation/Common/SimulatorBase.cs
+++ b/src/Simulation/Common/SimulatorBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.Simulation.Common
 
         public virtual void Init(AbstractCallable op)
         {
-            op.Init();
+            op.__Init__();
         }
 
         public override AbstractCallable CreateInstance(Type t)

--- a/src/Simulation/Common/SimulatorBase.cs
+++ b/src/Simulation/Common/SimulatorBase.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 sim = m;
             }
 
-            public override Func<String, QVoid> Body => (msg) =>
+            public override Func<String, QVoid> __Body__ => (msg) =>
             {
                 sim.OnLog?.Invoke(msg);
                 return QVoid.Instance;
@@ -401,7 +401,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 sim = m;
             }
 
-            public override Func<QVoid, long> Body => (arg) => sim.QubitManager.GetFreeQubitsCount();
+            public override Func<QVoid, long> __Body__ => (arg) => sim.QubitManager.GetFreeQubitsCount();
         }
 
         /// <summary>
@@ -416,8 +416,9 @@ namespace Microsoft.Quantum.Simulation.Common
                 sim = m;
             }
 
-            public override Func<QVoid, long> Body => (arg) => sim.QubitManager.GetParentQubitsAvailableToBorrowCount() +
-                                                               sim.QubitManager.GetFreeQubitsCount();
+            public override Func<QVoid, long> __Body__ => (arg) =>
+                sim.QubitManager.GetParentQubitsAvailableToBorrowCount() + 
+                sim.QubitManager.GetFreeQubitsCount();
         }
 
         public virtual void StartOperation(ICallable operation, IApplyData inputValue)

--- a/src/Simulation/Core/AbstractCallable.cs
+++ b/src/Simulation/Core/AbstractCallable.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Core
         /// <summary>
         /// This method is called once, to let the Operation initialize and verify its dependencies.
         /// </summary>
-        public abstract void Init();
+        public abstract void __Init__();
 
         /// <summary>
         /// Retrieves the runtime metadata of the Operation. If the Operation has no associated

--- a/src/Simulation/Core/Functions/Function.cs
+++ b/src/Simulation/Core/Functions/Function.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Quantum.Simulation.Core
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public abstract Func<I, O> Body { get; }
 
-        public virtual IApplyData __dataIn(I data) => new QTuple<I>(data);
+        public virtual IApplyData __DataIn__(I data) => new QTuple<I>(data);
 
-        public virtual IApplyData __dataOut(O data) => new QTuple<O>(data);
+        public virtual IApplyData __DataOut__(O data) => new QTuple<O>(data);
 
         public O Apply(I a)
         {

--- a/src/Simulation/Core/Functions/Function.cs
+++ b/src/Simulation/Core/Functions/Function.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Core
         OperationFunctor ICallable.Variant => OperationFunctor.Body;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public abstract Func<I, O> Body { get; }
+        public abstract Func<I, O> __Body__ { get; }
 
         public virtual IApplyData __DataIn__(I data) => new QTuple<I>(data);
 
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
         public O Apply(I a)
         {
-            var __result__ = this.Body(a);
+            var __result__ = this.__Body__(a);
             return __result__; 
         }
 

--- a/src/Simulation/Core/Functions/FunctionPartial.cs
+++ b/src/Simulation/Core/Functions/FunctionPartial.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Simulation.Core
             this.Mapper = PartialMapper.Create<P, I>(partialTuple);
         }
 
-        public override void Init() { }
+        public override void __Init__() { }
 
         public ICallable<I, O> BaseOp { get; }
 

--- a/src/Simulation/Core/Functions/FunctionPartial.cs
+++ b/src/Simulation/Core/Functions/FunctionPartial.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
         OperationFunctor ICallable.Variant => ((ICallable)this.BaseOp).Variant;
 
-        public override Func<P, O> Body => (a) =>
+        public override Func<P, O> __Body__ => (a) =>
         {
             var args = this.Mapper(a);
             return this.BaseOp.Apply(args);

--- a/src/Simulation/Core/Generics/GenericCallable.cs
+++ b/src/Simulation/Core/Generics/GenericCallable.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Simulation.Core
             _controlled = new Lazy<GenericControlled>(() => new GenericControlled(this));
         }
 
-        public override void Init() { }
+        public override void __Init__() { }
 
         public Type OperationType { get; }
 

--- a/src/Simulation/Core/Generics/GenericCallable.cs
+++ b/src/Simulation/Core/Generics/GenericCallable.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
             // Get the list of Parameters of the Invoke method of the Body of the operation:
             var expectedParameters = this.OperationType
-                .GetProperty("Body").PropertyType
+                .GetProperty("__Body__").PropertyType
                 .GetMethod("Invoke").GetParameters();
 
             // Tuple in...
@@ -171,7 +171,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
             // Tuple out...
             var expectedReturn = this.OperationType
-                .GetProperty("Body").PropertyType
+                .GetProperty("__Body__").PropertyType
                 .GetMethod("Invoke").ReturnType;
             Resolve(expectedReturn, O, typeArgs);
 

--- a/src/Simulation/Core/Operations/Adjoint.cs
+++ b/src/Simulation/Core/Operations/Adjoint.cs
@@ -70,9 +70,9 @@ namespace Microsoft.Quantum.Simulation.Core
 
         IEnumerable<Qubit> IApplyData.Qubits => ((IApplyData)this.BaseOp).Qubits;
 
-        public override IApplyData __dataIn(I data) => this.BaseOp.__dataIn(data);
+        public override IApplyData __DataIn__(I data) => this.BaseOp.__DataIn__(data);
 
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
 
         /// <inheritdoc/>
         public override RuntimeMetadata? GetRuntimeMetadata(IApplyData args)

--- a/src/Simulation/Core/Operations/Adjoint.cs
+++ b/src/Simulation/Core/Operations/Adjoint.cs
@@ -60,13 +60,13 @@ namespace Microsoft.Quantum.Simulation.Core
         string ICallable.FullName => ((ICallable)this.BaseOp).FullName;
         OperationFunctor ICallable.Variant => ((ICallable)this.BaseOp).AdjointVariant();
         
-        public override Func<I, QVoid> Body => this.BaseOp.AdjointBody;
+        public override Func<I, QVoid> __Body__ => this.BaseOp.__AdjointBody__;
 
-        public override Func<I, QVoid> AdjointBody => this.BaseOp.Body;
+        public override Func<I, QVoid> __AdjointBody__ => this.BaseOp.__Body__;
 
-        public override Func<(IQArray<Qubit>, I), QVoid> ControlledBody => this.BaseOp.ControlledAdjointBody;
+        public override Func<(IQArray<Qubit>, I), QVoid> __ControlledBody__ => this.BaseOp.__ControlledAdjointBody__;
                                                  
-        public override Func<(IQArray<Qubit>, I), QVoid> ControlledAdjointBody => this.BaseOp.ControlledBody;
+        public override Func<(IQArray<Qubit>, I), QVoid> __ControlledAdjointBody__ => this.BaseOp.__ControlledBody__;
 
         IEnumerable<Qubit> IApplyData.Qubits => ((IApplyData)this.BaseOp).Qubits;
 

--- a/src/Simulation/Core/Operations/Adjoint.cs
+++ b/src/Simulation/Core/Operations/Adjoint.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Simulation.Core
         public Operation<I, QVoid> BaseOp { get; }
         ICallable IOperationWrapper.BaseOperation => BaseOp;
 
-        public override void Init() { }
+        public override void __Init__() { }
 
         string ICallable.Name => ((ICallable)this.BaseOp).Name;
         string ICallable.FullName => ((ICallable)this.BaseOp).FullName;

--- a/src/Simulation/Core/Operations/Controlled.cs
+++ b/src/Simulation/Core/Operations/Controlled.cs
@@ -109,9 +109,9 @@ namespace Microsoft.Quantum.Simulation.Core
 
         IEnumerable<Qubit> IApplyData.Qubits => ((IApplyData)this.BaseOp).Qubits;
 
-        public override IApplyData __dataIn((IQArray<Qubit>, I) data) => new In((data.Item1, this.BaseOp.__dataIn(data.Item2)));
+        public override IApplyData __DataIn__((IQArray<Qubit>, I) data) => new In((data.Item1, this.BaseOp.__DataIn__(data.Item2)));
 
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
 
         /// <inheritdoc/>
         public override RuntimeMetadata? GetRuntimeMetadata(IApplyData args)
@@ -121,7 +121,7 @@ namespace Microsoft.Quantum.Simulation.Core
             if (args.Value is ValueTuple<IQArray<Qubit>, I> ctrlArgs)
             {
                 var (controls, baseArgs) = ctrlArgs;
-                var baseMetadata = this.BaseOp.GetRuntimeMetadata(this.BaseOp.__dataIn(baseArgs));
+                var baseMetadata = this.BaseOp.GetRuntimeMetadata(this.BaseOp.__DataIn__(baseArgs));
                 if (baseMetadata == null) return null;
                 baseMetadata.IsControlled = true;
                 baseMetadata.Controls = controls.Concat(baseMetadata.Controls);

--- a/src/Simulation/Core/Operations/Controlled.cs
+++ b/src/Simulation/Core/Operations/Controlled.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Quantum.Simulation.Core
         public Operation<I, QVoid> BaseOp { get; }
         ICallable IOperationWrapper.BaseOperation => BaseOp;
 
-        public override void Init() { }
+        public override void __Init__() { }
 
         string ICallable.Name => ((ICallable)this.BaseOp).Name;
         string ICallable.FullName => ((ICallable)this.BaseOp).FullName;

--- a/src/Simulation/Core/Operations/Controlled.cs
+++ b/src/Simulation/Core/Operations/Controlled.cs
@@ -77,11 +77,11 @@ namespace Microsoft.Quantum.Simulation.Core
         string ICallable.FullName => ((ICallable)this.BaseOp).FullName;
         OperationFunctor ICallable.Variant => ((ICallable)this.BaseOp).ControlledVariant();
 
-        public override Func<(IQArray<Qubit>, I), QVoid> Body => this.BaseOp.ControlledBody;
+        public override Func<(IQArray<Qubit>, I), QVoid> __Body__ => this.BaseOp.__ControlledBody__;
 
-        public override Func<(IQArray<Qubit>, I), QVoid> AdjointBody => this.BaseOp.ControlledAdjointBody;
+        public override Func<(IQArray<Qubit>, I), QVoid> __AdjointBody__ => this.BaseOp.__ControlledAdjointBody__;
 
-        public override Func<(IQArray<Qubit>, (IQArray<Qubit>, I)), QVoid> ControlledBody
+        public override Func<(IQArray<Qubit>, (IQArray<Qubit>, I)), QVoid> __ControlledBody__
         {
             get
             {
@@ -89,12 +89,12 @@ namespace Microsoft.Quantum.Simulation.Core
                 {
                     var (ctrl1, (ctrl2, args)) = __in;
                     var ctrls = QArray<Qubit>.Add(ctrl1, ctrl2);
-                    return this.BaseOp.ControlledBody.Invoke((ctrls, args));
+                    return this.BaseOp.__ControlledBody__.Invoke((ctrls, args));
                 };
             }
         }
 
-        public override Func<(IQArray<Qubit>, (IQArray<Qubit>, I)), QVoid> ControlledAdjointBody
+        public override Func<(IQArray<Qubit>, (IQArray<Qubit>, I)), QVoid> __ControlledAdjointBody__
         {
             get
             {
@@ -102,7 +102,7 @@ namespace Microsoft.Quantum.Simulation.Core
                 {
                     var (ctrl1, (ctrl2, args)) = __in;
                     var ctrls = QArray<Qubit>.Add(ctrl1, ctrl2);
-                    return this.BaseOp.ControlledAdjointBody.Invoke((ctrls, args));
+                    return this.BaseOp.__ControlledAdjointBody__.Invoke((ctrls, args));
                 };
             }
         }

--- a/src/Simulation/Core/Operations/Operation.cs
+++ b/src/Simulation/Core/Operations/Operation.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.Simulation.Core
     {
         O Apply(I args);
 
-        ICallable<P,O> Partial<P>(Func<P, I> mapper);
+        ICallable<P, O> Partial<P>(Func<P, I> mapper);
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Simulation.Core
     /// </summary>
     /// <typeparam name="I">Type of input parameters.</typeparam>
     /// <typeparam name="O">Type of return values.</typeparam>
-    [DebuggerTypeProxy(typeof(Operation<,>.DebuggerProxy))]  
+    [DebuggerTypeProxy(typeof(Operation<,>.DebuggerProxy))]
     public abstract class Operation<I, O> : AbstractCallable, ICallable<I, O>
     {
         private Lazy<AdjointedOperation<I, O>> _adjoint;
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
 
         public virtual IApplyData __dataIn(I data) => new QTuple<I>(data);
-                                               
+
         public virtual IApplyData __dataOut(O data) => new QTuple<O>(data);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -83,7 +83,7 @@ namespace Microsoft.Quantum.Simulation.Core
             {
                 Label = ((ICallable)this).Name,
                 FormattedNonQubitArgs = args.GetNonQubitArgumentsAsString() ?? "",
-                Targets = args.GetQubits() ?? new List<Qubit>(),
+                Targets = args.GetQubits()?.Distinct() ?? new List<Qubit>(),
             };
 
         public O Apply(I a)
@@ -95,7 +95,7 @@ namespace Microsoft.Quantum.Simulation.Core
                 this.Factory?.StartOperation(this, __dataIn(a));
                 __result__ = this.Body(a);
             }
-            catch( Exception e)
+            catch (Exception e)
             {
                 this.Factory?.Fail(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e));
                 throw;
@@ -105,7 +105,7 @@ namespace Microsoft.Quantum.Simulation.Core
                 this.Factory?.EndOperation(this, __dataOut(__result__));
             }
 
-            return __result__; 
+            return __result__;
         }
 
         public T Partial<T>(object partialInfo)
@@ -212,7 +212,7 @@ namespace Microsoft.Quantum.Simulation.Core
         {
             private Operation<I, O> op;
 
-            public DebuggerProxy(Operation<I,O> op)
+            public DebuggerProxy(Operation<I, O> op)
             {
                 this.op = op;
             }

--- a/src/Simulation/Core/Operations/Operation.cs
+++ b/src/Simulation/Core/Operations/Operation.cs
@@ -60,16 +60,16 @@ namespace Microsoft.Quantum.Simulation.Core
         public virtual IApplyData __DataOut__(O data) => new QTuple<O>(data);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public abstract Func<I, O> Body { get; }
+        public abstract Func<I, O> __Body__ { get; }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public virtual Func<I, QVoid> AdjointBody => throw new NotImplementedException();
+        public virtual Func<I, QVoid> __AdjointBody__ => throw new NotImplementedException();
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public virtual Func<(IQArray<Qubit>, I), QVoid> ControlledBody => throw new NotImplementedException();
+        public virtual Func<(IQArray<Qubit>, I), QVoid> __ControlledBody__ => throw new NotImplementedException();
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public virtual Func<(IQArray<Qubit>, I), QVoid> ControlledAdjointBody => throw new NotImplementedException();
+        public virtual Func<(IQArray<Qubit>, I), QVoid> __ControlledAdjointBody__ => throw new NotImplementedException();
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public AdjointedOperation<I, O> Adjoint => _adjoint.Value;
@@ -93,7 +93,7 @@ namespace Microsoft.Quantum.Simulation.Core
             try
             {
                 this.Factory?.StartOperation(this, __DataIn__(a));
-                __result__ = this.Body(a);
+                __result__ = this.__Body__(a);
             }
             catch (Exception e)
             {

--- a/src/Simulation/Core/Operations/Operation.cs
+++ b/src/Simulation/Core/Operations/Operation.cs
@@ -55,9 +55,9 @@ namespace Microsoft.Quantum.Simulation.Core
         OperationFunctor ICallable.Variant => OperationFunctor.Body;
 
 
-        public virtual IApplyData __dataIn(I data) => new QTuple<I>(data);
+        public virtual IApplyData __DataIn__(I data) => new QTuple<I>(data);
 
-        public virtual IApplyData __dataOut(O data) => new QTuple<O>(data);
+        public virtual IApplyData __DataOut__(O data) => new QTuple<O>(data);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public abstract Func<I, O> Body { get; }
@@ -92,7 +92,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
             try
             {
-                this.Factory?.StartOperation(this, __dataIn(a));
+                this.Factory?.StartOperation(this, __DataIn__(a));
                 __result__ = this.Body(a);
             }
             catch (Exception e)
@@ -102,7 +102,7 @@ namespace Microsoft.Quantum.Simulation.Core
             }
             finally
             {
-                this.Factory?.EndOperation(this, __dataOut(__result__));
+                this.Factory?.EndOperation(this, __DataOut__(__result__));
             }
 
             return __result__;

--- a/src/Simulation/Core/Operations/OperationPartial.cs
+++ b/src/Simulation/Core/Operations/OperationPartial.cs
@@ -74,35 +74,35 @@ namespace Microsoft.Quantum.Simulation.Core
 
         public override IApplyData __DataOut__(O data) => this.BaseOp.__DataOut__(data);
 
-        public override Func<P, O> Body => (a) =>
+        public override Func<P, O> __Body__ => (a) =>
         {
             var args = this.Mapper(a);
-            return this.BaseOp.Body.Invoke(args);
+            return this.BaseOp.__Body__.Invoke(args);
         };
 
-        public override Func<P, QVoid> AdjointBody => (a) =>
+        public override Func<P, QVoid> __AdjointBody__ => (a) =>
         {
             Debug.Assert(typeof(O) == typeof(QVoid));
             var op = this.BaseOp;
 
             var args = this.Mapper(a);
-            return op.AdjointBody.Invoke(args);
+            return op.__AdjointBody__.Invoke(args);
         };
 
-        public override Func<(IQArray<Qubit>, P), QVoid> ControlledBody => (a) =>
+        public override Func<(IQArray<Qubit>, P), QVoid> __ControlledBody__ => (a) =>
         {
             Debug.Assert(typeof(O) == typeof(QVoid));
             var op = this.BaseOp;
             var (ctrl, ps) = a;
-            return op.ControlledBody.Invoke((ctrl, this.Mapper(ps)));
+            return op.__ControlledBody__.Invoke((ctrl, this.Mapper(ps)));
         };
 
-        public override Func<(IQArray<Qubit>, P), QVoid> ControlledAdjointBody => (a) =>
+        public override Func<(IQArray<Qubit>, P), QVoid> __ControlledAdjointBody__ => (a) =>
         {
             Debug.Assert(typeof(O) == typeof(QVoid));
             var op = this.BaseOp;
             var (ctrl, ps) = a;
-            return op.ControlledAdjointBody.Invoke((ctrl, this.Mapper(ps)));
+            return op.__ControlledAdjointBody__.Invoke((ctrl, this.Mapper(ps)));
         };
 
         IEnumerable<Qubit> IApplyData.Qubits => __qubits.Value;

--- a/src/Simulation/Core/Operations/OperationPartial.cs
+++ b/src/Simulation/Core/Operations/OperationPartial.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Simulation.Core
             this.__qubits = new Lazy<Qubit[]>(() => op?.__dataIn(this.Mapper(default(P)))?.Qubits?.ToArray());
         }
 
-        public override void Init() { }
+        public override void __Init__() { }
 
         public Operation<I, O> BaseOp { get; }
         ICallable IOperationWrapper.BaseOperation => BaseOp;

--- a/src/Simulation/Core/Operations/OperationPartial.cs
+++ b/src/Simulation/Core/Operations/OperationPartial.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
             public In(Operation<I, O> op, Func<P, I> mapper, P data)
             {
-                this.__data = new Lazy<IApplyData>(() => op?.__dataIn(mapper(data)));
+                this.__data = new Lazy<IApplyData>(() => op?.__DataIn__(mapper(data)));
             }
 
             public object Value => __data.Value.Value;
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
             this.BaseOp = op;
             this.Mapper = mapper;
-            this.__qubits = new Lazy<Qubit[]>(() => op?.__dataIn(mapper(default(P)))?.Qubits?.ToArray());
+            this.__qubits = new Lazy<Qubit[]>(() => op?.__DataIn__(mapper(default(P)))?.Qubits?.ToArray());
         }
 
         public OperationPartial(Operation<I, O> op, object partialTuple) : base(op.Factory)
@@ -55,7 +55,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
             this.BaseOp = op;
             this.Mapper = PartialMapper.Create<P, I>(partialTuple);
-            this.__qubits = new Lazy<Qubit[]>(() => op?.__dataIn(this.Mapper(default(P)))?.Qubits?.ToArray());
+            this.__qubits = new Lazy<Qubit[]>(() => op?.__DataIn__(this.Mapper(default(P)))?.Qubits?.ToArray());
         }
 
         public override void __Init__() { }
@@ -70,9 +70,9 @@ namespace Microsoft.Quantum.Simulation.Core
 
         OperationFunctor ICallable.Variant => ((ICallable)this.BaseOp).Variant;
 
-        public override IApplyData __dataIn(P data) => new In(this.BaseOp, this.Mapper, data);
+        public override IApplyData __DataIn__(P data) => new In(this.BaseOp, this.Mapper, data);
 
-        public override IApplyData __dataOut(O data) => this.BaseOp.__dataOut(data);
+        public override IApplyData __DataOut__(O data) => this.BaseOp.__DataOut__(data);
 
         public override Func<P, O> Body => (a) =>
         {

--- a/src/Simulation/Core/Udts/UdtFactory.cs
+++ b/src/Simulation/Core/Udts/UdtFactory.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.Simulation.Core
 
         public ICallable Partial(object partialTuple) => this.Partial<ICallable>(partialTuple);
 
-        public override void Init()
+        public override void __Init__()
         { }
     }
 }

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -1189,22 +1189,22 @@ namespace N1
     let ``usesGenerics body`` () =
         [
             "var a = (IQArray<Result>)new QArray<Result>(Result.One, Result.Zero, Result.Zero);"
-            "var s = (IQArray<String>)new QArray<String>(ResultToString.Apply(a[0L]), ResultToString.Apply(a[1L]));"
-            "MicrosoftQuantumTestingnoOpResult.Apply(a[0L]);"
+            "var s = (IQArray<String>)new QArray<String>(__ResultToString__.Apply(a[0L]), __ResultToString__.Apply(a[1L]));"
+            "__MicrosoftQuantumTestingnoOpResult__.Apply(a[0L]);"
 
             """
             {
-                var qubits = Allocate.Apply(3L);
+                var qubits = __Allocate__.Apply(3L);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    var op = MicrosoftQuantumTestingHold.Partial(new Func<QVoid,(ICallable,(Qubit,Qubit),QVoid)>((__arg2__) => (CNOT, (qubits[0L], qubits[1L]), __arg2__)));
+                    var op = __MicrosoftQuantumTestingHold__.Partial(new Func<QVoid,(ICallable,(Qubit,Qubit),QVoid)>((__arg2__) => (__CNOT__, (qubits[0L], qubits[1L]), __arg2__)));
                     op.Apply(QVoid.Instance);
 
-                    MicrosoftQuantumTestingnoOpGeneric.Apply(qubits[0L]);
-                    MicrosoftQuantumTestingnoOpGeneric.Apply(a[0L]);
-                    genIter.Apply((X, qubits));
+                    __MicrosoftQuantumTestingnoOpGeneric__.Apply(qubits[0L]);
+                    __MicrosoftQuantumTestingnoOpGeneric__.Apply(a[0L]);
+                    __genIter__.Apply((__X__, qubits));
                 }
 #line hidden
                 catch
@@ -1217,17 +1217,17 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        Release.Apply(qubits);
+                        __Release__.Apply(qubits);
                     }
                 }
             }
             """
-            "genIter.Apply((MicrosoftQuantumTestingnoOpResult, a));"
+            "__genIter__.Apply((__MicrosoftQuantumTestingnoOpResult__, a));"
             """
-            genIter.Apply((genU1, genMapper.Apply<IQArray<String>>((ResultToString, a))));
+            __genIter__.Apply((__genU1__, __genMapper__.Apply<IQArray<String>>((__ResultToString__, a))));
             """
-            "genIter.Apply((genU1, s));"
-            "genIter.Apply((genU1, a));"
+            "__genIter__.Apply((__genU1__, s));"
+            "__genIter__.Apply((__genU1__, a));"
         ]
         |> testOneBody (applyVisitor usesGenerics)
 

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -861,10 +861,10 @@ namespace N1
             let context  = createTestContext op
             let deps     = op   |> operationDependencies |> depsByName
             let actual   = deps |> buildInit context |> formatSyntaxTree
-            let expected = sprintf "public override void Init() { %s }" (String.concat "" body)
+            let expected = sprintf "public override void __Init__() { %s }" (String.concat "" body)
             Assert.Equal (expected |> clearFormatting, actual |> clearFormatting)
 
-        let template = sprintf "this.%s = this.Factory.Get<%s>(typeof(%s));"
+        let template = sprintf "this.__%s__ = this.Factory.Get<%s>(typeof(%s));"
         [
         ]
         |> testOne emptyOperation
@@ -909,7 +909,7 @@ namespace N1
 
         [
             template "Z"                                    "IUnitary<Qubit>"                   "Microsoft.Quantum.Intrinsic.Z"
-            "this.self = this;"
+            "this.__self__ = this;"
         ]
         |> testOne selfInvokingOperation
 
@@ -978,7 +978,7 @@ namespace N1
                 |> List.map formatSyntaxTree
             List.zip (expected |> List.map clearFormatting) (actual  |> List.map clearFormatting) |> List.iter Assert.Equal
 
-        let template = sprintf @"protected %s %s { get; set; }"
+        let template = sprintf @"protected %s __%s__ { get; set; }"
 
         [
             template "Allocate"                     "Allocate"
@@ -1094,38 +1094,38 @@ namespace N1
         |> testOne (applyVisitor zeroQubitOperation)
 
         [
-            "X.Apply(q1);"
+            "__X__.Apply(q1);"
         ]
         |> testOne (applyVisitor oneQubitOperation)
 
         [
-            "X.Adjoint.Apply(q1);"
+            "__X__.Adjoint.Apply(q1);"
         ]
         |> testOne (adjointVisitor oneQubitOperation)
 
         [
             "var (q2, r) = t1;        "
-            "CNOT.Apply((q1,q2));       "
-            "R.Apply((r,q1));           "
+            "__CNOT__.Apply((q1,q2));       "
+            "__R__.Apply((r,q1));           "
         ]
         |> testOne (applyVisitor twoQubitOperation)
         [
             "var (q2, r) = t1;        "
-            "R.Adjoint.Apply((r,q1));"
-            "CNOT.Adjoint.Apply((q1,q2));"
+            "__R__.Adjoint.Apply((r,q1));"
+            "__CNOT__.Adjoint.Apply((q1,q2));"
         ]
         |> testOne (adjointVisitor twoQubitOperation)
 
         [
-            "three_op1.Apply((q1,q2));"
-            "three_op1.Apply((q2,q1));"
-            "three_op1.Apply((q1,q2));"
+            "__three_op1__.Apply((q1,q2));"
+            "__three_op1__.Apply((q2,q1));"
+            "__three_op1__.Apply((q1,q2));"
         ]
         |> testOne (applyVisitor threeQubitOperation)
 
         [
-            "Z.Adjoint.Apply(q1);"
-            "self.Apply(q1);"
+            "__Z__.Adjoint.Apply(q1);"
+            "__self__.Apply(q1);"
         ]
         |> testOne (adjointVisitor selfInvokingOperation)
 
@@ -1141,7 +1141,7 @@ namespace N1
             }
             else
             {
-                return self.Apply<__T__>((x, (cnt - 1L)));
+                return __self__.Apply<__T__>((x, (cnt - 1L)));
             }
             """
         ]
@@ -1155,7 +1155,7 @@ namespace N1
             }
             else
             {
-                return (x * self.Apply<Int64>((x - 1L)));
+                return (x * __self__.Apply<Int64>((x - 1L)));
             }
             """
         ]
@@ -1166,7 +1166,7 @@ namespace N1
         let testOne = testOneBody
 
         [
-            "X.Apply(q1);"
+            "__X__.Apply(q1);"
         ]
         |> testOne (applyVisitor oneQubitOperation)
 
@@ -1180,7 +1180,7 @@ namespace N1
         |> testOne (applyVisitor composeImpl)
 
         [
-            "return composeImpl.Partial((second, first, _));"
+            "return __composeImpl__.Partial((second, first, _));"
         ]
         |> testOne (applyVisitor compose)
 
@@ -1235,20 +1235,20 @@ namespace N1
     [<Fact>]
     let ``callTests body`` () =
         [
-            "var plain = new call_plain(X);"
-            "var adj   = new call_adj(X);"
-            "var ctr   = new call_ctr(X);"
-            "var uni   = new call_uni(X);"
+            "var plain = new call_plain(__X__);"
+            "var adj   = new call_adj(__X__);"
+            "var ctr   = new call_ctr(__X__);"
+            "var uni   = new call_uni(__X__);"
 
-            "X.Apply(qubits.Data[0L]);"
-            "X.Adjoint.Apply(qubits.Data[0L]);"
-            "X.Controlled.Apply((qubits.Data?.Slice(new QRange(1L,5L)), qubits.Data[0L]));"
+            "__X__.Apply(qubits.Data[0L]);"
+            "__X__.Adjoint.Apply(qubits.Data[0L]);"
+            "__X__.Controlled.Apply((qubits.Data?.Slice(new QRange(1L,5L)), qubits.Data[0L]));"
 
-            "call_target1.Apply((1L, X,     X,   X,   X));"
-            "call_target1.Apply((1L, plain.Data, adj.Data, ctr.Data, uni.Data));"
+            "__call_target1__.Apply((1L, __X__,     __X__,   __X__,   __X__));"
+            "__call_target1__.Apply((1L, plain.Data, adj.Data, ctr.Data, uni.Data));"
 
-            "call_target2.Apply((1L, (Result.Zero, X),    (Result.Zero, X),  (Result.Zero, X),  (Result.Zero, X)));"
-            "call_target2.Apply((2L, (Result.One, plain.Data), (Result.One, adj.Data), (Result.One, ctr.Data), (Result.One, uni.Data)));"
+            "__call_target2__.Apply((1L, (Result.Zero, __X__),    (Result.Zero, __X__),  (Result.Zero, __X__),  (Result.Zero, __X__)));"
+            "__call_target2__.Apply((2L, (Result.One, plain.Data), (Result.One, adj.Data), (Result.One, ctr.Data), (Result.One, uni.Data)));"
         ]
         |> testOneBody (applyVisitor callTests)
 
@@ -1258,7 +1258,7 @@ namespace N1
         [
             "var q2 = q1;"
 
-            "var r = M.Apply(q1);"
+            "var r = __M__.Apply(q1);"
 
             "var i = 1.1D;"
             "var iZero = 0L;"
@@ -1291,7 +1291,7 @@ namespace N1
             "var __arg1__ = t;"
             "var __arg2__ = t;"
 
-            "return let_f0.Apply(n);"
+            "return __let_f0__.Apply(n);"
         ]
         |> testOneBody (applyVisitor letsOperations)
 
@@ -1334,7 +1334,7 @@ namespace N1
             """
             if ((r == Result.One))
             {
-                n = (if_f0.Apply(QVoid.Instance) * i);
+                n = (__if_f0__.Apply(QVoid.Instance) * i);
             }
             """
             """
@@ -1358,7 +1358,7 @@ namespace N1
             }
             else
             {
-                return ((p==Pauli.PauliI)?3L:if_f0.Apply(QVoid.Instance));
+                return ((p==Pauli.PauliI)?3L:__if_f0__.Apply(QVoid.Instance));
             }
             """
         ]
@@ -1382,7 +1382,7 @@ namespace N1
             @"foreach (var n in range)
             #line hidden
             {
-                result = ((range.End + result) + (n * -(foreach_f2.Apply((n, 4L)))));
+                result = ((range.End + result) + (n * -(__foreach_f2__.Apply((n, 4L)))));
             }"
             """
             if ((result > 10L))
@@ -1420,7 +1420,7 @@ namespace N1
     [<Fact>]
     let ``test Length dependency`` () =
         [
-            "iter.Apply((Length, new QArray<IQArray<Result>>(new QArray<Result>(Result.One), new QArray<Result>(Result.Zero, Result.One))));"
+            "__iter__.Apply((__Length__, new QArray<IQArray<Result>>(new QArray<Result>(Result.One), new QArray<Result>(Result.Zero, Result.One))));"
         ]
         |> testOneBody (applyVisitor testLengthDependency)
 
@@ -1481,22 +1481,22 @@ namespace N1
         [
             """
             {
-                var qubits = Allocate.Apply(i);
+                var qubits = __Allocate__.Apply(i);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
                     while (true)
                     {
-                        var res =  repeat_op0.Apply(new repeat_udt0((0L, qubits)));
+                        var res =  __repeat_op0__.Apply(new repeat_udt0((0L, qubits)));
 
-                        if ((repeat_op1.Apply((0L, qubits)) == Result.One))
+                        if ((__repeat_op1__.Apply((0L, qubits)) == Result.One))
                         {
                             break;
                         }
                         else
                         {
-                            res = repeat_op2.Apply((3D, new repeat_udt0(((i-1L), qubits))));
+                            res = __repeat_op2__.Apply((3D, new repeat_udt0(((i-1L), qubits))));
                         }
                     }
                 }
@@ -1511,7 +1511,7 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        Release.Apply(qubits);
+                        __Release__.Apply(qubits);
                     }
                 }
             }
@@ -1524,14 +1524,14 @@ namespace N1
         [
             """
             {
-                var q = Allocate.Apply();
+                var q = __Allocate__.Apply();
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
                     var flag = true;
-                    (flag ? X : Z).Apply(q);
-                    alloc_op0.Apply(q);
+                    (flag ? __X__ : __Z__).Apply(q);
+                    __alloc_op0__.Apply(q);
                 }
 #line hidden
                 catch
@@ -1544,18 +1544,18 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        Release.Apply(q);
+                        __Release__.Apply(q);
                     }
                 }
             }"""
             """
             {
-                var qs = Allocate.Apply(n);
+                var qs = __Allocate__.Apply(n);
 #line hidden
                 bool __arg2__ = true;
                 try
                 {
-                    alloc_op0.Apply(qs[(n-1L)]);
+                    __alloc_op0__.Apply(qs[(n-1L)]);
                 }
 #line hidden
                 catch
@@ -1568,19 +1568,19 @@ namespace N1
                 {
                     if (__arg2__)
                     {
-                        Release.Apply(qs);
+                        __Release__.Apply(qs);
                     }
                 }
             }"""
             """
             {
-                var (q1, (q2, (__arg3__, q3, __arg4__, q4))) = (Allocate.Apply(), ((Allocate.Apply(), Allocate.Apply(2L)), (Allocate.Apply(), Allocate.Apply(n), Allocate.Apply((n-1L)), Allocate.Apply(4L))));
+                var (q1, (q2, (__arg3__, q3, __arg4__, q4))) = (__Allocate__.Apply(), ((__Allocate__.Apply(), __Allocate__.Apply(2L)), (__Allocate__.Apply(), __Allocate__.Apply(n), __Allocate__.Apply((n-1L)), __Allocate__.Apply(4L))));
 #line hidden
                 bool __arg5__ = true;
                 try
                 {
-                    alloc_op0.Apply(q1);
-                    alloc_op0.Apply(q3[1L]);
+                    __alloc_op0__.Apply(q1);
+                    __alloc_op0__.Apply(q3[1L]);
                 }
 #line hidden
                 catch
@@ -1593,13 +1593,13 @@ namespace N1
                 {
                     if (__arg5__)
                     {
-                        Release.Apply(q1);
-                        Release.Apply(q2.Item1);
-                        Release.Apply(q2.Item2);
-                        Release.Apply(__arg3__);
-                        Release.Apply(q3);
-                        Release.Apply(__arg4__);
-                        Release.Apply(q4);
+                        __Release__.Apply(q1);
+                        __Release__.Apply(q2.Item1);
+                        __Release__.Apply(q2.Item2);
+                        __Release__.Apply(__arg3__);
+                        __Release__.Apply(q3);
+                        __Release__.Apply(__arg4__);
+                        __Release__.Apply(q4);
                     }
                 }
             }"""
@@ -1609,12 +1609,12 @@ namespace N1
         [
             """
             {
-                var b = Borrow.Apply(n);
+                var b = __Borrow__.Apply(n);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    alloc_op0.Apply(b[(n-1L)]);
+                    __alloc_op0__.Apply(b[(n-1L)]);
                 }
 #line hidden
                 catch
@@ -1627,25 +1627,25 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        Return.Apply(b);
+                        __Return__.Apply(b);
                     }
                 }
             }"""
             """
             {
-                var (q1, (q2, (__arg2__, q3))) = (Borrow.Apply(), (Borrow.Apply(2L), (Borrow.Apply(), (Borrow.Apply(n), Borrow.Apply(4L)))));
+                var (q1, (q2, (__arg2__, q3))) = (__Borrow__.Apply(), (__Borrow__.Apply(2L), (__Borrow__.Apply(), (__Borrow__.Apply(n), __Borrow__.Apply(4L)))));
 #line hidden
                 bool __arg3__ = true;
                 try
                 {
                     {
-                        var qt = (Allocate.Apply(), (Allocate.Apply(1L), Allocate.Apply(2L)));
+                        var qt = (__Allocate__.Apply(), (__Allocate__.Apply(1L), __Allocate__.Apply(2L)));
 #line hidden
                         bool __arg4__ = true;
                         try
                         {
                             var (qt1, qt2) = ((Qubit, (IQArray<Qubit>, IQArray<Qubit>)))qt;
-                            alloc_op0.Apply(qt1);
+                            __alloc_op0__.Apply(qt1);
                         }
 #line hidden
                         catch
@@ -1658,15 +1658,15 @@ namespace N1
                         {
                             if (__arg4__)
                             {
-                                Release.Apply(qt.Item1);
-                                Release.Apply(qt.Item2.Item1);
-                                Release.Apply(qt.Item2.Item2);
+                                __Release__.Apply(qt.Item1);
+                                __Release__.Apply(qt.Item2.Item1);
+                                __Release__.Apply(qt.Item2.Item2);
                             }
                         }
                     }
 
-                    alloc_op0.Apply(q1);
-                    alloc_op0.Apply(q2[1L]);
+                    __alloc_op0__.Apply(q1);
+                    __alloc_op0__.Apply(q2[1L]);
                 }
 #line hidden
                 catch
@@ -1679,11 +1679,11 @@ namespace N1
                 {
                     if (__arg3__)
                     {
-                        Return.Apply(q1);
-                        Return.Apply(q2);
-                        Return.Apply(__arg2__);
-                        Return.Apply(q3.Item1);
-                        Return.Apply(q3.Item2);
+                        __Return__.Apply(q1);
+                        __Return__.Apply(q2);
+                        __Return__.Apply(__arg2__);
+                        __Return__.Apply(q3.Item1);
+                        __Return__.Apply(q3.Item2);
                     }
                 }
             }"""
@@ -1732,7 +1732,7 @@ namespace N1
         |> testOne randomAbstractOperation
 
         Some """
-        public override Func<QVoid,QVoid> Body => (__in__) =>
+        public override Func<QVoid,QVoid> __Body__ => (__in__) =>
         {
             #line hidden
             return QVoid.Instance;
@@ -1740,11 +1740,11 @@ namespace N1
         |> testOne zeroQubitOperation
 
         Some """
-        public override Func<Qubit,QVoid> Body => (__in__) =>
+        public override Func<Qubit,QVoid> __Body__ => (__in__) =>
         {
             var q1 = __in__;
 
-            X.Apply(q1);
+            __X__.Apply(q1);
             #line hidden
             return  QVoid.Instance;
         };
@@ -1752,14 +1752,14 @@ namespace N1
         |> testOne oneQubitOperation
 
         Some """
-        public override Func<(Qubit,(Qubit,Double)), QVoid> Body => (__in__) =>
+        public override Func<(Qubit,(Qubit,Double)), QVoid> __Body__ => (__in__) =>
         {
             var (q1,t1) = __in__;
 
             var (q2,r) = t1;
 
-            CNOT.Apply((q1, q2));
-            R.Apply((r, q1));
+            __CNOT__.Apply((q1, q2));
+            __R__.Apply((r, q1));
 
             #line hidden
             return  QVoid.Instance;
@@ -1769,14 +1769,14 @@ namespace N1
 
 
         Some """
-        public override Func<(Qubit,Qubit,IQArray<Qubit>), QVoid> Body => (__in__) =>
+        public override Func<(Qubit,Qubit,IQArray<Qubit>), QVoid> __Body__ => (__in__) =>
         {
             var (q1,q2,arr1) = __in__;
 
-            da_op0.Apply(QVoid.Instance);
-            da_op1.Adjoint.Apply(q1);
-            da_op2.Controlled.Apply((new QArray<Qubit>(q1), (1L, q2)));
-            da_op3.Controlled.Adjoint.Apply((new QArray<Qubit>(q1, q2), (1.1D, Result.One, arr1.Length)));
+            __da_op0__.Apply(QVoid.Instance);
+            __da_op1__.Adjoint.Apply(q1);
+            __da_op2__.Controlled.Apply((new QArray<Qubit>(q1), (1L, q2)));
+            __da_op3__.Controlled.Adjoint.Apply((new QArray<Qubit>(q1, q2), (1.1D, Result.One, arr1.Length)));
 
             #line hidden
             return QVoid.Instance;
@@ -1796,10 +1796,10 @@ namespace N1
         let op4 = "IUnitary";
         let f1  = "ICallable"
         Some (sprintf """
-        public override Func<(Qubit, %s, %s, %s, (%s, %s), %s), %s> Body  => (__in__) =>
+        public override Func<(Qubit, %s, %s, %s, (%s, %s), %s), %s> __Body__  => (__in__) =>
                 {
                     var (q1, op0, op1, op2, t1, f1) = __in__;
-                    op1.Apply(OP_1);
+                    op1.Apply(__OP_1__);
                     var v0 = op0;
                     var r0 = v0.Apply<Result>(q1);
                     var (op3, op4) = t1;
@@ -1863,7 +1863,7 @@ namespace N1
             "var s1 = (IQArray<Qubit>)qubits?.Slice(new QRange(0L,10L));"
             "var s2 = (IQArray<Qubit>)qubits?.Slice(r2);"
             "var s3 = (IQArray<Qubit>)qubits?.Slice(ranges[3L]);"
-            "var s4 = (IQArray<Qubit>)qubits?.Slice(GetMeARange.Apply(QVoid.Instance));"
+            "var s4 = (IQArray<Qubit>)qubits?.Slice(__GetMeARange__.Apply(QVoid.Instance));"
 
             "return qubits?.Slice(new QRange(10L,-(3L),0L));"
         ]
@@ -1925,17 +1925,17 @@ namespace N1
         None
         |> testOne oneQubitAbstractOperation
 
-        Some "public override Func<Qubit, QVoid> AdjointBody  => Body;"
+        Some "public override Func<Qubit, QVoid> __AdjointBody__ => __Body__;"
         |> testOne oneQubitSelfAdjointAbstractOperation
 
         None
         |> testOne randomAbstractOperation
 
-        Some "public override Func<Qubit, QVoid> AdjointBody => Body;"
+        Some "public override Func<Qubit, QVoid> __AdjointBody__ => __Body__;"
         |> testOne oneQubitSelfAdjointOperation
 
         Some """
-        public override Func<QVoid, QVoid> AdjointBody => (__in__) =>
+        public override Func<QVoid, QVoid> __AdjointBody__ => (__in__) =>
         {
             #line hidden
             return QVoid.Instance;
@@ -1943,10 +1943,10 @@ namespace N1
         |> testOne zeroQubitOperation
 
         Some """
-        public override Func<Qubit, QVoid> AdjointBody => (__in__) =>
+        public override Func<Qubit, QVoid> __AdjointBody__ => (__in__) =>
         {
             var q1 = __in__;
-            X.Adjoint.Apply(q1);
+            __X__.Adjoint.Apply(q1);
 
             #line hidden
             return QVoid.Instance;
@@ -1954,14 +1954,14 @@ namespace N1
         |> testOne oneQubitOperation
 
         Some """
-        public override Func<(Qubit,(Qubit,Double)), QVoid> AdjointBody => (__in__) =>
+        public override Func<(Qubit,(Qubit,Double)), QVoid> __AdjointBody__ => (__in__) =>
         {
             var (q1,t1) = __in__;
 
             var (q2,r) = t1;
 
-            R.Adjoint.Apply((r, q1));
-            CNOT.Adjoint.Apply((q1, q2));
+            __R__.Adjoint.Apply((r, q1));
+            __CNOT__.Adjoint.Apply((q1, q2));
 
             #line hidden
             return QVoid.Instance;
@@ -1969,19 +1969,19 @@ namespace N1
         |> testOne twoQubitOperation
 
         Some """
-        public override Func<(Qubit,Qubit,Qubits), QVoid> AdjointBody => (__in__) =>
+        public override Func<(Qubit,Qubit,Qubits), QVoid> __AdjointBody__ => (__in__) =>
         {
             var (q1,q2,arr1) = __in__;
-            three_op1.Adjoint.Apply((q1, q2));
-            three_op1.Adjoint.Apply((q2, q1));
-            three_op1.Adjoint.Apply((q1, q2));
+            __three_op1__.Adjoint.Apply((q1, q2));
+            __three_op1__.Adjoint.Apply((q2, q1));
+            __three_op1__.Adjoint.Apply((q1, q2));
             #line hidden
             return QVoid.Instance;
         };"""
         |> testOne threeQubitOperation
 
 
-        Some "public override Func<__T__, QVoid> AdjointBody => Body;"
+        Some "public override Func<__T__, QVoid> __AdjointBody__ => __Body__;"
         |> testOne genAdj1
 
     [<Fact>]
@@ -1998,7 +1998,7 @@ namespace N1
         |> testOne randomAbstractOperation
 
         Some """
-        public override Func<(IQArray<Qubit>,QVoid), QVoid> ControlledBody => (__in__) =>
+        public override Func<(IQArray<Qubit>,QVoid), QVoid> __ControlledBody__ => (__in__) =>
         {
             var (__controlQubits__, __unitArg__) = __in__;
 
@@ -2008,11 +2008,11 @@ namespace N1
         |> testOne zeroQubitOperation
 
         Some """
-        public override Func<(IQArray<Qubit>,Qubit), QVoid> ControlledBody => (__in__) =>
+        public override Func<(IQArray<Qubit>,Qubit), QVoid> __ControlledBody__ => (__in__) =>
         {
             var (c, q1) = __in__;
 
-            X.Controlled.Apply((c, q1));
+            __X__.Controlled.Apply((c, q1));
 
             #line hidden
             return QVoid.Instance;
@@ -2020,13 +2020,13 @@ namespace N1
         |> testOne oneQubitOperation
 
         Some """
-        public override Func<(IQArray<Qubit>,(Qubit,Qubit,Qubits)), QVoid> ControlledBody => (__in__) =>
+        public override Func<(IQArray<Qubit>,(Qubit,Qubit,Qubits)), QVoid> __ControlledBody__ => (__in__) =>
         {
             var (c, (q1, q2, arr1)) = __in__;
 
-            three_op1.Controlled.Apply((c, (q1, q2)));
-            three_op1.Controlled.Apply((c, (q2, q1)));
-            three_op1.Controlled.Apply((c, (q1, q2)));
+            __three_op1__.Controlled.Apply((c, (q1, q2)));
+            __three_op1__.Controlled.Apply((c, (q2, q1)));
+            __three_op1__.Controlled.Apply((c, (q1, q2)));
 
             #line hidden
             return QVoid.Instance;
@@ -2040,14 +2040,14 @@ namespace N1
         None
         |> testOne oneQubitAbstractOperation
 
-        Some "public override Func<(IQArray<Qubit>,Qubit), QVoid> ControlledAdjointBody  => ControlledBody;"
+        Some "public override Func<(IQArray<Qubit>,Qubit), QVoid> __ControlledAdjointBody__ => __ControlledBody__;"
         |> testOne oneQubitSelfAdjointAbstractOperation
 
         None
         |> testOne randomAbstractOperation
 
         Some """
-        public override Func<(IQArray<Qubit>,QVoid), QVoid> ControlledAdjointBody => (__in__) =>
+        public override Func<(IQArray<Qubit>,QVoid), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (__controlQubits__, __unitArg__) = __in__;
 
@@ -2057,10 +2057,10 @@ namespace N1
         |> testOne zeroQubitOperation
 
         Some """
-        public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (__in__) =>
+        public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            X.Controlled.Adjoint.Apply((c, q1));
+            __X__.Controlled.Adjoint.Apply((c, q1));
             #line hidden
             return QVoid.Instance;
         };"""
@@ -2068,13 +2068,13 @@ namespace N1
         |> testOne oneQubitOperation
 
         Some """
-        public override Func<(IQArray<Qubit>,(Qubit,Qubit,Qubits)), QVoid> ControlledAdjointBody => (__in__) =>
+        public override Func<(IQArray<Qubit>,(Qubit,Qubit,Qubits)), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (c,(q1,q2,arr1)) = __in__;
 
-            three_op1.Controlled.Adjoint.Apply((c, (q1, q2)));
-            three_op1.Controlled.Adjoint.Apply((c, (q2, q1)));
-            three_op1.Controlled.Adjoint.Apply((c, (q1, q2)));
+            __three_op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
+            __three_op1__.Controlled.Adjoint.Apply((c, (q2, q1)));
+            __three_op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
 
             #line hidden
             return QVoid.Instance;
@@ -2085,40 +2085,40 @@ namespace N1
     let ``partial application`` () =
         [
             //todo: "partial1Args.Partial<Int64>(_).Apply(1L);"
-            "partial3Args
+            "__partial3Args__
                 .Partial(new Func<(Int64,Double,Result), (Int64,Double,Result)>((__arg1__) => (__arg1__.Item1, __arg1__.Item2, __arg1__.Item3)))
                 .Apply((1L, 3.5D, Result.One));"
-            "partial3Args
+            "__partial3Args__
                 .Partial(new Func<Double, (Int64,Double,Result)>((__arg2__) => (1L, __arg2__, Result.Zero)))
                 .Apply(3.5D);"
-            "partial3Args
+            "__partial3Args__
                 .Partial(new Func<(Int64,Result), (Int64,Double,Result)>((__arg3__) => (__arg3__.Item1, 3.5D, __arg3__.Item2)))
                 .Apply((1L, Result.Zero));"
-            "partial3Args
+            "__partial3Args__
                 .Partial(new Func<Result, (Int64,Double,Result)>((__arg4__) => (1L, 3.5D, __arg4__)))
                 .Apply(Result.Zero);"
-            "partial3Args
+            "__partial3Args__
                 .Partial(new Func<(Double,Result), (Int64,Double,Result)>((__arg5__) => (1L, __arg5__.Item1, __arg5__.Item2)))
                 .Apply((3.5D, Result.Zero));"
-            "partialInnerTuple
+            "__partialInnerTuple__
                 .Partial(new Func<(Int64,(Double,Result)), (Int64,(Double,Result))>((__arg6__) => (__arg6__.Item1, (__arg6__.Item2.Item1, __arg6__.Item2.Item2))))
                 .Apply((1L, (3.5D, Result.One)));"
-            "partialInnerTuple
+            "__partialInnerTuple__
                 .Partial(new Func<(Int64,(Double,Result)), (Int64,(Double,Result))>((__arg7__) => (__arg7__.Item1, (__arg7__.Item2.Item1, __arg7__.Item2.Item2))))
                 .Apply((1L, (3.5D, Result.Zero)));"
-            "partialInnerTuple
+            "__partialInnerTuple__
                 .Partial(new Func<(Double,Result), (Int64,(Double,Result))>((__arg8__) => (1L, (__arg8__.Item1, __arg8__.Item2))))
                 .Apply((3.5D, Result.Zero));"
-            "partialInnerTuple
+            "__partialInnerTuple__
                 .Partial(new Func<(Int64,Result), (Int64,(Double,Result))>((__arg9__) => (__arg9__.Item1, (3.5D, __arg9__.Item2))))
                 .Apply((1L, Result.Zero));"
-            "partialInnerTuple
+            "__partialInnerTuple__
                 .Partial(new Func<(Int64,Double), (Int64,(Double,Result))>((__arg10__) => (__arg10__.Item1, (__arg10__.Item2, Result.One))))
                 .Apply((1L, 3.5D));"
-            "partialInnerTuple
+            "__partialInnerTuple__
                 .Partial(new Func<Result, (Int64,(Double,Result))>((__arg11__) => (1L, (3.5D, __arg11__))))
                 .Apply(Result.One);"
-            "partialNestedArgsOp
+            "__partialNestedArgsOp__
                 .Partial(new Func<((Int64,Int64,Int64),((Double,Double),(Result,Result,Result))), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg12__) =>
                     (
                         (__arg12__.Item1.Item1, __arg12__.Item1.Item2, __arg12__.Item1.Item3),
@@ -2138,7 +2138,7 @@ namespace N1
                     )
                 ))
                 .Apply((1L, ((3.3D, 2D), Result.Zero)));"
-            "partialNestedArgsOp
+            "__partialNestedArgsOp__
                 .Partial(new Func<(Int64,((Double,Double),Result)), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg14__) =>
                     (
                         (1L, i, __arg14__.Item1),
@@ -2158,7 +2158,7 @@ namespace N1
                     )
                 ))
                 .Apply((3.3D, Result.Zero));"
-            "partialNestedArgsOp
+            "__partialNestedArgsOp__
                 .Partial(new Func<(Int64,(Double,Result)), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg16__) =>
                     (
                         (i, __arg16__.Item1, 1L),
@@ -2174,20 +2174,20 @@ namespace N1
                     )
                 ))
                 .Apply(3.3D);"
-            "partialGeneric1
+            "__partialGeneric1__
                 .Partial(new Func<Int64, (Int64, Result, (Int64, Result))>((__arg18__) =>
                     (0L, Result.Zero, (__arg18__, Result.One))
                 ))
                 .Apply(1L);"
-            "partialGeneric1
+            "__partialGeneric1__
                 .Partial(new Func<(Int64, Result), (Int64, Result, (Int64, Result))>((__arg19__) =>
                     (__arg19__.Item1, __arg19__.Item2, (1L, Result.One))
                 ))
                 .Apply((0L, Result.Zero));"
-            "partialGeneric1.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
-            "partialGeneric2.Partial((0L, Result.Zero, (_, Result.One))).Apply(1L);"
-            "partialGeneric2.Partial((_, _, (1L, Result.One))).Apply((0L, Result.Zero));"
-            "partialGeneric2.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
+            "__partialGeneric1__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
+            "__partialGeneric2__.Partial((0L, Result.Zero, (_, Result.One))).Apply(1L);"
+            "__partialGeneric2__.Partial((_, _, (1L, Result.One))).Apply((0L, Result.Zero));"
+            "__partialGeneric2__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
             "partialInput
                 .Partial(new Func<(Double,(Result,Result)), (Int64,(Double,Double),(Result,Result,Result))>((__arg20__) =>
                     (
@@ -2202,7 +2202,7 @@ namespace N1
                 .Partial(new Func<IQArray<Qubit>, (Double,ICallable,IQArray<Qubit>)>((__arg21__) =>
                 (
                     1.1D,
-                    partialFunction.Partial(new Func<(Int64,Double), (Int64,Double,Pauli)>((__arg22__) =>
+                    __partialFunction__.Partial(new Func<(Int64,Double), (Int64,Double,Pauli)>((__arg22__) =>
                         (
                             __arg22__.Item1,
                             __arg22__.Item2,
@@ -2216,10 +2216,10 @@ namespace N1
         |> testOneBody (applyVisitor partialApplicationTest)
 
         [
-            "var r1 = partialFunction
+            "var r1 = __partialFunction__
                 .Partial(new Func<(Int64,Double,Pauli), (Int64,Double,Pauli)>((__arg1__) => (__arg1__.Item1, __arg1__.Item2, __arg1__.Item3)))
                 .Apply<Result>((2L, 2.2D, Pauli.PauliY));"
-            "var r2 = partialFunction
+            "var r2 = __partialFunction__
                 .Partial(new Func<(Double,Pauli), (Int64,Double,Pauli)>((__arg2__) => (1L, __arg2__.Item1, __arg2__.Item2)))
                 .Partial(new Func<Pauli, (Double,Pauli)>((__arg3__) => (3.3D, __arg3__)))
                 .Apply<Result>(Pauli.PauliZ);"
@@ -2357,10 +2357,10 @@ namespace N1
 
         public static HoneywellEntryPointInfo<QVoid, QVoid> Info => new HoneywellEntryPointInfo<QVoid, QVoid>(typeof(emptyOperation));
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn(QVoid data) => data;
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__)
         {
             return __m__.Run<emptyOperation, QVoid, QVoid>(QVoid.Instance);
@@ -2396,10 +2396,10 @@ namespace N1
 
         public static IonQEntryPointInfo<(Qubit, Basis, (Pauli, IQArray<IQArray<Double>>, Boolean), Int64), QVoid> Info => new IonQEntryPointInfo<(Qubit, Basis, (Pauli, IQArray<IQArray<Double>>, Boolean), Int64), QVoid>(typeof(randomAbstractOperation));
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn((Qubit,Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64) data) => new In(data);
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__((Qubit,Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64) data) => new In(data);
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Qubit q1, Basis b, (Pauli,IQArray<IQArray<Double>>,Boolean) t, Int64 i)
         {
             return __m__.Run<randomAbstractOperation, (Qubit,Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64), QVoid>((q1, b, t, i));
@@ -2424,52 +2424,52 @@ namespace N1
 
         public static QCIEntryPointInfo<Qubit, QVoid> Info => new QCIEntryPointInfo<Qubit, QVoid>(typeof(oneQubitOperation));
 
-        protected IUnitary<Qubit> X { get; set; }
+        protected IUnitary<Qubit> __X__ { get; set; }
 
-        public override Func<Qubit, QVoid> Body => (__in__) =>
+        public override Func<Qubit, QVoid> __Body__ => (__in__) =>
         {
             var q1 = __in__;
-            X.Apply(q1);
+            __X__.Apply(q1);
 #line hidden
             return QVoid.Instance;
         }
 
         ;
-        public override Func<Qubit, QVoid> AdjointBody => (__in__) =>
+        public override Func<Qubit, QVoid> __AdjointBody__ => (__in__) =>
         {
             var q1 = __in__;
-            X.Adjoint.Apply(q1);
+            __X__.Adjoint.Apply(q1);
 #line hidden
             return QVoid.Instance;
         }
 
         ;
-        public override Func<(IQArray<Qubit>,Qubit), QVoid> ControlledBody => (__in__) =>
+        public override Func<(IQArray<Qubit>,Qubit), QVoid> __ControlledBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            X.Controlled.Apply((c, q1));
+            __X__.Controlled.Apply((c, q1));
 #line hidden
             return QVoid.Instance;
         }
 
         ;
-        public override Func<(IQArray<Qubit>,Qubit), QVoid> ControlledAdjointBody => (__in__) =>
+        public override Func<(IQArray<Qubit>,Qubit), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            X.Controlled.Adjoint.Apply((c, q1));
+            __X__.Controlled.Adjoint.Apply((c, q1));
 #line hidden
             return QVoid.Instance;
         }
 
         ;
 
-        public override void Init()
+        public override void __Init__()
         {
-            this.X = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
+            this.__X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
         }
 
-        public override IApplyData __dataIn(Qubit data) => data;
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__(Qubit data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Qubit q1)
         {
             return __m__.Run<oneQubitOperation, Qubit, QVoid>(q1);
@@ -2510,10 +2510,10 @@ namespace N1
 
         public static HoneywellEntryPointInfo<(__X__, (Int64, (__Y__, __Z__), Result)), QVoid> Info => new HoneywellEntryPointInfo<(__X__, (Int64, (__Y__, __Z__), Result)), QVoid>(typeof(genCtrl3<__X__,__Y__,__Z__>));
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn((__X__,(Int64,(__Y__,__Z__),Result)) data) => new In(data);
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__((__X__,(Int64,(__Y__,__Z__),Result)) data) => new In(data);
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, __X__ arg1, (Int64,(__Y__,__Z__),Result) arg2)
         {
             return __m__.Run<genCtrl3<__X__,__Y__,__Z__>, (__X__,(Int64,(__Y__,__Z__),Result)), QVoid>((arg1, arg2));
@@ -2551,7 +2551,7 @@ namespace N1
 
         public static IonQEntryPointInfo<(ICallable, ICallable, __B__), QVoid> Info => new IonQEntryPointInfo<(ICallable, ICallable, __B__), QVoid>(typeof(composeImpl<__A__,__B__>));
 
-        public override Func<(ICallable,ICallable,__B__), QVoid> Body => (__in__) =>
+        public override Func<(ICallable,ICallable,__B__), QVoid> __Body__ => (__in__) =>
         {
             var (second,first,arg) = __in__;
             second.Apply(first.Apply<__A__>(arg));
@@ -2559,10 +2559,10 @@ namespace N1
             return QVoid.Instance;
         };
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn((ICallable,ICallable,__B__) data) => new In(data);
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__((ICallable,ICallable,__B__) data) => new In(data);
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, ICallable second, ICallable first, __B__ arg)
         {
             return __m__.Run<composeImpl<__A__,__B__>, (ICallable,ICallable,__B__), QVoid>((second, first, arg));
@@ -2585,10 +2585,10 @@ namespace N1
 
         public static QCIEntryPointInfo<__A__, QVoid> Info => new QCIEntryPointInfo<__A__, QVoid>(typeof(genF1<__A__>));
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn(__A__ data) => new QTuple<__A__>(data);
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__(__A__ data) => new QTuple<__A__>(data);
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, __A__ arg)
         {
             return __m__.Run<genF1<__A__>, __A__, QVoid>(arg);
@@ -2611,19 +2611,19 @@ internal partial class EmptyInternalFunction : Function<QVoid, QVoid>, ICallable
         String ICallable.FullName => "Microsoft.Quantum.Compiler.Generics.EmptyInternalFunction";
         public static EntryPointInfo<QVoid, QVoid> Info => new EntryPointInfo<QVoid, QVoid>(typeof(EmptyInternalFunction));
 
-        public override Func<QVoid, QVoid> Body => (__in__) =>
+        public override Func<QVoid, QVoid> __Body__ => (__in__) =>
         {
 #line hidden
             return QVoid.Instance;
         };
 
-        public override void Init()
+        public override void __Init__()
         {
         }
 
-        public override IApplyData __dataIn(QVoid data) => data;
+        public override IApplyData __DataIn__(QVoid data) => data;
 
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
 
     public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__)
     {
@@ -2645,19 +2645,19 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         String ICallable.FullName => "Microsoft.Quantum.Compiler.Generics.EmptyInternalOperation";
         public static EntryPointInfo<QVoid, QVoid> Info => new EntryPointInfo<QVoid, QVoid>(typeof(EmptyInternalOperation));
 
-        public override Func<QVoid, QVoid> Body => (__in__) =>
+        public override Func<QVoid, QVoid> __Body__ => (__in__) =>
         {
     #line hidden
             return QVoid.Instance;
         };
 
-        public override void Init()
+        public override void __Init__()
         {
         }
 
-        public override IApplyData __dataIn(QVoid data) => data;
+        public override IApplyData __DataIn__(QVoid data) => data;
 
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
 
     public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__)
     {
@@ -2671,17 +2671,17 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
     [<Fact>]
     let ``duplicatedDefinitionsCaller body`` () =
         [
-            "emptyFunction.Apply(QVoid.Instance);"
-            "MicrosoftQuantumOverridesemptyFunction.Apply(QVoid.Instance);"
+            "__emptyFunction__.Apply(QVoid.Instance);"
+            "__MicrosoftQuantumOverridesemptyFunction__.Apply(QVoid.Instance);"
             """
             {
-                var qubits = Allocate.Apply(1L);
+                var qubits = __Allocate__.Apply(1L);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    H.Apply(qubits[0L]);
-                    MicrosoftQuantumIntrinsicH.Apply(qubits[0L]);
+                    __H__.Apply(qubits[0L]);
+                    __MicrosoftQuantumIntrinsicH__.Apply(qubits[0L]);
                 }
 #line hidden
                 catch
@@ -2694,7 +2694,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
                 {
                     if (__arg1__)
                     {
-                        Release.Apply(qubits);
+                        __Release__.Apply(qubits);
                     }
                 }
             }"""
@@ -2704,7 +2704,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
 
     [<Fact>]
     let ``buildOpsProperties with duplicatedDefinitionsCaller`` () =
-        let t = sprintf @"protected %s %s { get; set; }"
+        let t = sprintf @"protected %s __%s__ { get; set; }"
         let template (sign: string) (name: string) = t sign name
 
         let expected =
@@ -2730,7 +2730,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
 
     [<Fact>]
     let ``buildOpsProperties - internal callables`` () =
-        let property = sprintf "private protected %s %s { get; set; }"
+        let property = sprintf "private protected %s __%s__ { get; set; }"
         let expected =
             [
                 property "ICallable<QVoid, QVoid>" "EmptyInternalFunction"
@@ -2762,17 +2762,17 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         String ICallable.FullName => "Microsoft.Quantum.Compiler.Generics.UpdateUdtItems";
         public static EntryPointInfo<MyType2, MyType2> Info => new EntryPointInfo<MyType2, MyType2>(typeof(UpdateUdtItems));
 
-        public override Func<MyType2, MyType2> Body => (__in__) =>
+        public override Func<MyType2, MyType2> __Body__ => (__in__) =>
         {
             var udt = __in__;
             vararr=QArray<Int64>.Create(10L);
             return new MyType2((1L,udt.Data.Item2,(arr?.Copy(),udt.Data.Item3.Item2)));
         };
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn(MyType2data) => data;
-        public override IApplyData __dataOut(MyType2data) => data;
+        public override IApplyData __DataIn__(MyType2data) => data;
+        public override IApplyData __DataOut__(MyType2data) => data;
         public static System.Threading.Tasks.Task<MyType2> Run(IOperationFactory __m__, MyType2 udt)
         {
             return __m__.Run<UpdateUdtItems,MyType2,MyType2>(udt);
@@ -2793,10 +2793,10 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         String ICallable.FullName => "Microsoft.Quantum.Overrides.emptyFunction";
         public static EntryPointInfo<QVoid, QVoid> Info => new EntryPointInfo<QVoid, QVoid>(typeof(emptyFunction));
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn(QVoid data) => data;
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__)
         {
             return __m__.Run<emptyFunction, QVoid, QVoid>(QVoid.Instance);
@@ -2817,15 +2817,15 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         String ICallable.FullName => "Microsoft.Quantum.Testing.intFunction";
         public static EntryPointInfo<QVoid, Int64> Info => new EntryPointInfo<QVoid, Int64>(typeof(intFunction));
 
-        public override Func<QVoid, Int64> Body => (__in__) =>
+        public override Func<QVoid, Int64> __Body__ => (__in__) =>
         {
             return 1L;
         };
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn(QVoid data) => data;
-        public override IApplyData __dataOut(Int64 data) => new QTuple<Int64>(data);
+        public override IApplyData __DataIn__(QVoid data) => data;
+        public override IApplyData __DataOut__(Int64 data) => new QTuple<Int64>(data);
         public static System.Threading.Tasks.Task<Int64> Run(IOperationFactory __m__)
         {
             return __m__.Run<intFunction, QVoid, Int64>(QVoid.Instance);
@@ -2855,16 +2855,16 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         String ICallable.FullName => "Microsoft.Quantum.Testing.powFunction";
         public static EntryPointInfo<(Int64, Int64), Int64> Info => new EntryPointInfo<(Int64, Int64), Int64>(typeof(powFunction));
 
-        public override Func<(Int64,Int64), Int64> Body => (__in__) =>
+        public override Func<(Int64,Int64), Int64> __Body__ => (__in__) =>
         {
             var (x,y) = __in__;
             return x.Pow(y);
         };
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn((Int64,Int64) data) => new In(data);
-        public override IApplyData __dataOut(Int64 data) => new QTuple<Int64>(data);
+        public override IApplyData __DataIn__((Int64,Int64) data) => new In(data);
+        public override IApplyData __DataOut__(Int64 data) => new QTuple<Int64>(data);
         public static System.Threading.Tasks.Task<Int64> Run(IOperationFactory __m__, Int64 x, Int64 y)
         {
             return __m__.Run<powFunction, (Int64,Int64), Int64>((x, y));
@@ -2894,16 +2894,16 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         String ICallable.FullName => "Microsoft.Quantum.Testing.bigPowFunction";
         public static EntryPointInfo<(System.Numerics.BigInteger, Int64), System.Numerics.BigInteger> Info => new EntryPointInfo<(System.Numerics.BigInteger, Int64), System.Numerics.BigInteger>(typeof(bigPowFunction));
 
-        public override Func<(System.Numerics.BigInteger,Int64), System.Numerics.BigInteger> Body => (__in__) =>
+        public override Func<(System.Numerics.BigInteger,Int64), System.Numerics.BigInteger> __Body__ => (__in__) =>
         {
             var (x,y) = __in__;
             return x.Pow(y);
         };
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn((System.Numerics.BigInteger,Int64) data) => new In(data);
-        public override IApplyData __dataOut(System.Numerics.BigInteger data) => new QTuple<System.Numerics.BigInteger>(data);
+        public override IApplyData __DataIn__((System.Numerics.BigInteger,Int64) data) => new In(data);
+        public override IApplyData __DataOut__(System.Numerics.BigInteger data) => new QTuple<System.Numerics.BigInteger>(data);
         public static System.Threading.Tasks.Task<System.Numerics.BigInteger> Run(IOperationFactory __m__, System.Numerics.BigInteger x, Int64 y)
         {
             return __m__.Run<bigPowFunction, (System.Numerics.BigInteger,Int64), System.Numerics.BigInteger>((x, y));
@@ -3277,9 +3277,9 @@ namespace Microsoft.Quantum
 
         String ICallable.Name => "emptyFunction";
         String ICallable.FullName => "Microsoft.Quantum.emptyFunction";
-        public override void Init() { }
-        public override IApplyData __dataIn(Pair data) => data;
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override void __Init__() { }
+        public override IApplyData __DataIn__(Pair data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Pair p)
         {
             return __m__.Run<emptyFunction, Pair, QVoid>(p);
@@ -3294,9 +3294,9 @@ namespace Microsoft.Quantum
 
         String ICallable.Name => "emptyOperation";
         String ICallable.FullName => "Microsoft.Quantum.emptyOperation";
-        public override void Init() { }
-        public override IApplyData __dataIn(QVoid data) => data;
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override void __Init__() { }
+        public override IApplyData __DataIn__(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__)
         {
             return __m__.Run<emptyOperation, QVoid, QVoid>(QVoid.Instance);
@@ -3432,7 +3432,7 @@ namespace Microsoft.Quantum.Tests.Inline
 
         String ICallable.Name => "HelloWorld";
         String ICallable.FullName => "Microsoft.Quantum.Tests.Inline.HelloWorld";
-        public override Func<Int64, Int64> Body => (__in__) =>
+        public override Func<Int64, Int64> __Body__ => (__in__) =>
         {
             var n = __in__;
 #line 9 "%%"
@@ -3441,10 +3441,10 @@ namespace Microsoft.Quantum.Tests.Inline
             return r;
         };
 
-        public override void Init() { }
+        public override void __Init__() { }
 
-        public override IApplyData __dataIn(Int64 data) => new QTuple<Int64>(data);
-        public override IApplyData __dataOut(Int64 data) => new QTuple<Int64>(data);
+        public override IApplyData __DataIn__(Int64 data) => new QTuple<Int64>(data);
+        public override IApplyData __DataOut__(Int64 data) => new QTuple<Int64>(data);
         public static System.Threading.Tasks.Task<Int64> Run(IOperationFactory __m__, Int64 n)
         {
             return __m__.Run<HelloWorld, Int64, Int64>(n);
@@ -3489,25 +3489,25 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 
         String ICallable.Name => "TestLineInBlocks";
         String ICallable.FullName => "Microsoft.Quantum.Tests.LineNumbers.TestLineInBlocks";
-        protected Allocate Allocate
+        protected Allocate __Allocate__
         {
             get;
             set;
         }
 
-        protected Release Release
+        protected Release __Release__
         {
             get;
             set;
         }
 
-        protected IUnitary<Qubit> X
+        protected IUnitary<Qubit> __X__
         {
             get;
             set;
         }
 
-        public override Func<Int64, Result> Body => (__in__) =>
+        public override Func<Int64, Result> __Body__ => (__in__) =>
         {
             var n = __in__;
 #line 11 "%%"
@@ -3515,7 +3515,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 #line hidden
             {
 #line 13 "%%"
-                var (ctrls,q) = (Allocate.Apply(r), Allocate.Apply());
+                var (ctrls,q) = (__Allocate__.Apply(r), __Allocate__.Apply());
 #line hidden
                 bool __arg1__ = true;
                 try
@@ -3524,7 +3524,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
                     if ((n == 0L))
                     {
 #line 16 "%%"
-                        X.Apply(q);
+                        __X__.Apply(q);
                     }
                     else
                     {
@@ -3533,7 +3533,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 #line hidden
                         {
 #line 21 "%%"
-                            X.Controlled.Apply((new QArray<Qubit>(c), q));
+                            __X__.Controlled.Apply((new QArray<Qubit>(c), q));
                         }
                     }
                 }
@@ -3549,9 +3549,9 @@ namespace Microsoft.Quantum.Tests.LineNumbers
                     if (__arg1__)
                     {
 #line hidden
-                        Release.Apply(ctrls);
+                        __Release__.Apply(ctrls);
 #line hidden
-                        Release.Apply(q);
+                        __Release__.Apply(q);
                     }
                 }
             }
@@ -3561,15 +3561,15 @@ namespace Microsoft.Quantum.Tests.LineNumbers
         }
 
         ;
-        public override void Init()
+        public override void __Init__()
         {
-            this.Allocate = this.Factory.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
-            this.Release = this.Factory.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
-            this.X = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
+            this.__Allocate__ = this.Factory.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
+            this.__Release__ = this.Factory.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
+            this.__X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
         }
 
-        public override IApplyData __dataIn(Int64 data) => new QTuple<Int64>(data);
-        public override IApplyData __dataOut(Result data) => new QTuple<Result>(data);
+        public override IApplyData __DataIn__(Int64 data) => new QTuple<Int64>(data);
+        public override IApplyData __DataOut__(Result data) => new QTuple<Result>(data);
         public static System.Threading.Tasks.Task<Result> Run(IOperationFactory __m__, Int64 n)
         {
             return __m__.Run<TestLineInBlocks, Int64, Result>(n);
@@ -3728,19 +3728,19 @@ namespace Microsoft.Quantum.Tests.UnitTests
         String ICallable.Name => "UnitTest1";
         String ICallable.FullName => "Microsoft.Quantum.Tests.UnitTests.UnitTest1";
 
-        public override Func<QVoid, QVoid> Body => (__in__) =>
+        public override Func<QVoid, QVoid> __Body__ => (__in__) =>
         {
         #line hidden
             return QVoid.Instance;
         }
 
         ;
-        public override void Init()
+        public override void __Init__()
         {
         }
 
-        public override IApplyData __dataIn(QVoid data) => data;
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__)
         {
             return __m__.Run<UnitTest1, QVoid, QVoid>(QVoid.Instance);
@@ -3789,19 +3789,19 @@ namespace Microsoft.Quantum.Tests.UnitTests
         String ICallable.Name => "UnitTest2";
         String ICallable.FullName => "Microsoft.Quantum.Tests.UnitTests.UnitTest2";
 
-        public override Func<QVoid, QVoid> Body => (__in__) =>
+        public override Func<QVoid, QVoid> __Body__ => (__in__) =>
         {
         #line hidden
             return QVoid.Instance;
         }
 
         ;
-        public override void Init()
+        public override void __Init__()
         {
         }
 
-        public override IApplyData __dataIn(QVoid data) => data;
-        public override IApplyData __dataOut(QVoid data) => data;
+        public override IApplyData __DataIn__(QVoid data) => data;
+        public override IApplyData __DataOut__(QVoid data) => data;
         public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__)
         {
             return __m__.Run<UnitTest2, QVoid, QVoid>(QVoid.Instance);

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -864,7 +864,7 @@ namespace N1
             let expected = sprintf "public override void __Init__() { %s }" (String.concat "" body)
             Assert.Equal (expected |> clearFormatting, actual |> clearFormatting)
 
-        let template = sprintf "this.__%s__ = this.Factory.Get<%s>(typeof(%s));"
+        let template = sprintf "this.__Call_%s__ = this.Factory.Get<%s>(typeof(%s));"
 
         [
         ]
@@ -979,7 +979,7 @@ namespace N1
                 |> List.map formatSyntaxTree
             List.zip (expected |> List.map clearFormatting) (actual  |> List.map clearFormatting) |> List.iter Assert.Equal
 
-        let template = sprintf @"protected %s __%s__ { get; set; }"
+        let template = sprintf @"protected %s __Call_%s__ { get; set; }"
 
         [
             template "Allocate"                     "Allocate"
@@ -1095,37 +1095,37 @@ namespace N1
         |> testOne (applyVisitor zeroQubitOperation)
 
         [
-            "__X__.Apply(q1);"
+            "__Call_X__.Apply(q1);"
         ]
         |> testOne (applyVisitor oneQubitOperation)
 
         [
-            "__X__.Adjoint.Apply(q1);"
+            "__Call_X__.Adjoint.Apply(q1);"
         ]
         |> testOne (adjointVisitor oneQubitOperation)
 
         [
             "var (q2, r) = t1;        "
-            "__CNOT__.Apply((q1,q2));       "
-            "__R__.Apply((r,q1));           "
+            "__Call_CNOT__.Apply((q1,q2));       "
+            "__Call_R__.Apply((r,q1));           "
         ]
         |> testOne (applyVisitor twoQubitOperation)
         [
             "var (q2, r) = t1;        "
-            "__R__.Adjoint.Apply((r,q1));"
-            "__CNOT__.Adjoint.Apply((q1,q2));"
+            "__Call_R__.Adjoint.Apply((r,q1));"
+            "__Call_CNOT__.Adjoint.Apply((q1,q2));"
         ]
         |> testOne (adjointVisitor twoQubitOperation)
 
         [
-            "__three_op1__.Apply((q1,q2));"
-            "__three_op1__.Apply((q2,q1));"
-            "__three_op1__.Apply((q1,q2));"
+            "__Call_three_op1__.Apply((q1,q2));"
+            "__Call_three_op1__.Apply((q2,q1));"
+            "__Call_three_op1__.Apply((q1,q2));"
         ]
         |> testOne (applyVisitor threeQubitOperation)
 
         [
-            "__Z__.Adjoint.Apply(q1);"
+            "__Call_Z__.Adjoint.Apply(q1);"
             "self.Apply(q1);"
         ]
         |> testOne (adjointVisitor selfInvokingOperation)
@@ -1167,7 +1167,7 @@ namespace N1
         let testOne = testOneBody
 
         [
-            "__X__.Apply(q1);"
+            "__Call_X__.Apply(q1);"
         ]
         |> testOne (applyVisitor oneQubitOperation)
 
@@ -1181,7 +1181,7 @@ namespace N1
         |> testOne (applyVisitor composeImpl)
 
         [
-            "return __composeImpl__.Partial((second, first, _));"
+            "return __Call_composeImpl__.Partial((second, first, _));"
         ]
         |> testOne (applyVisitor compose)
 
@@ -1190,22 +1190,22 @@ namespace N1
     let ``usesGenerics body`` () =
         [
             "var a = (IQArray<Result>)new QArray<Result>(Result.One, Result.Zero, Result.Zero);"
-            "var s = (IQArray<String>)new QArray<String>(__ResultToString__.Apply(a[0L]), __ResultToString__.Apply(a[1L]));"
-            "__MicrosoftQuantumTestingnoOpResult__.Apply(a[0L]);"
+            "var s = (IQArray<String>)new QArray<String>(__Call_ResultToString__.Apply(a[0L]), __Call_ResultToString__.Apply(a[1L]));"
+            "__Call_MicrosoftQuantumTestingnoOpResult__.Apply(a[0L]);"
 
             """
             {
-                var qubits = __Allocate__.Apply(3L);
+                var qubits = __Call_Allocate__.Apply(3L);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    var op = __MicrosoftQuantumTestingHold__.Partial(new Func<QVoid,(ICallable,(Qubit,Qubit),QVoid)>((__arg2__) => (__CNOT__, (qubits[0L], qubits[1L]), __arg2__)));
+                    var op = __Call_MicrosoftQuantumTestingHold__.Partial(new Func<QVoid,(ICallable,(Qubit,Qubit),QVoid)>((__arg2__) => (__Call_CNOT__, (qubits[0L], qubits[1L]), __arg2__)));
                     op.Apply(QVoid.Instance);
 
-                    __MicrosoftQuantumTestingnoOpGeneric__.Apply(qubits[0L]);
-                    __MicrosoftQuantumTestingnoOpGeneric__.Apply(a[0L]);
-                    __genIter__.Apply((__X__, qubits));
+                    __Call_MicrosoftQuantumTestingnoOpGeneric__.Apply(qubits[0L]);
+                    __Call_MicrosoftQuantumTestingnoOpGeneric__.Apply(a[0L]);
+                    __Call_genIter__.Apply((__Call_X__, qubits));
                 }
 #line hidden
                 catch
@@ -1218,17 +1218,17 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        __Release__.Apply(qubits);
+                        __Call_Release__.Apply(qubits);
                     }
                 }
             }
             """
-            "__genIter__.Apply((__MicrosoftQuantumTestingnoOpResult__, a));"
+            "__Call_genIter__.Apply((__Call_MicrosoftQuantumTestingnoOpResult__, a));"
             """
-            __genIter__.Apply((__genU1__, __genMapper__.Apply<IQArray<String>>((__ResultToString__, a))));
+            __Call_genIter__.Apply((__Call_genU1__, __Call_genMapper__.Apply<IQArray<String>>((__Call_ResultToString__, a))));
             """
-            "__genIter__.Apply((__genU1__, s));"
-            "__genIter__.Apply((__genU1__, a));"
+            "__Call_genIter__.Apply((__Call_genU1__, s));"
+            "__Call_genIter__.Apply((__Call_genU1__, a));"
         ]
         |> testOneBody (applyVisitor usesGenerics)
 
@@ -1236,20 +1236,20 @@ namespace N1
     [<Fact>]
     let ``callTests body`` () =
         [
-            "var plain = new call_plain(__X__);"
-            "var adj   = new call_adj(__X__);"
-            "var ctr   = new call_ctr(__X__);"
-            "var uni   = new call_uni(__X__);"
+            "var plain = new call_plain(__Call_X__);"
+            "var adj   = new call_adj(__Call_X__);"
+            "var ctr   = new call_ctr(__Call_X__);"
+            "var uni   = new call_uni(__Call_X__);"
 
-            "__X__.Apply(qubits.Data[0L]);"
-            "__X__.Adjoint.Apply(qubits.Data[0L]);"
-            "__X__.Controlled.Apply((qubits.Data?.Slice(new QRange(1L,5L)), qubits.Data[0L]));"
+            "__Call_X__.Apply(qubits.Data[0L]);"
+            "__Call_X__.Adjoint.Apply(qubits.Data[0L]);"
+            "__Call_X__.Controlled.Apply((qubits.Data?.Slice(new QRange(1L,5L)), qubits.Data[0L]));"
 
-            "__call_target1__.Apply((1L, __X__,     __X__,   __X__,   __X__));"
-            "__call_target1__.Apply((1L, plain.Data, adj.Data, ctr.Data, uni.Data));"
+            "__Call_call_target1__.Apply((1L, __Call_X__,     __Call_X__,   __Call_X__,   __Call_X__));"
+            "__Call_call_target1__.Apply((1L, plain.Data, adj.Data, ctr.Data, uni.Data));"
 
-            "__call_target2__.Apply((1L, (Result.Zero, __X__),    (Result.Zero, __X__),  (Result.Zero, __X__),  (Result.Zero, __X__)));"
-            "__call_target2__.Apply((2L, (Result.One, plain.Data), (Result.One, adj.Data), (Result.One, ctr.Data), (Result.One, uni.Data)));"
+            "__Call_call_target2__.Apply((1L, (Result.Zero, __Call_X__),    (Result.Zero, __Call_X__),  (Result.Zero, __Call_X__),  (Result.Zero, __Call_X__)));"
+            "__Call_call_target2__.Apply((2L, (Result.One, plain.Data), (Result.One, adj.Data), (Result.One, ctr.Data), (Result.One, uni.Data)));"
         ]
         |> testOneBody (applyVisitor callTests)
 
@@ -1259,7 +1259,7 @@ namespace N1
         [
             "var q2 = q1;"
 
-            "var r = __M__.Apply(q1);"
+            "var r = __Call_M__.Apply(q1);"
 
             "var i = 1.1D;"
             "var iZero = 0L;"
@@ -1292,7 +1292,7 @@ namespace N1
             "var __arg1__ = t;"
             "var __arg2__ = t;"
 
-            "return __let_f0__.Apply(n);"
+            "return __Call_let_f0__.Apply(n);"
         ]
         |> testOneBody (applyVisitor letsOperations)
 
@@ -1335,7 +1335,7 @@ namespace N1
             """
             if ((r == Result.One))
             {
-                n = (__if_f0__.Apply(QVoid.Instance) * i);
+                n = (__Call_if_f0__.Apply(QVoid.Instance) * i);
             }
             """
             """
@@ -1359,7 +1359,7 @@ namespace N1
             }
             else
             {
-                return ((p==Pauli.PauliI)?3L:__if_f0__.Apply(QVoid.Instance));
+                return ((p==Pauli.PauliI)?3L:__Call_if_f0__.Apply(QVoid.Instance));
             }
             """
         ]
@@ -1383,7 +1383,7 @@ namespace N1
             @"foreach (var n in range)
             #line hidden
             {
-                result = ((range.End + result) + (n * -(__foreach_f2__.Apply((n, 4L)))));
+                result = ((range.End + result) + (n * -(__Call_foreach_f2__.Apply((n, 4L)))));
             }"
             """
             if ((result > 10L))
@@ -1421,7 +1421,7 @@ namespace N1
     [<Fact>]
     let ``test Length dependency`` () =
         [
-            "__iter__.Apply((__Length__, new QArray<IQArray<Result>>(new QArray<Result>(Result.One), new QArray<Result>(Result.Zero, Result.One))));"
+            "__Call_iter__.Apply((__Call_Length__, new QArray<IQArray<Result>>(new QArray<Result>(Result.One), new QArray<Result>(Result.Zero, Result.One))));"
         ]
         |> testOneBody (applyVisitor testLengthDependency)
 
@@ -1482,22 +1482,22 @@ namespace N1
         [
             """
             {
-                var qubits = __Allocate__.Apply(i);
+                var qubits = __Call_Allocate__.Apply(i);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
                     while (true)
                     {
-                        var res =  __repeat_op0__.Apply(new repeat_udt0((0L, qubits)));
+                        var res =  __Call_repeat_op0__.Apply(new repeat_udt0((0L, qubits)));
 
-                        if ((__repeat_op1__.Apply((0L, qubits)) == Result.One))
+                        if ((__Call_repeat_op1__.Apply((0L, qubits)) == Result.One))
                         {
                             break;
                         }
                         else
                         {
-                            res = __repeat_op2__.Apply((3D, new repeat_udt0(((i-1L), qubits))));
+                            res = __Call_repeat_op2__.Apply((3D, new repeat_udt0(((i-1L), qubits))));
                         }
                     }
                 }
@@ -1512,7 +1512,7 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        __Release__.Apply(qubits);
+                        __Call_Release__.Apply(qubits);
                     }
                 }
             }
@@ -1525,14 +1525,14 @@ namespace N1
         [
             """
             {
-                var q = __Allocate__.Apply();
+                var q = __Call_Allocate__.Apply();
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
                     var flag = true;
-                    (flag ? __X__ : __Z__).Apply(q);
-                    __alloc_op0__.Apply(q);
+                    (flag ? __Call_X__ : __Call_Z__).Apply(q);
+                    __Call_alloc_op0__.Apply(q);
                 }
 #line hidden
                 catch
@@ -1545,18 +1545,18 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        __Release__.Apply(q);
+                        __Call_Release__.Apply(q);
                     }
                 }
             }"""
             """
             {
-                var qs = __Allocate__.Apply(n);
+                var qs = __Call_Allocate__.Apply(n);
 #line hidden
                 bool __arg2__ = true;
                 try
                 {
-                    __alloc_op0__.Apply(qs[(n-1L)]);
+                    __Call_alloc_op0__.Apply(qs[(n-1L)]);
                 }
 #line hidden
                 catch
@@ -1569,19 +1569,19 @@ namespace N1
                 {
                     if (__arg2__)
                     {
-                        __Release__.Apply(qs);
+                        __Call_Release__.Apply(qs);
                     }
                 }
             }"""
             """
             {
-                var (q1, (q2, (__arg3__, q3, __arg4__, q4))) = (__Allocate__.Apply(), ((__Allocate__.Apply(), __Allocate__.Apply(2L)), (__Allocate__.Apply(), __Allocate__.Apply(n), __Allocate__.Apply((n-1L)), __Allocate__.Apply(4L))));
+                var (q1, (q2, (__arg3__, q3, __arg4__, q4))) = (__Call_Allocate__.Apply(), ((__Call_Allocate__.Apply(), __Call_Allocate__.Apply(2L)), (__Call_Allocate__.Apply(), __Call_Allocate__.Apply(n), __Call_Allocate__.Apply((n-1L)), __Call_Allocate__.Apply(4L))));
 #line hidden
                 bool __arg5__ = true;
                 try
                 {
-                    __alloc_op0__.Apply(q1);
-                    __alloc_op0__.Apply(q3[1L]);
+                    __Call_alloc_op0__.Apply(q1);
+                    __Call_alloc_op0__.Apply(q3[1L]);
                 }
 #line hidden
                 catch
@@ -1594,13 +1594,13 @@ namespace N1
                 {
                     if (__arg5__)
                     {
-                        __Release__.Apply(q1);
-                        __Release__.Apply(q2.Item1);
-                        __Release__.Apply(q2.Item2);
-                        __Release__.Apply(__arg3__);
-                        __Release__.Apply(q3);
-                        __Release__.Apply(__arg4__);
-                        __Release__.Apply(q4);
+                        __Call_Release__.Apply(q1);
+                        __Call_Release__.Apply(q2.Item1);
+                        __Call_Release__.Apply(q2.Item2);
+                        __Call_Release__.Apply(__arg3__);
+                        __Call_Release__.Apply(q3);
+                        __Call_Release__.Apply(__arg4__);
+                        __Call_Release__.Apply(q4);
                     }
                 }
             }"""
@@ -1610,12 +1610,12 @@ namespace N1
         [
             """
             {
-                var b = __Borrow__.Apply(n);
+                var b = __Call_Borrow__.Apply(n);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    __alloc_op0__.Apply(b[(n-1L)]);
+                    __Call_alloc_op0__.Apply(b[(n-1L)]);
                 }
 #line hidden
                 catch
@@ -1628,25 +1628,25 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        __Return__.Apply(b);
+                        __Call_Return__.Apply(b);
                     }
                 }
             }"""
             """
             {
-                var (q1, (q2, (__arg2__, q3))) = (__Borrow__.Apply(), (__Borrow__.Apply(2L), (__Borrow__.Apply(), (__Borrow__.Apply(n), __Borrow__.Apply(4L)))));
+                var (q1, (q2, (__arg2__, q3))) = (__Call_Borrow__.Apply(), (__Call_Borrow__.Apply(2L), (__Call_Borrow__.Apply(), (__Call_Borrow__.Apply(n), __Call_Borrow__.Apply(4L)))));
 #line hidden
                 bool __arg3__ = true;
                 try
                 {
                     {
-                        var qt = (__Allocate__.Apply(), (__Allocate__.Apply(1L), __Allocate__.Apply(2L)));
+                        var qt = (__Call_Allocate__.Apply(), (__Call_Allocate__.Apply(1L), __Call_Allocate__.Apply(2L)));
 #line hidden
                         bool __arg4__ = true;
                         try
                         {
                             var (qt1, qt2) = ((Qubit, (IQArray<Qubit>, IQArray<Qubit>)))qt;
-                            __alloc_op0__.Apply(qt1);
+                            __Call_alloc_op0__.Apply(qt1);
                         }
 #line hidden
                         catch
@@ -1659,15 +1659,15 @@ namespace N1
                         {
                             if (__arg4__)
                             {
-                                __Release__.Apply(qt.Item1);
-                                __Release__.Apply(qt.Item2.Item1);
-                                __Release__.Apply(qt.Item2.Item2);
+                                __Call_Release__.Apply(qt.Item1);
+                                __Call_Release__.Apply(qt.Item2.Item1);
+                                __Call_Release__.Apply(qt.Item2.Item2);
                             }
                         }
                     }
 
-                    __alloc_op0__.Apply(q1);
-                    __alloc_op0__.Apply(q2[1L]);
+                    __Call_alloc_op0__.Apply(q1);
+                    __Call_alloc_op0__.Apply(q2[1L]);
                 }
 #line hidden
                 catch
@@ -1680,11 +1680,11 @@ namespace N1
                 {
                     if (__arg3__)
                     {
-                        __Return__.Apply(q1);
-                        __Return__.Apply(q2);
-                        __Return__.Apply(__arg2__);
-                        __Return__.Apply(q3.Item1);
-                        __Return__.Apply(q3.Item2);
+                        __Call_Return__.Apply(q1);
+                        __Call_Return__.Apply(q2);
+                        __Call_Return__.Apply(__arg2__);
+                        __Call_Return__.Apply(q3.Item1);
+                        __Call_Return__.Apply(q3.Item2);
                     }
                 }
             }"""
@@ -1745,7 +1745,7 @@ namespace N1
         {
             var q1 = __in__;
 
-            __X__.Apply(q1);
+            __Call_X__.Apply(q1);
             #line hidden
             return  QVoid.Instance;
         };
@@ -1759,8 +1759,8 @@ namespace N1
 
             var (q2,r) = t1;
 
-            __CNOT__.Apply((q1, q2));
-            __R__.Apply((r, q1));
+            __Call_CNOT__.Apply((q1, q2));
+            __Call_R__.Apply((r, q1));
 
             #line hidden
             return  QVoid.Instance;
@@ -1774,10 +1774,10 @@ namespace N1
         {
             var (q1,q2,arr1) = __in__;
 
-            __da_op0__.Apply(QVoid.Instance);
-            __da_op1__.Adjoint.Apply(q1);
-            __da_op2__.Controlled.Apply((new QArray<Qubit>(q1), (1L, q2)));
-            __da_op3__.Controlled.Adjoint.Apply((new QArray<Qubit>(q1, q2), (1.1D, Result.One, arr1.Length)));
+            __Call_da_op0__.Apply(QVoid.Instance);
+            __Call_da_op1__.Adjoint.Apply(q1);
+            __Call_da_op2__.Controlled.Apply((new QArray<Qubit>(q1), (1L, q2)));
+            __Call_da_op3__.Controlled.Adjoint.Apply((new QArray<Qubit>(q1, q2), (1.1D, Result.One, arr1.Length)));
 
             #line hidden
             return QVoid.Instance;
@@ -1800,7 +1800,7 @@ namespace N1
         public override Func<(Qubit, %s, %s, %s, (%s, %s), %s), %s> __Body__  => (__in__) =>
                 {
                     var (q1, op0, op1, op2, t1, f1) = __in__;
-                    op1.Apply(__OP_1__);
+                    op1.Apply(__Call_OP_1__);
                     var v0 = op0;
                     var r0 = v0.Apply<Result>(q1);
                     var (op3, op4) = t1;
@@ -1864,7 +1864,7 @@ namespace N1
             "var s1 = (IQArray<Qubit>)qubits?.Slice(new QRange(0L,10L));"
             "var s2 = (IQArray<Qubit>)qubits?.Slice(r2);"
             "var s3 = (IQArray<Qubit>)qubits?.Slice(ranges[3L]);"
-            "var s4 = (IQArray<Qubit>)qubits?.Slice(__GetMeARange__.Apply(QVoid.Instance));"
+            "var s4 = (IQArray<Qubit>)qubits?.Slice(__Call_GetMeARange__.Apply(QVoid.Instance));"
 
             "return qubits?.Slice(new QRange(10L,-(3L),0L));"
         ]
@@ -1947,7 +1947,7 @@ namespace N1
         public override Func<Qubit, QVoid> __AdjointBody__ => (__in__) =>
         {
             var q1 = __in__;
-            __X__.Adjoint.Apply(q1);
+            __Call_X__.Adjoint.Apply(q1);
 
             #line hidden
             return QVoid.Instance;
@@ -1961,8 +1961,8 @@ namespace N1
 
             var (q2,r) = t1;
 
-            __R__.Adjoint.Apply((r, q1));
-            __CNOT__.Adjoint.Apply((q1, q2));
+            __Call_R__.Adjoint.Apply((r, q1));
+            __Call_CNOT__.Adjoint.Apply((q1, q2));
 
             #line hidden
             return QVoid.Instance;
@@ -1973,9 +1973,9 @@ namespace N1
         public override Func<(Qubit,Qubit,Qubits), QVoid> __AdjointBody__ => (__in__) =>
         {
             var (q1,q2,arr1) = __in__;
-            __three_op1__.Adjoint.Apply((q1, q2));
-            __three_op1__.Adjoint.Apply((q2, q1));
-            __three_op1__.Adjoint.Apply((q1, q2));
+            __Call_three_op1__.Adjoint.Apply((q1, q2));
+            __Call_three_op1__.Adjoint.Apply((q2, q1));
+            __Call_three_op1__.Adjoint.Apply((q1, q2));
             #line hidden
             return QVoid.Instance;
         };"""
@@ -2013,7 +2013,7 @@ namespace N1
         {
             var (c, q1) = __in__;
 
-            __X__.Controlled.Apply((c, q1));
+            __Call_X__.Controlled.Apply((c, q1));
 
             #line hidden
             return QVoid.Instance;
@@ -2025,9 +2025,9 @@ namespace N1
         {
             var (c, (q1, q2, arr1)) = __in__;
 
-            __three_op1__.Controlled.Apply((c, (q1, q2)));
-            __three_op1__.Controlled.Apply((c, (q2, q1)));
-            __three_op1__.Controlled.Apply((c, (q1, q2)));
+            __Call_three_op1__.Controlled.Apply((c, (q1, q2)));
+            __Call_three_op1__.Controlled.Apply((c, (q2, q1)));
+            __Call_three_op1__.Controlled.Apply((c, (q1, q2)));
 
             #line hidden
             return QVoid.Instance;
@@ -2061,7 +2061,7 @@ namespace N1
         public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            __X__.Controlled.Adjoint.Apply((c, q1));
+            __Call_X__.Controlled.Adjoint.Apply((c, q1));
             #line hidden
             return QVoid.Instance;
         };"""
@@ -2073,9 +2073,9 @@ namespace N1
         {
             var (c,(q1,q2,arr1)) = __in__;
 
-            __three_op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
-            __three_op1__.Controlled.Adjoint.Apply((c, (q2, q1)));
-            __three_op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
+            __Call_three_op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
+            __Call_three_op1__.Controlled.Adjoint.Apply((c, (q2, q1)));
+            __Call_three_op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
 
             #line hidden
             return QVoid.Instance;
@@ -2086,40 +2086,40 @@ namespace N1
     let ``partial application`` () =
         [
             //todo: "partial1Args.Partial<Int64>(_).Apply(1L);"
-            "__partial3Args__
+            "__Call_partial3Args__
                 .Partial(new Func<(Int64,Double,Result), (Int64,Double,Result)>((__arg1__) => (__arg1__.Item1, __arg1__.Item2, __arg1__.Item3)))
                 .Apply((1L, 3.5D, Result.One));"
-            "__partial3Args__
+            "__Call_partial3Args__
                 .Partial(new Func<Double, (Int64,Double,Result)>((__arg2__) => (1L, __arg2__, Result.Zero)))
                 .Apply(3.5D);"
-            "__partial3Args__
+            "__Call_partial3Args__
                 .Partial(new Func<(Int64,Result), (Int64,Double,Result)>((__arg3__) => (__arg3__.Item1, 3.5D, __arg3__.Item2)))
                 .Apply((1L, Result.Zero));"
-            "__partial3Args__
+            "__Call_partial3Args__
                 .Partial(new Func<Result, (Int64,Double,Result)>((__arg4__) => (1L, 3.5D, __arg4__)))
                 .Apply(Result.Zero);"
-            "__partial3Args__
+            "__Call_partial3Args__
                 .Partial(new Func<(Double,Result), (Int64,Double,Result)>((__arg5__) => (1L, __arg5__.Item1, __arg5__.Item2)))
                 .Apply((3.5D, Result.Zero));"
-            "__partialInnerTuple__
+            "__Call_partialInnerTuple__
                 .Partial(new Func<(Int64,(Double,Result)), (Int64,(Double,Result))>((__arg6__) => (__arg6__.Item1, (__arg6__.Item2.Item1, __arg6__.Item2.Item2))))
                 .Apply((1L, (3.5D, Result.One)));"
-            "__partialInnerTuple__
+            "__Call_partialInnerTuple__
                 .Partial(new Func<(Int64,(Double,Result)), (Int64,(Double,Result))>((__arg7__) => (__arg7__.Item1, (__arg7__.Item2.Item1, __arg7__.Item2.Item2))))
                 .Apply((1L, (3.5D, Result.Zero)));"
-            "__partialInnerTuple__
+            "__Call_partialInnerTuple__
                 .Partial(new Func<(Double,Result), (Int64,(Double,Result))>((__arg8__) => (1L, (__arg8__.Item1, __arg8__.Item2))))
                 .Apply((3.5D, Result.Zero));"
-            "__partialInnerTuple__
+            "__Call_partialInnerTuple__
                 .Partial(new Func<(Int64,Result), (Int64,(Double,Result))>((__arg9__) => (__arg9__.Item1, (3.5D, __arg9__.Item2))))
                 .Apply((1L, Result.Zero));"
-            "__partialInnerTuple__
+            "__Call_partialInnerTuple__
                 .Partial(new Func<(Int64,Double), (Int64,(Double,Result))>((__arg10__) => (__arg10__.Item1, (__arg10__.Item2, Result.One))))
                 .Apply((1L, 3.5D));"
-            "__partialInnerTuple__
+            "__Call_partialInnerTuple__
                 .Partial(new Func<Result, (Int64,(Double,Result))>((__arg11__) => (1L, (3.5D, __arg11__))))
                 .Apply(Result.One);"
-            "__partialNestedArgsOp__
+            "__Call_partialNestedArgsOp__
                 .Partial(new Func<((Int64,Int64,Int64),((Double,Double),(Result,Result,Result))), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg12__) =>
                     (
                         (__arg12__.Item1.Item1, __arg12__.Item1.Item2, __arg12__.Item1.Item3),
@@ -2139,7 +2139,7 @@ namespace N1
                     )
                 ))
                 .Apply((1L, ((3.3D, 2D), Result.Zero)));"
-            "__partialNestedArgsOp__
+            "__Call_partialNestedArgsOp__
                 .Partial(new Func<(Int64,((Double,Double),Result)), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg14__) =>
                     (
                         (1L, i, __arg14__.Item1),
@@ -2159,7 +2159,7 @@ namespace N1
                     )
                 ))
                 .Apply((3.3D, Result.Zero));"
-            "__partialNestedArgsOp__
+            "__Call_partialNestedArgsOp__
                 .Partial(new Func<(Int64,(Double,Result)), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg16__) =>
                     (
                         (i, __arg16__.Item1, 1L),
@@ -2175,20 +2175,20 @@ namespace N1
                     )
                 ))
                 .Apply(3.3D);"
-            "__partialGeneric1__
+            "__Call_partialGeneric1__
                 .Partial(new Func<Int64, (Int64, Result, (Int64, Result))>((__arg18__) =>
                     (0L, Result.Zero, (__arg18__, Result.One))
                 ))
                 .Apply(1L);"
-            "__partialGeneric1__
+            "__Call_partialGeneric1__
                 .Partial(new Func<(Int64, Result), (Int64, Result, (Int64, Result))>((__arg19__) =>
                     (__arg19__.Item1, __arg19__.Item2, (1L, Result.One))
                 ))
                 .Apply((0L, Result.Zero));"
-            "__partialGeneric1__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
-            "__partialGeneric2__.Partial((0L, Result.Zero, (_, Result.One))).Apply(1L);"
-            "__partialGeneric2__.Partial((_, _, (1L, Result.One))).Apply((0L, Result.Zero));"
-            "__partialGeneric2__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
+            "__Call_partialGeneric1__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
+            "__Call_partialGeneric2__.Partial((0L, Result.Zero, (_, Result.One))).Apply(1L);"
+            "__Call_partialGeneric2__.Partial((_, _, (1L, Result.One))).Apply((0L, Result.Zero));"
+            "__Call_partialGeneric2__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
             "partialInput
                 .Partial(new Func<(Double,(Result,Result)), (Int64,(Double,Double),(Result,Result,Result))>((__arg20__) =>
                     (
@@ -2203,7 +2203,7 @@ namespace N1
                 .Partial(new Func<IQArray<Qubit>, (Double,ICallable,IQArray<Qubit>)>((__arg21__) =>
                 (
                     1.1D,
-                    __partialFunction__.Partial(new Func<(Int64,Double), (Int64,Double,Pauli)>((__arg22__) =>
+                    __Call_partialFunction__.Partial(new Func<(Int64,Double), (Int64,Double,Pauli)>((__arg22__) =>
                         (
                             __arg22__.Item1,
                             __arg22__.Item2,
@@ -2217,10 +2217,10 @@ namespace N1
         |> testOneBody (applyVisitor partialApplicationTest)
 
         [
-            "var r1 = __partialFunction__
+            "var r1 = __Call_partialFunction__
                 .Partial(new Func<(Int64,Double,Pauli), (Int64,Double,Pauli)>((__arg1__) => (__arg1__.Item1, __arg1__.Item2, __arg1__.Item3)))
                 .Apply<Result>((2L, 2.2D, Pauli.PauliY));"
-            "var r2 = __partialFunction__
+            "var r2 = __Call_partialFunction__
                 .Partial(new Func<(Double,Pauli), (Int64,Double,Pauli)>((__arg2__) => (1L, __arg2__.Item1, __arg2__.Item2)))
                 .Partial(new Func<Pauli, (Double,Pauli)>((__arg3__) => (3.3D, __arg3__)))
                 .Apply<Result>(Pauli.PauliZ);"
@@ -2425,12 +2425,12 @@ namespace N1
 
         public static QCIEntryPointInfo<Qubit, QVoid> Info => new QCIEntryPointInfo<Qubit, QVoid>(typeof(oneQubitOperation));
 
-        protected IUnitary<Qubit> __X__ { get; set; }
+        protected IUnitary<Qubit> __Call_X__ { get; set; }
 
         public override Func<Qubit, QVoid> __Body__ => (__in__) =>
         {
             var q1 = __in__;
-            __X__.Apply(q1);
+            __Call_X__.Apply(q1);
 #line hidden
             return QVoid.Instance;
         }
@@ -2439,7 +2439,7 @@ namespace N1
         public override Func<Qubit, QVoid> __AdjointBody__ => (__in__) =>
         {
             var q1 = __in__;
-            __X__.Adjoint.Apply(q1);
+            __Call_X__.Adjoint.Apply(q1);
 #line hidden
             return QVoid.Instance;
         }
@@ -2448,7 +2448,7 @@ namespace N1
         public override Func<(IQArray<Qubit>,Qubit), QVoid> __ControlledBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            __X__.Controlled.Apply((c, q1));
+            __Call_X__.Controlled.Apply((c, q1));
 #line hidden
             return QVoid.Instance;
         }
@@ -2457,7 +2457,7 @@ namespace N1
         public override Func<(IQArray<Qubit>,Qubit), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            __X__.Controlled.Adjoint.Apply((c, q1));
+            __Call_X__.Controlled.Adjoint.Apply((c, q1));
 #line hidden
             return QVoid.Instance;
         }
@@ -2466,7 +2466,7 @@ namespace N1
 
         public override void __Init__()
         {
-            this.__X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
+            this.__Call_X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
         }
 
         public override IApplyData __DataIn__(Qubit data) => data;
@@ -2672,17 +2672,17 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
     [<Fact>]
     let ``duplicatedDefinitionsCaller body`` () =
         [
-            "__emptyFunction__.Apply(QVoid.Instance);"
-            "__MicrosoftQuantumOverridesemptyFunction__.Apply(QVoid.Instance);"
+            "__Call_emptyFunction__.Apply(QVoid.Instance);"
+            "__Call_MicrosoftQuantumOverridesemptyFunction__.Apply(QVoid.Instance);"
             """
             {
-                var qubits = __Allocate__.Apply(1L);
+                var qubits = __Call_Allocate__.Apply(1L);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    __H__.Apply(qubits[0L]);
-                    __MicrosoftQuantumIntrinsicH__.Apply(qubits[0L]);
+                    __Call_H__.Apply(qubits[0L]);
+                    __Call_MicrosoftQuantumIntrinsicH__.Apply(qubits[0L]);
                 }
 #line hidden
                 catch
@@ -2695,7 +2695,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
                 {
                     if (__arg1__)
                     {
-                        __Release__.Apply(qubits);
+                        __Call_Release__.Apply(qubits);
                     }
                 }
             }"""
@@ -2705,7 +2705,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
 
     [<Fact>]
     let ``buildOpsProperties with duplicatedDefinitionsCaller`` () =
-        let t = sprintf @"protected %s __%s__ { get; set; }"
+        let t = sprintf @"protected %s __Call_%s__ { get; set; }"
         let template (sign: string) (name: string) = t sign name
 
         let expected =
@@ -2731,7 +2731,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
 
     [<Fact>]
     let ``buildOpsProperties - internal callables`` () =
-        let property = sprintf "private protected %s __%s__ { get; set; }"
+        let property = sprintf "private protected %s __Call_%s__ { get; set; }"
         let expected =
             [
                 property "ICallable<QVoid, QVoid>" "EmptyInternalFunction"
@@ -3490,19 +3490,19 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 
         String ICallable.Name => "TestLineInBlocks";
         String ICallable.FullName => "Microsoft.Quantum.Tests.LineNumbers.TestLineInBlocks";
-        protected Allocate __Allocate__
+        protected Allocate __Call_Allocate__
         {
             get;
             set;
         }
 
-        protected Release __Release__
+        protected Release __Call_Release__
         {
             get;
             set;
         }
 
-        protected IUnitary<Qubit> __X__
+        protected IUnitary<Qubit> __Call_X__
         {
             get;
             set;
@@ -3516,7 +3516,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 #line hidden
             {
 #line 13 "%%"
-                var (ctrls,q) = (__Allocate__.Apply(r), __Allocate__.Apply());
+                var (ctrls,q) = (__Call_Allocate__.Apply(r), __Call_Allocate__.Apply());
 #line hidden
                 bool __arg1__ = true;
                 try
@@ -3525,7 +3525,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
                     if ((n == 0L))
                     {
 #line 16 "%%"
-                        __X__.Apply(q);
+                        __Call_X__.Apply(q);
                     }
                     else
                     {
@@ -3534,7 +3534,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 #line hidden
                         {
 #line 21 "%%"
-                            __X__.Controlled.Apply((new QArray<Qubit>(c), q));
+                            __Call_X__.Controlled.Apply((new QArray<Qubit>(c), q));
                         }
                     }
                 }
@@ -3550,9 +3550,9 @@ namespace Microsoft.Quantum.Tests.LineNumbers
                     if (__arg1__)
                     {
 #line hidden
-                        __Release__.Apply(ctrls);
+                        __Call_Release__.Apply(ctrls);
 #line hidden
-                        __Release__.Apply(q);
+                        __Call_Release__.Apply(q);
                     }
                 }
             }
@@ -3564,9 +3564,9 @@ namespace Microsoft.Quantum.Tests.LineNumbers
         ;
         public override void __Init__()
         {
-            this.__Allocate__ = this.Factory.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
-            this.__Release__ = this.Factory.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
-            this.__X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
+            this.__Call_Allocate__ = this.Factory.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
+            this.__Call_Release__ = this.Factory.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
+            this.__Call_X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
         }
 
         public override IApplyData __DataIn__(Int64 data) => new QTuple<Int64>(data);

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -865,6 +865,7 @@ namespace N1
             Assert.Equal (expected |> clearFormatting, actual |> clearFormatting)
 
         let template = sprintf "this.__%s__ = this.Factory.Get<%s>(typeof(%s));"
+
         [
         ]
         |> testOne emptyOperation
@@ -909,12 +910,12 @@ namespace N1
 
         [
             template "Z"                                    "IUnitary<Qubit>"                   "Microsoft.Quantum.Intrinsic.Z"
-            "this.__self__ = this;"
+            "this.self = this;"
         ]
         |> testOne selfInvokingOperation
 
         [
-            template "self"                                 "ICallable"                         "genRecursion<>"
+            "this.self = this.Factory.Get<ICallable>(typeof(genRecursion<>));"
         ]
         |> testOne genRecursion
 
@@ -1002,12 +1003,12 @@ namespace N1
 
         [
             template "IUnitary<Qubit>"              "Z"
-            template "IAdjointable<Qubit>"          "self"
+            "protected IAdjointable<Qubit> self { get; set; }"
         ]
         |> testOne selfInvokingOperation
 
         [
-            template "ICallable"                    "self"
+            "protected ICallable self { get; set; }"
         ]
         |> testOne genRecursion
 
@@ -1125,7 +1126,7 @@ namespace N1
 
         [
             "__Z__.Adjoint.Apply(q1);"
-            "__self__.Apply(q1);"
+            "self.Apply(q1);"
         ]
         |> testOne (adjointVisitor selfInvokingOperation)
 
@@ -1141,7 +1142,7 @@ namespace N1
             }
             else
             {
-                return __self__.Apply<__T__>((x, (cnt - 1L)));
+                return self.Apply<__T__>((x, (cnt - 1L)));
             }
             """
         ]
@@ -1155,7 +1156,7 @@ namespace N1
             }
             else
             {
-                return (x * __self__.Apply<Int64>((x - 1L)));
+                return (x * self.Apply<Int64>((x - 1L)));
             }
             """
         ]

--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -265,7 +265,7 @@ namespace N1
         "QTuple<ICallable>"
         |> testOne udt_A
 
-        "QTuple<A>"
+        "QTuple<Microsoft.Quantum.Testing.A>"
         |> testOne udt_AA
 
         "QTuple<IUnitary>"
@@ -277,7 +277,7 @@ namespace N1
         "QTuple<Double>"
         |> testOne udt_Real
 
-        "QTuple<(udt_Real,udt_Real)>"
+        "QTuple<(Microsoft.Quantum.Testing.udt_Real,Microsoft.Quantum.Testing.udt_Real)>"
         |> testOne udt_Complex
 
         "QTuple<IQArray<IQArray<Result>>>"
@@ -373,10 +373,10 @@ namespace N1
         [
             ((NS2, "Allocate"),    "Allocate")
             ((NS2, "Release"),     "Release")
-            ((NS1, "repeat_op0"),  "ICallable<repeat_udt0, Result>")
+            ((NS1, "repeat_op0"),  "ICallable<Microsoft.Quantum.Testing.repeat_udt0, Result>")
             ((NS1, "repeat_op1"),  "ICallable<(Int64,IQArray<Qubit>), Result>")
-            ((NS1, "repeat_op2"),  "ICallable<(Double,repeat_udt0), Result>")
-            ((NS1, "repeat_udt0"), "ICallable<(Int64,IQArray<Qubit>), repeat_udt0>")
+            ((NS1, "repeat_op2"),  "ICallable<(Double,Microsoft.Quantum.Testing.repeat_udt0), Result>")
+            ((NS1, "repeat_udt0"), "ICallable<(Int64,IQArray<Qubit>), Microsoft.Quantum.Testing.repeat_udt0>")
         ]
         |> testOne repeatOperation
 
@@ -504,13 +504,13 @@ namespace N1
         [
             "q1",   "Qubit"
             "q2",   "Qubit"
-            "arr1", "Qubits"
+            "arr1", "Microsoft.Quantum.Intrinsic.Qubits"
         ]
         |> testOne threeQubitOperation
 
         [
             "q1", "Qubit"
-            "b",  "Basis"
+            "b",  "Microsoft.Quantum.Testing.Basis"
             "t",  "(Pauli,IQArray<IQArray<Double>>,Boolean)"
             "i",  "Int64"
         ]
@@ -864,7 +864,7 @@ namespace N1
             let expected = sprintf "public override void __Init__() { %s }" (String.concat "" body)
             Assert.Equal (expected |> clearFormatting, actual |> clearFormatting)
 
-        let template = sprintf "this.__Call_%s__ = this.Factory.Get<%s>(typeof(%s));"
+        let template = sprintf "this.__%s__ = this.Factory.Get<%s>(typeof(%s));"
 
         [
         ]
@@ -879,37 +879,37 @@ namespace N1
         |> testOne genU2
 
         [
-            template "Allocate"                               "Allocate"                        "Microsoft.Quantum.Intrinsic.Allocate"
-            template "MicrosoftQuantumIntrinsicH"             "IUnitary<Qubit>"                 "Microsoft.Quantum.Intrinsic.H"
-            template "H"                                      "ICallable<Qubit, QVoid>"         "H"
-            template "Release"                                "Release"                         "Microsoft.Quantum.Intrinsic.Release"
-            template "MicrosoftQuantumOverridesemptyFunction" "ICallable<QVoid, QVoid>"         "Microsoft.Quantum.Overrides.emptyFunction"
-            template "emptyFunction"                          "ICallable<QVoid, QVoid>"         "emptyFunction"
+            template "Microsoft_Quantum_Intrinsic_Allocate" "Allocate" "Microsoft.Quantum.Intrinsic.Allocate"
+            template "Microsoft_Quantum_Intrinsic_H" "IUnitary<Qubit>" "Microsoft.Quantum.Intrinsic.H"
+            template "Microsoft_Quantum_Testing_H" "ICallable<Qubit, QVoid>" "H"
+            template "Microsoft_Quantum_Intrinsic_Release" "Release" "Microsoft.Quantum.Intrinsic.Release"
+            template "Microsoft_Quantum_Overrides_emptyFunction" "ICallable<QVoid, QVoid>" "Microsoft.Quantum.Overrides.emptyFunction"
+            template "Microsoft_Quantum_Testing_emptyFunction" "ICallable<QVoid, QVoid>" "emptyFunction"
         ]
         |> testOne duplicatedDefinitionsCaller
 
         [
-            template "Allocate"                             "Allocate"                          "Microsoft.Quantum.Intrinsic.Allocate"
-            template "CNOT"                                 "IAdjointable<(Qubit, Qubit)>"      "Microsoft.Quantum.Intrinsic.CNOT"
-            template "MicrosoftQuantumTestingHold"          "ICallable"                         "Microsoft.Quantum.Testing.Hold<>"
-            template "Release"                              "Release"                           "Microsoft.Quantum.Intrinsic.Release"
-            template "ResultToString"                       "ICallable<Result,String>"          "ResultToString"
-            template "X"                                    "IUnitary<Qubit>"                   "Microsoft.Quantum.Intrinsic.X"
-            template "genIter"                              "IUnitary"                          "genIter<>"
-            template "genMapper"                            "ICallable"                         "genMapper<,>"
-            template "genU1"                                "IUnitary"                          "genU1<>"
-            template "MicrosoftQuantumTestingnoOpGeneric"   "IUnitary"                          "Microsoft.Quantum.Testing.noOpGeneric<>"
-            template "MicrosoftQuantumTestingnoOpResult"    "IUnitary<Result>"                  "Microsoft.Quantum.Testing.noOpResult"
+            template "Microsoft_Quantum_Intrinsic_Allocate" "Allocate" "Microsoft.Quantum.Intrinsic.Allocate"
+            template "Microsoft_Quantum_Intrinsic_CNOT" "IAdjointable<(Qubit, Qubit)>" "Microsoft.Quantum.Intrinsic.CNOT"
+            template "Microsoft_Quantum_Testing_Hold" "ICallable" "Microsoft.Quantum.Testing.Hold<>"
+            template "Microsoft_Quantum_Intrinsic_Release" "Release" "Microsoft.Quantum.Intrinsic.Release"
+            template "Microsoft_Quantum_Compiler_Generics_ResultToString" "ICallable<Result,String>" "ResultToString"
+            template "Microsoft_Quantum_Intrinsic_X" "IUnitary<Qubit>" "Microsoft.Quantum.Intrinsic.X"
+            template "Microsoft_Quantum_Compiler_Generics_genIter" "IUnitary" "genIter<>"
+            template "Microsoft_Quantum_Compiler_Generics_genMapper" "ICallable" "genMapper<,>"
+            template "Microsoft_Quantum_Compiler_Generics_genU1" "IUnitary" "genU1<>"
+            template "Microsoft_Quantum_Testing_noOpGeneric" "IUnitary" "Microsoft.Quantum.Testing.noOpGeneric<>"
+            template "Microsoft_Quantum_Testing_noOpResult" "IUnitary<Result>" "Microsoft.Quantum.Testing.noOpResult"
         ]
         |> testOne usesGenerics
 
         [
-            template "genericWithMultipleTypeParams"        "ICallable"                         "genericWithMultipleTypeParams<,,>"
+            template "Microsoft_Quantum_Compiler_Generics_genericWithMultipleTypeParams" "ICallable" "genericWithMultipleTypeParams<,,>"
         ]
         |> testOne callsGenericWithMultipleTypeParams
 
         [
-            template "Z"                                    "IUnitary<Qubit>"                   "Microsoft.Quantum.Intrinsic.Z"
+            template "Microsoft_Quantum_Intrinsic_Z" "IUnitary<Qubit>" "Microsoft.Quantum.Intrinsic.Z"
             "this.self = this;"
         ]
         |> testOne selfInvokingOperation
@@ -979,30 +979,30 @@ namespace N1
                 |> List.map formatSyntaxTree
             List.zip (expected |> List.map clearFormatting) (actual  |> List.map clearFormatting) |> List.iter Assert.Equal
 
-        let template = sprintf @"protected %s __Call_%s__ { get; set; }"
+        let template = sprintf @"protected %s __%s__ { get; set; }"
 
         [
-            template "Allocate"                     "Allocate"
-            template "IAdjointable<(Qubit,Qubit)>"  "CNOT"
-            template "ICallable"                    "MicrosoftQuantumTestingHold"
-            template "Release"                      "Release"
-            template "ICallable<Result, String>"    "ResultToString"
-            template "IUnitary<Qubit>"              "X"
-            template "IUnitary"                     "genIter"
-            template "ICallable"                    "genMapper"
-            template "IUnitary"                     "genU1"
-            template "IUnitary"                     "MicrosoftQuantumTestingnoOpGeneric"
-            template "IUnitary<Result>"             "MicrosoftQuantumTestingnoOpResult"
+            template "Allocate" "Microsoft_Quantum_Intrinsic_Allocate"
+            template "IAdjointable<(Qubit,Qubit)>" "Microsoft_Quantum_Intrinsic_CNOT"
+            template "ICallable" "Microsoft_Quantum_Testing_Hold"
+            template "Release" "Microsoft_Quantum_Intrinsic_Release"
+            template "ICallable<Result, String>" "Microsoft_Quantum_Compiler_Generics_ResultToString"
+            template "IUnitary<Qubit>" "Microsoft_Quantum_Intrinsic_X"
+            template "IUnitary" "Microsoft_Quantum_Compiler_Generics_genIter"
+            template "ICallable" "Microsoft_Quantum_Compiler_Generics_genMapper"
+            template "IUnitary" "Microsoft_Quantum_Compiler_Generics_genU1"
+            template "IUnitary" "Microsoft_Quantum_Testing_noOpGeneric"
+            template "IUnitary<Result>" "Microsoft_Quantum_Testing_noOpResult"
         ]
         |> testOne usesGenerics
 
         [
-            template "ICallable"                    "genericWithMultipleTypeParams"
+            template "ICallable" "Microsoft_Quantum_Compiler_Generics_genericWithMultipleTypeParams"
         ]
         |> testOne callsGenericWithMultipleTypeParams
 
         [
-            template "IUnitary<Qubit>"              "Z"
+            template "IUnitary<Qubit>" "Microsoft_Quantum_Intrinsic_Z"
             "protected IAdjointable<Qubit> self { get; set; }"
         ]
         |> testOne selfInvokingOperation
@@ -1039,7 +1039,7 @@ namespace N1
         template "(Qubit,(Qubit,Double))" "QVoid" "twoQubitOperation"
         |> testOne twoQubitOperation
 
-        template "(Qubit,Qubit,Qubits)" "QVoid" "threeQubitOperation"
+        template "(Qubit,Qubit,Microsoft.Quantum.Intrinsic.Qubits)" "QVoid" "threeQubitOperation"
         |> testOne threeQubitOperation
 
         template "(Qubit,Qubit,IQArray<Qubit>)" "QVoid" "differentArgsOperation"
@@ -1095,37 +1095,37 @@ namespace N1
         |> testOne (applyVisitor zeroQubitOperation)
 
         [
-            "__Call_X__.Apply(q1);"
+            "__Microsoft_Quantum_Intrinsic_X__.Apply(q1);"
         ]
         |> testOne (applyVisitor oneQubitOperation)
 
         [
-            "__Call_X__.Adjoint.Apply(q1);"
+            "__Microsoft_Quantum_Intrinsic_X__.Adjoint.Apply(q1);"
         ]
         |> testOne (adjointVisitor oneQubitOperation)
 
         [
             "var (q2, r) = t1;        "
-            "__Call_CNOT__.Apply((q1,q2));       "
-            "__Call_R__.Apply((r,q1));           "
+            "__Microsoft_Quantum_Intrinsic_CNOT__.Apply((q1,q2));       "
+            "__Microsoft_Quantum_Intrinsic_R__.Apply((r,q1));           "
         ]
         |> testOne (applyVisitor twoQubitOperation)
         [
             "var (q2, r) = t1;        "
-            "__Call_R__.Adjoint.Apply((r,q1));"
-            "__Call_CNOT__.Adjoint.Apply((q1,q2));"
+            "__Microsoft_Quantum_Intrinsic_R__.Adjoint.Apply((r,q1));"
+            "__Microsoft_Quantum_Intrinsic_CNOT__.Adjoint.Apply((q1,q2));"
         ]
         |> testOne (adjointVisitor twoQubitOperation)
 
         [
-            "__Call_three_op1__.Apply((q1,q2));"
-            "__Call_three_op1__.Apply((q2,q1));"
-            "__Call_three_op1__.Apply((q1,q2));"
+            "__Microsoft_Quantum_Testing_three__op1__.Apply((q1,q2));"
+            "__Microsoft_Quantum_Testing_three__op1__.Apply((q2,q1));"
+            "__Microsoft_Quantum_Testing_three__op1__.Apply((q1,q2));"
         ]
         |> testOne (applyVisitor threeQubitOperation)
 
         [
-            "__Call_Z__.Adjoint.Apply(q1);"
+            "__Microsoft_Quantum_Intrinsic_Z__.Adjoint.Apply(q1);"
             "self.Apply(q1);"
         ]
         |> testOne (adjointVisitor selfInvokingOperation)
@@ -1167,7 +1167,7 @@ namespace N1
         let testOne = testOneBody
 
         [
-            "__Call_X__.Apply(q1);"
+            "__Microsoft_Quantum_Intrinsic_X__.Apply(q1);"
         ]
         |> testOne (applyVisitor oneQubitOperation)
 
@@ -1181,7 +1181,7 @@ namespace N1
         |> testOne (applyVisitor composeImpl)
 
         [
-            "return __Call_composeImpl__.Partial((second, first, _));"
+            "return __Microsoft_Quantum_Compiler_Generics_composeImpl__.Partial((second, first, _));"
         ]
         |> testOne (applyVisitor compose)
 
@@ -1190,22 +1190,22 @@ namespace N1
     let ``usesGenerics body`` () =
         [
             "var a = (IQArray<Result>)new QArray<Result>(Result.One, Result.Zero, Result.Zero);"
-            "var s = (IQArray<String>)new QArray<String>(__Call_ResultToString__.Apply(a[0L]), __Call_ResultToString__.Apply(a[1L]));"
-            "__Call_MicrosoftQuantumTestingnoOpResult__.Apply(a[0L]);"
+            "var s = (IQArray<String>)new QArray<String>(__Microsoft_Quantum_Compiler_Generics_ResultToString__.Apply(a[0L]), __Microsoft_Quantum_Compiler_Generics_ResultToString__.Apply(a[1L]));"
+            "__Microsoft_Quantum_Testing_noOpResult__.Apply(a[0L]);"
 
             """
             {
-                var qubits = __Call_Allocate__.Apply(3L);
+                var qubits = __Microsoft_Quantum_Intrinsic_Allocate__.Apply(3L);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    var op = __Call_MicrosoftQuantumTestingHold__.Partial(new Func<QVoid,(ICallable,(Qubit,Qubit),QVoid)>((__arg2__) => (__Call_CNOT__, (qubits[0L], qubits[1L]), __arg2__)));
+                    var op = __Microsoft_Quantum_Testing_Hold__.Partial(new Func<QVoid,(ICallable,(Qubit,Qubit),QVoid)>((__arg2__) => (__Microsoft_Quantum_Intrinsic_CNOT__, (qubits[0L], qubits[1L]), __arg2__)));
                     op.Apply(QVoid.Instance);
 
-                    __Call_MicrosoftQuantumTestingnoOpGeneric__.Apply(qubits[0L]);
-                    __Call_MicrosoftQuantumTestingnoOpGeneric__.Apply(a[0L]);
-                    __Call_genIter__.Apply((__Call_X__, qubits));
+                    __Microsoft_Quantum_Testing_noOpGeneric__.Apply(qubits[0L]);
+                    __Microsoft_Quantum_Testing_noOpGeneric__.Apply(a[0L]);
+                    __Microsoft_Quantum_Compiler_Generics_genIter__.Apply((__Microsoft_Quantum_Intrinsic_X__, qubits));
                 }
 #line hidden
                 catch
@@ -1218,17 +1218,17 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        __Call_Release__.Apply(qubits);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(qubits);
                     }
                 }
             }
             """
-            "__Call_genIter__.Apply((__Call_MicrosoftQuantumTestingnoOpResult__, a));"
+            "__Microsoft_Quantum_Compiler_Generics_genIter__.Apply((__Microsoft_Quantum_Testing_noOpResult__, a));"
             """
-            __Call_genIter__.Apply((__Call_genU1__, __Call_genMapper__.Apply<IQArray<String>>((__Call_ResultToString__, a))));
+            __Microsoft_Quantum_Compiler_Generics_genIter__.Apply((__Microsoft_Quantum_Compiler_Generics_genU1__, __Microsoft_Quantum_Compiler_Generics_genMapper__.Apply<IQArray<String>>((__Microsoft_Quantum_Compiler_Generics_ResultToString__, a))));
             """
-            "__Call_genIter__.Apply((__Call_genU1__, s));"
-            "__Call_genIter__.Apply((__Call_genU1__, a));"
+            "__Microsoft_Quantum_Compiler_Generics_genIter__.Apply((__Microsoft_Quantum_Compiler_Generics_genU1__, s));"
+            "__Microsoft_Quantum_Compiler_Generics_genIter__.Apply((__Microsoft_Quantum_Compiler_Generics_genU1__, a));"
         ]
         |> testOneBody (applyVisitor usesGenerics)
 
@@ -1236,20 +1236,20 @@ namespace N1
     [<Fact>]
     let ``callTests body`` () =
         [
-            "var plain = new call_plain(__Call_X__);"
-            "var adj   = new call_adj(__Call_X__);"
-            "var ctr   = new call_ctr(__Call_X__);"
-            "var uni   = new call_uni(__Call_X__);"
+            "var plain = new Microsoft.Quantum.Testing.call_plain(__Microsoft_Quantum_Intrinsic_X__);"
+            "var adj   = new Microsoft.Quantum.Testing.call_adj(__Microsoft_Quantum_Intrinsic_X__);"
+            "var ctr   = new Microsoft.Quantum.Testing.call_ctr(__Microsoft_Quantum_Intrinsic_X__);"
+            "var uni   = new Microsoft.Quantum.Testing.call_uni(__Microsoft_Quantum_Intrinsic_X__);"
 
-            "__Call_X__.Apply(qubits.Data[0L]);"
-            "__Call_X__.Adjoint.Apply(qubits.Data[0L]);"
-            "__Call_X__.Controlled.Apply((qubits.Data?.Slice(new QRange(1L,5L)), qubits.Data[0L]));"
+            "__Microsoft_Quantum_Intrinsic_X__.Apply(qubits.Data[0L]);"
+            "__Microsoft_Quantum_Intrinsic_X__.Adjoint.Apply(qubits.Data[0L]);"
+            "__Microsoft_Quantum_Intrinsic_X__.Controlled.Apply((qubits.Data?.Slice(new QRange(1L,5L)), qubits.Data[0L]));"
 
-            "__Call_call_target1__.Apply((1L, __Call_X__,     __Call_X__,   __Call_X__,   __Call_X__));"
-            "__Call_call_target1__.Apply((1L, plain.Data, adj.Data, ctr.Data, uni.Data));"
+            "__Microsoft_Quantum_Testing_call__target1__.Apply((1L, __Microsoft_Quantum_Intrinsic_X__,     __Microsoft_Quantum_Intrinsic_X__,   __Microsoft_Quantum_Intrinsic_X__,   __Microsoft_Quantum_Intrinsic_X__));"
+            "__Microsoft_Quantum_Testing_call__target1__.Apply((1L, plain.Data, adj.Data, ctr.Data, uni.Data));"
 
-            "__Call_call_target2__.Apply((1L, (Result.Zero, __Call_X__),    (Result.Zero, __Call_X__),  (Result.Zero, __Call_X__),  (Result.Zero, __Call_X__)));"
-            "__Call_call_target2__.Apply((2L, (Result.One, plain.Data), (Result.One, adj.Data), (Result.One, ctr.Data), (Result.One, uni.Data)));"
+            "__Microsoft_Quantum_Testing_call__target2__.Apply((1L, (Result.Zero, __Microsoft_Quantum_Intrinsic_X__),    (Result.Zero, __Microsoft_Quantum_Intrinsic_X__),  (Result.Zero, __Microsoft_Quantum_Intrinsic_X__),  (Result.Zero, __Microsoft_Quantum_Intrinsic_X__)));"
+            "__Microsoft_Quantum_Testing_call__target2__.Apply((2L, (Result.One, plain.Data), (Result.One, adj.Data), (Result.One, ctr.Data), (Result.One, uni.Data)));"
         ]
         |> testOneBody (applyVisitor callTests)
 
@@ -1259,7 +1259,7 @@ namespace N1
         [
             "var q2 = q1;"
 
-            "var r = __Call_M__.Apply(q1);"
+            "var r = __Microsoft_Quantum_Intrinsic_M__.Apply(q1);"
 
             "var i = 1.1D;"
             "var iZero = 0L;"
@@ -1274,15 +1274,15 @@ namespace N1
             "var (l,(m,o)) = t;             "
             "var (p,q) = t;                 "
             "var (u0,u1,u2,u3,call1) = udts;"
-            "var u = u3.Data.Apply<let_udt_2>(u1);"
+            "var u = u3.Data.Apply<Microsoft.Quantum.Testing.let_udt_2>(u1);"
             """
             if (true)
             {
                 var (l2,(m2,o2)) = t;
-                return u3.Data.Apply<let_udt_2>(u1).Data.Apply<QRange>(u1);
+                return u3.Data.Apply<Microsoft.Quantum.Testing.let_udt_2>(u1).Data.Apply<QRange>(u1);
             }
             """
-            "var s = String.Format(\"n is {0} and u is {1}, {2}, {3}, {4}\",n,u3.Data.Apply<let_udt_2>(u1),r,n,j);"
+            "var s = String.Format(\"n is {0} and u is {1}, {2}, {3}, {4}\",n,u3.Data.Apply<Microsoft.Quantum.Testing.let_udt_2>(u1),r,n,j);"
             "var str = String.Format(\"Hello{0} world!\", (true ? \" quantum\" : \"\"));"
 
             "var (l3,_) = t;"
@@ -1292,7 +1292,7 @@ namespace N1
             "var __arg1__ = t;"
             "var __arg2__ = t;"
 
-            "return __Call_let_f0__.Apply(n);"
+            "return __Microsoft_Quantum_Testing_let__f0__.Apply(n);"
         ]
         |> testOneBody (applyVisitor letsOperations)
 
@@ -1335,7 +1335,7 @@ namespace N1
             """
             if ((r == Result.One))
             {
-                n = (__Call_if_f0__.Apply(QVoid.Instance) * i);
+                n = (__Microsoft_Quantum_Testing_if__f0__.Apply(QVoid.Instance) * i);
             }
             """
             """
@@ -1359,7 +1359,7 @@ namespace N1
             }
             else
             {
-                return ((p==Pauli.PauliI)?3L:__Call_if_f0__.Apply(QVoid.Instance));
+                return ((p==Pauli.PauliI)?3L:__Microsoft_Quantum_Testing_if__f0__.Apply(QVoid.Instance));
             }
             """
         ]
@@ -1383,7 +1383,7 @@ namespace N1
             @"foreach (var n in range)
             #line hidden
             {
-                result = ((range.End + result) + (n * -(__Call_foreach_f2__.Apply((n, 4L)))));
+                result = ((range.End + result) + (n * -(__Microsoft_Quantum_Testing_foreach__f2__.Apply((n, 4L)))));
             }"
             """
             if ((result > 10L))
@@ -1400,28 +1400,28 @@ namespace N1
     [<Fact>]
     let ``udt operations`` () =
         [
-            "var args0 = new udt_args0(qubits);"
-            "var args1 = new udt_args1((1L, args0.Data));"
-            "var args1a = op2.Apply<udt_args1>(args0);"
-            "var args2 = new udt_args2(op2);"
-            "var args3 = new udt_args3(op2);"
-            "var args4 = new udt_args4(op2);"
+            "var args0 = new Microsoft.Quantum.Testing.udt_args0(qubits);"
+            "var args1 = new Microsoft.Quantum.Testing.udt_args1((1L, args0.Data));"
+            "var args1a = op2.Apply<Microsoft.Quantum.Testing.udt_args1>(args0);"
+            "var args2 = new Microsoft.Quantum.Testing.udt_args2(op2);"
+            "var args3 = new Microsoft.Quantum.Testing.udt_args3(op2);"
+            "var args4 = new Microsoft.Quantum.Testing.udt_args4(op2);"
             "var ext0  = new Microsoft.Quantum.Overrides.udt0((Result.Zero, Result.One));"
             "op0.Apply(args0);"
-            "op0.Apply(new udt_args0(qubits));"
+            "op0.Apply(new Microsoft.Quantum.Testing.udt_args0(qubits));"
             "op1.Apply(args1);"
-            "op1.Apply(new udt_args1((2L, qubits)));"
-            "op1.Apply(new udt_args1((3L, args0.Data)));"
-            "op1.Apply(new udt_args1((4L, new udt_args0(qubits).Data)));"
+            "op1.Apply(new Microsoft.Quantum.Testing.udt_args1((2L, qubits)));"
+            "op1.Apply(new Microsoft.Quantum.Testing.udt_args1((3L, args0.Data)));"
+            "op1.Apply(new Microsoft.Quantum.Testing.udt_args1((4L, new Microsoft.Quantum.Testing.udt_args0(qubits).Data)));"
 
-            "return new udt_args1((22L, qubits));"
+            "return new Microsoft.Quantum.Testing.udt_args1((22L, qubits));"
         ]
         |> testOneBody (applyVisitor udtsTest)
 
     [<Fact>]
     let ``test Length dependency`` () =
         [
-            "__Call_iter__.Apply((__Call_Length__, new QArray<IQArray<Result>>(new QArray<Result>(Result.One), new QArray<Result>(Result.Zero, Result.One))));"
+            "__Microsoft_Quantum_Testing_iter__.Apply((__Microsoft_Quantum_Core_Length__, new QArray<IQArray<Result>>(new QArray<Result>(Result.One), new QArray<Result>(Result.Zero, Result.One))));"
         ]
         |> testOneBody (applyVisitor testLengthDependency)
 
@@ -1443,7 +1443,7 @@ namespace N1
         |> testOneBody (applyVisitor returnTest3)
 
         [
-            "return new returnUdt0((7L, 8L));"
+            "return new Microsoft.Quantum.Testing.returnUdt0((7L, 8L));"
         ]
         |> testOneBody (applyVisitor returnTest4)
 
@@ -1453,22 +1453,22 @@ namespace N1
         |> testOneBody (applyVisitor returnTest5)
 
         [
-            "return new returnUdt1( new QArray<(Int64,Int64)>((1L, 2L), (3L, 4L)));"
+            "return new Microsoft.Quantum.Testing.returnUdt1( new QArray<(Int64,Int64)>((1L, 2L), (3L, 4L)));"
         ]
         |> testOneBody (applyVisitor returnTest6)
 
         [
-            "return new QArray<returnUdt0>( new returnUdt0((1L, 2L)), new returnUdt0((3L, 4L)));"
+            "return new QArray<Microsoft.Quantum.Testing.returnUdt0>( new Microsoft.Quantum.Testing.returnUdt0((1L, 2L)), new Microsoft.Quantum.Testing.returnUdt0((3L, 4L)));"
         ]
         |> testOneBody (applyVisitor returnTest7)
 
         [
-            "return new returnUdt3(new QArray<returnUdt0>(new returnUdt0((1L, 2L)), new returnUdt0((3L, 4L))));"
+            "return new Microsoft.Quantum.Testing.returnUdt3(new QArray<Microsoft.Quantum.Testing.returnUdt0>(new Microsoft.Quantum.Testing.returnUdt0((1L, 2L)), new Microsoft.Quantum.Testing.returnUdt0((3L, 4L))));"
         ]
         |> testOneBody (applyVisitor returnTest8)
 
         [
-            "return (new returnUdt0((7L, 8L)), new returnUdt1(new QArray<(Int64,Int64)>((1L, 2L), (3L, 4L))));"
+            "return (new Microsoft.Quantum.Testing.returnUdt0((7L, 8L)), new Microsoft.Quantum.Testing.returnUdt1(new QArray<(Int64,Int64)>((1L, 2L), (3L, 4L))));"
         ]
         |> testOneBody (applyVisitor returnTest9)
 
@@ -1482,22 +1482,22 @@ namespace N1
         [
             """
             {
-                var qubits = __Call_Allocate__.Apply(i);
+                var qubits = __Microsoft_Quantum_Intrinsic_Allocate__.Apply(i);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
                     while (true)
                     {
-                        var res =  __Call_repeat_op0__.Apply(new repeat_udt0((0L, qubits)));
+                        var res =  __Microsoft_Quantum_Testing_repeat__op0__.Apply(new Microsoft.Quantum.Testing.repeat_udt0((0L, qubits)));
 
-                        if ((__Call_repeat_op1__.Apply((0L, qubits)) == Result.One))
+                        if ((__Microsoft_Quantum_Testing_repeat__op1__.Apply((0L, qubits)) == Result.One))
                         {
                             break;
                         }
                         else
                         {
-                            res = __Call_repeat_op2__.Apply((3D, new repeat_udt0(((i-1L), qubits))));
+                            res = __Microsoft_Quantum_Testing_repeat__op2__.Apply((3D, new Microsoft.Quantum.Testing.repeat_udt0(((i-1L), qubits))));
                         }
                     }
                 }
@@ -1512,7 +1512,7 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        __Call_Release__.Apply(qubits);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(qubits);
                     }
                 }
             }
@@ -1525,14 +1525,14 @@ namespace N1
         [
             """
             {
-                var q = __Call_Allocate__.Apply();
+                var q = __Microsoft_Quantum_Intrinsic_Allocate__.Apply();
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
                     var flag = true;
-                    (flag ? __Call_X__ : __Call_Z__).Apply(q);
-                    __Call_alloc_op0__.Apply(q);
+                    (flag ? __Microsoft_Quantum_Intrinsic_X__ : __Microsoft_Quantum_Intrinsic_Z__).Apply(q);
+                    __Microsoft_Quantum_Testing_alloc__op0__.Apply(q);
                 }
 #line hidden
                 catch
@@ -1545,18 +1545,18 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        __Call_Release__.Apply(q);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(q);
                     }
                 }
             }"""
             """
             {
-                var qs = __Call_Allocate__.Apply(n);
+                var qs = __Microsoft_Quantum_Intrinsic_Allocate__.Apply(n);
 #line hidden
                 bool __arg2__ = true;
                 try
                 {
-                    __Call_alloc_op0__.Apply(qs[(n-1L)]);
+                    __Microsoft_Quantum_Testing_alloc__op0__.Apply(qs[(n-1L)]);
                 }
 #line hidden
                 catch
@@ -1569,19 +1569,19 @@ namespace N1
                 {
                     if (__arg2__)
                     {
-                        __Call_Release__.Apply(qs);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(qs);
                     }
                 }
             }"""
             """
             {
-                var (q1, (q2, (__arg3__, q3, __arg4__, q4))) = (__Call_Allocate__.Apply(), ((__Call_Allocate__.Apply(), __Call_Allocate__.Apply(2L)), (__Call_Allocate__.Apply(), __Call_Allocate__.Apply(n), __Call_Allocate__.Apply((n-1L)), __Call_Allocate__.Apply(4L))));
+                var (q1, (q2, (__arg3__, q3, __arg4__, q4))) = (__Microsoft_Quantum_Intrinsic_Allocate__.Apply(), ((__Microsoft_Quantum_Intrinsic_Allocate__.Apply(), __Microsoft_Quantum_Intrinsic_Allocate__.Apply(2L)), (__Microsoft_Quantum_Intrinsic_Allocate__.Apply(), __Microsoft_Quantum_Intrinsic_Allocate__.Apply(n), __Microsoft_Quantum_Intrinsic_Allocate__.Apply((n-1L)), __Microsoft_Quantum_Intrinsic_Allocate__.Apply(4L))));
 #line hidden
                 bool __arg5__ = true;
                 try
                 {
-                    __Call_alloc_op0__.Apply(q1);
-                    __Call_alloc_op0__.Apply(q3[1L]);
+                    __Microsoft_Quantum_Testing_alloc__op0__.Apply(q1);
+                    __Microsoft_Quantum_Testing_alloc__op0__.Apply(q3[1L]);
                 }
 #line hidden
                 catch
@@ -1594,13 +1594,13 @@ namespace N1
                 {
                     if (__arg5__)
                     {
-                        __Call_Release__.Apply(q1);
-                        __Call_Release__.Apply(q2.Item1);
-                        __Call_Release__.Apply(q2.Item2);
-                        __Call_Release__.Apply(__arg3__);
-                        __Call_Release__.Apply(q3);
-                        __Call_Release__.Apply(__arg4__);
-                        __Call_Release__.Apply(q4);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(q1);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(q2.Item1);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(q2.Item2);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(__arg3__);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(q3);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(__arg4__);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(q4);
                     }
                 }
             }"""
@@ -1610,12 +1610,12 @@ namespace N1
         [
             """
             {
-                var b = __Call_Borrow__.Apply(n);
+                var b = __Microsoft_Quantum_Intrinsic_Borrow__.Apply(n);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    __Call_alloc_op0__.Apply(b[(n-1L)]);
+                    __Microsoft_Quantum_Testing_alloc__op0__.Apply(b[(n-1L)]);
                 }
 #line hidden
                 catch
@@ -1628,25 +1628,25 @@ namespace N1
                 {
                     if (__arg1__)
                     {
-                        __Call_Return__.Apply(b);
+                        __Microsoft_Quantum_Intrinsic_Return__.Apply(b);
                     }
                 }
             }"""
             """
             {
-                var (q1, (q2, (__arg2__, q3))) = (__Call_Borrow__.Apply(), (__Call_Borrow__.Apply(2L), (__Call_Borrow__.Apply(), (__Call_Borrow__.Apply(n), __Call_Borrow__.Apply(4L)))));
+                var (q1, (q2, (__arg2__, q3))) = (__Microsoft_Quantum_Intrinsic_Borrow__.Apply(), (__Microsoft_Quantum_Intrinsic_Borrow__.Apply(2L), (__Microsoft_Quantum_Intrinsic_Borrow__.Apply(), (__Microsoft_Quantum_Intrinsic_Borrow__.Apply(n), __Microsoft_Quantum_Intrinsic_Borrow__.Apply(4L)))));
 #line hidden
                 bool __arg3__ = true;
                 try
                 {
                     {
-                        var qt = (__Call_Allocate__.Apply(), (__Call_Allocate__.Apply(1L), __Call_Allocate__.Apply(2L)));
+                        var qt = (__Microsoft_Quantum_Intrinsic_Allocate__.Apply(), (__Microsoft_Quantum_Intrinsic_Allocate__.Apply(1L), __Microsoft_Quantum_Intrinsic_Allocate__.Apply(2L)));
 #line hidden
                         bool __arg4__ = true;
                         try
                         {
                             var (qt1, qt2) = ((Qubit, (IQArray<Qubit>, IQArray<Qubit>)))qt;
-                            __Call_alloc_op0__.Apply(qt1);
+                            __Microsoft_Quantum_Testing_alloc__op0__.Apply(qt1);
                         }
 #line hidden
                         catch
@@ -1659,15 +1659,15 @@ namespace N1
                         {
                             if (__arg4__)
                             {
-                                __Call_Release__.Apply(qt.Item1);
-                                __Call_Release__.Apply(qt.Item2.Item1);
-                                __Call_Release__.Apply(qt.Item2.Item2);
+                                __Microsoft_Quantum_Intrinsic_Release__.Apply(qt.Item1);
+                                __Microsoft_Quantum_Intrinsic_Release__.Apply(qt.Item2.Item1);
+                                __Microsoft_Quantum_Intrinsic_Release__.Apply(qt.Item2.Item2);
                             }
                         }
                     }
 
-                    __Call_alloc_op0__.Apply(q1);
-                    __Call_alloc_op0__.Apply(q2[1L]);
+                    __Microsoft_Quantum_Testing_alloc__op0__.Apply(q1);
+                    __Microsoft_Quantum_Testing_alloc__op0__.Apply(q2[1L]);
                 }
 #line hidden
                 catch
@@ -1680,11 +1680,11 @@ namespace N1
                 {
                     if (__arg3__)
                     {
-                        __Call_Return__.Apply(q1);
-                        __Call_Return__.Apply(q2);
-                        __Call_Return__.Apply(__arg2__);
-                        __Call_Return__.Apply(q3.Item1);
-                        __Call_Return__.Apply(q3.Item2);
+                        __Microsoft_Quantum_Intrinsic_Return__.Apply(q1);
+                        __Microsoft_Quantum_Intrinsic_Return__.Apply(q2);
+                        __Microsoft_Quantum_Intrinsic_Return__.Apply(__arg2__);
+                        __Microsoft_Quantum_Intrinsic_Return__.Apply(q3.Item1);
+                        __Microsoft_Quantum_Intrinsic_Return__.Apply(q3.Item2);
                     }
                 }
             }"""
@@ -1745,7 +1745,7 @@ namespace N1
         {
             var q1 = __in__;
 
-            __Call_X__.Apply(q1);
+            __Microsoft_Quantum_Intrinsic_X__.Apply(q1);
             #line hidden
             return  QVoid.Instance;
         };
@@ -1759,8 +1759,8 @@ namespace N1
 
             var (q2,r) = t1;
 
-            __Call_CNOT__.Apply((q1, q2));
-            __Call_R__.Apply((r, q1));
+            __Microsoft_Quantum_Intrinsic_CNOT__.Apply((q1, q2));
+            __Microsoft_Quantum_Intrinsic_R__.Apply((r, q1));
 
             #line hidden
             return  QVoid.Instance;
@@ -1774,10 +1774,10 @@ namespace N1
         {
             var (q1,q2,arr1) = __in__;
 
-            __Call_da_op0__.Apply(QVoid.Instance);
-            __Call_da_op1__.Adjoint.Apply(q1);
-            __Call_da_op2__.Controlled.Apply((new QArray<Qubit>(q1), (1L, q2)));
-            __Call_da_op3__.Controlled.Adjoint.Apply((new QArray<Qubit>(q1, q2), (1.1D, Result.One, arr1.Length)));
+            __Microsoft_Quantum_Testing_da__op0__.Apply(QVoid.Instance);
+            __Microsoft_Quantum_Testing_da__op1__.Adjoint.Apply(q1);
+            __Microsoft_Quantum_Testing_da__op2__.Controlled.Apply((new QArray<Qubit>(q1), (1L, q2)));
+            __Microsoft_Quantum_Testing_da__op3__.Controlled.Adjoint.Apply((new QArray<Qubit>(q1, q2), (1.1D, Result.One, arr1.Length)));
 
             #line hidden
             return QVoid.Instance;
@@ -1800,7 +1800,7 @@ namespace N1
         public override Func<(Qubit, %s, %s, %s, (%s, %s), %s), %s> __Body__  => (__in__) =>
                 {
                     var (q1, op0, op1, op2, t1, f1) = __in__;
-                    op1.Apply(__Call_OP_1__);
+                    op1.Apply(__Microsoft_Quantum_Testing_OP__1__);
                     var v0 = op0;
                     var r0 = v0.Apply<Result>(q1);
                     var (op3, op4) = t1;
@@ -1823,15 +1823,15 @@ namespace N1
             "var r7 = (IQArray<Int64>)QArray<Int64>.Add(r2, r4);"
             "var r8 = (IQArray<Int64>)r7?.Slice(new QRange(1L, 5L, 10L));"
 
-            "var r9 = new arrays_T1(new QArray<Pauli>(Pauli.PauliX, Pauli.PauliY));"
-            "var r10 = (IQArray<arrays_T1>)QArray<arrays_T1>.Create(4L);"
-            "var r11 = new arrays_T2((new QArray<Pauli>(Pauli.PauliZ), new QArray<Int64>(4L)));"
-            "var r12 = (IQArray<arrays_T2>)QArray<arrays_T2>.Create(r10.Length);"
-            "var r13 = new arrays_T3(new QArray<IQArray<Result>>(new QArray<Result>(Result.Zero, Result.One), new QArray<Result>(Result.One, Result.Zero)));"
+            "var r9 = new Microsoft.Quantum.Testing.arrays_T1(new QArray<Pauli>(Pauli.PauliX, Pauli.PauliY));"
+            "var r10 = (IQArray<Microsoft.Quantum.Testing.arrays_T1>)QArray<Microsoft.Quantum.Testing.arrays_T1>.Create(4L);"
+            "var r11 = new Microsoft.Quantum.Testing.arrays_T2((new QArray<Pauli>(Pauli.PauliZ), new QArray<Int64>(4L)));"
+            "var r12 = (IQArray<Microsoft.Quantum.Testing.arrays_T2>)QArray<Microsoft.Quantum.Testing.arrays_T2>.Create(r10.Length);"
+            "var r13 = new Microsoft.Quantum.Testing.arrays_T3(new QArray<IQArray<Result>>(new QArray<Result>(Result.Zero, Result.One), new QArray<Result>(Result.One, Result.Zero)));"
             "var r14 = (IQArray<Qubit>)QArray<Qubit>.Add(qubits, register.Data);"
             "var r15 = (IQArray<Qubit>)register.Data?.Slice(new QRange(0L, 2L));"
             "var r16 = (IQArray<Qubit>)qubits?.Slice(new QRange(1L, -(1L)));"
-            "var r18 = (IQArray<Qubits>)QArray<Qubits>.Create(2L);"
+            "var r18 = (IQArray<Microsoft.Quantum.Intrinsic.Qubits>)QArray<Microsoft.Quantum.Intrinsic.Qubits>.Create(2L);"
             "var r19 = (IQArray<Microsoft.Quantum.Overrides.udt0>)QArray<Microsoft.Quantum.Overrides.udt0>.Create(7L);"
             "var i0 = r13.Data[0L][1L];"
             "var i1 = r2[(0L + r1.Length)];"
@@ -1864,7 +1864,7 @@ namespace N1
             "var s1 = (IQArray<Qubit>)qubits?.Slice(new QRange(0L,10L));"
             "var s2 = (IQArray<Qubit>)qubits?.Slice(r2);"
             "var s3 = (IQArray<Qubit>)qubits?.Slice(ranges[3L]);"
-            "var s4 = (IQArray<Qubit>)qubits?.Slice(__Call_GetMeARange__.Apply(QVoid.Instance));"
+            "var s4 = (IQArray<Qubit>)qubits?.Slice(__Microsoft_Quantum_Testing_GetMeARange__.Apply(QVoid.Instance));"
 
             "return qubits?.Slice(new QRange(10L,-(3L),0L));"
         ]
@@ -1947,7 +1947,7 @@ namespace N1
         public override Func<Qubit, QVoid> __AdjointBody__ => (__in__) =>
         {
             var q1 = __in__;
-            __Call_X__.Adjoint.Apply(q1);
+            __Microsoft_Quantum_Intrinsic_X__.Adjoint.Apply(q1);
 
             #line hidden
             return QVoid.Instance;
@@ -1961,8 +1961,8 @@ namespace N1
 
             var (q2,r) = t1;
 
-            __Call_R__.Adjoint.Apply((r, q1));
-            __Call_CNOT__.Adjoint.Apply((q1, q2));
+            __Microsoft_Quantum_Intrinsic_R__.Adjoint.Apply((r, q1));
+            __Microsoft_Quantum_Intrinsic_CNOT__.Adjoint.Apply((q1, q2));
 
             #line hidden
             return QVoid.Instance;
@@ -1970,12 +1970,12 @@ namespace N1
         |> testOne twoQubitOperation
 
         Some """
-        public override Func<(Qubit,Qubit,Qubits), QVoid> __AdjointBody__ => (__in__) =>
+        public override Func<(Qubit,Qubit,Microsoft.Quantum.Intrinsic.Qubits), QVoid> __AdjointBody__ => (__in__) =>
         {
             var (q1,q2,arr1) = __in__;
-            __Call_three_op1__.Adjoint.Apply((q1, q2));
-            __Call_three_op1__.Adjoint.Apply((q2, q1));
-            __Call_three_op1__.Adjoint.Apply((q1, q2));
+            __Microsoft_Quantum_Testing_three__op1__.Adjoint.Apply((q1, q2));
+            __Microsoft_Quantum_Testing_three__op1__.Adjoint.Apply((q2, q1));
+            __Microsoft_Quantum_Testing_three__op1__.Adjoint.Apply((q1, q2));
             #line hidden
             return QVoid.Instance;
         };"""
@@ -2013,7 +2013,7 @@ namespace N1
         {
             var (c, q1) = __in__;
 
-            __Call_X__.Controlled.Apply((c, q1));
+            __Microsoft_Quantum_Intrinsic_X__.Controlled.Apply((c, q1));
 
             #line hidden
             return QVoid.Instance;
@@ -2021,13 +2021,13 @@ namespace N1
         |> testOne oneQubitOperation
 
         Some """
-        public override Func<(IQArray<Qubit>,(Qubit,Qubit,Qubits)), QVoid> __ControlledBody__ => (__in__) =>
+        public override Func<(IQArray<Qubit>,(Qubit,Qubit,Microsoft.Quantum.Intrinsic.Qubits)), QVoid> __ControlledBody__ => (__in__) =>
         {
             var (c, (q1, q2, arr1)) = __in__;
 
-            __Call_three_op1__.Controlled.Apply((c, (q1, q2)));
-            __Call_three_op1__.Controlled.Apply((c, (q2, q1)));
-            __Call_three_op1__.Controlled.Apply((c, (q1, q2)));
+            __Microsoft_Quantum_Testing_three__op1__.Controlled.Apply((c, (q1, q2)));
+            __Microsoft_Quantum_Testing_three__op1__.Controlled.Apply((c, (q2, q1)));
+            __Microsoft_Quantum_Testing_three__op1__.Controlled.Apply((c, (q1, q2)));
 
             #line hidden
             return QVoid.Instance;
@@ -2061,7 +2061,7 @@ namespace N1
         public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            __Call_X__.Controlled.Adjoint.Apply((c, q1));
+            __Microsoft_Quantum_Intrinsic_X__.Controlled.Adjoint.Apply((c, q1));
             #line hidden
             return QVoid.Instance;
         };"""
@@ -2069,13 +2069,13 @@ namespace N1
         |> testOne oneQubitOperation
 
         Some """
-        public override Func<(IQArray<Qubit>,(Qubit,Qubit,Qubits)), QVoid> __ControlledAdjointBody__ => (__in__) =>
+        public override Func<(IQArray<Qubit>,(Qubit,Qubit,Microsoft.Quantum.Intrinsic.Qubits)), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (c,(q1,q2,arr1)) = __in__;
 
-            __Call_three_op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
-            __Call_three_op1__.Controlled.Adjoint.Apply((c, (q2, q1)));
-            __Call_three_op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
+            __Microsoft_Quantum_Testing_three__op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
+            __Microsoft_Quantum_Testing_three__op1__.Controlled.Adjoint.Apply((c, (q2, q1)));
+            __Microsoft_Quantum_Testing_three__op1__.Controlled.Adjoint.Apply((c, (q1, q2)));
 
             #line hidden
             return QVoid.Instance;
@@ -2086,40 +2086,40 @@ namespace N1
     let ``partial application`` () =
         [
             //todo: "partial1Args.Partial<Int64>(_).Apply(1L);"
-            "__Call_partial3Args__
+            "__Microsoft_Quantum_Testing_partial3Args__
                 .Partial(new Func<(Int64,Double,Result), (Int64,Double,Result)>((__arg1__) => (__arg1__.Item1, __arg1__.Item2, __arg1__.Item3)))
                 .Apply((1L, 3.5D, Result.One));"
-            "__Call_partial3Args__
+            "__Microsoft_Quantum_Testing_partial3Args__
                 .Partial(new Func<Double, (Int64,Double,Result)>((__arg2__) => (1L, __arg2__, Result.Zero)))
                 .Apply(3.5D);"
-            "__Call_partial3Args__
+            "__Microsoft_Quantum_Testing_partial3Args__
                 .Partial(new Func<(Int64,Result), (Int64,Double,Result)>((__arg3__) => (__arg3__.Item1, 3.5D, __arg3__.Item2)))
                 .Apply((1L, Result.Zero));"
-            "__Call_partial3Args__
+            "__Microsoft_Quantum_Testing_partial3Args__
                 .Partial(new Func<Result, (Int64,Double,Result)>((__arg4__) => (1L, 3.5D, __arg4__)))
                 .Apply(Result.Zero);"
-            "__Call_partial3Args__
+            "__Microsoft_Quantum_Testing_partial3Args__
                 .Partial(new Func<(Double,Result), (Int64,Double,Result)>((__arg5__) => (1L, __arg5__.Item1, __arg5__.Item2)))
                 .Apply((3.5D, Result.Zero));"
-            "__Call_partialInnerTuple__
+            "__Microsoft_Quantum_Testing_partialInnerTuple__
                 .Partial(new Func<(Int64,(Double,Result)), (Int64,(Double,Result))>((__arg6__) => (__arg6__.Item1, (__arg6__.Item2.Item1, __arg6__.Item2.Item2))))
                 .Apply((1L, (3.5D, Result.One)));"
-            "__Call_partialInnerTuple__
+            "__Microsoft_Quantum_Testing_partialInnerTuple__
                 .Partial(new Func<(Int64,(Double,Result)), (Int64,(Double,Result))>((__arg7__) => (__arg7__.Item1, (__arg7__.Item2.Item1, __arg7__.Item2.Item2))))
                 .Apply((1L, (3.5D, Result.Zero)));"
-            "__Call_partialInnerTuple__
+            "__Microsoft_Quantum_Testing_partialInnerTuple__
                 .Partial(new Func<(Double,Result), (Int64,(Double,Result))>((__arg8__) => (1L, (__arg8__.Item1, __arg8__.Item2))))
                 .Apply((3.5D, Result.Zero));"
-            "__Call_partialInnerTuple__
+            "__Microsoft_Quantum_Testing_partialInnerTuple__
                 .Partial(new Func<(Int64,Result), (Int64,(Double,Result))>((__arg9__) => (__arg9__.Item1, (3.5D, __arg9__.Item2))))
                 .Apply((1L, Result.Zero));"
-            "__Call_partialInnerTuple__
+            "__Microsoft_Quantum_Testing_partialInnerTuple__
                 .Partial(new Func<(Int64,Double), (Int64,(Double,Result))>((__arg10__) => (__arg10__.Item1, (__arg10__.Item2, Result.One))))
                 .Apply((1L, 3.5D));"
-            "__Call_partialInnerTuple__
+            "__Microsoft_Quantum_Testing_partialInnerTuple__
                 .Partial(new Func<Result, (Int64,(Double,Result))>((__arg11__) => (1L, (3.5D, __arg11__))))
                 .Apply(Result.One);"
-            "__Call_partialNestedArgsOp__
+            "__Microsoft_Quantum_Testing_partialNestedArgsOp__
                 .Partial(new Func<((Int64,Int64,Int64),((Double,Double),(Result,Result,Result))), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg12__) =>
                     (
                         (__arg12__.Item1.Item1, __arg12__.Item1.Item2, __arg12__.Item1.Item3),
@@ -2139,7 +2139,7 @@ namespace N1
                     )
                 ))
                 .Apply((1L, ((3.3D, 2D), Result.Zero)));"
-            "__Call_partialNestedArgsOp__
+            "__Microsoft_Quantum_Testing_partialNestedArgsOp__
                 .Partial(new Func<(Int64,((Double,Double),Result)), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg14__) =>
                     (
                         (1L, i, __arg14__.Item1),
@@ -2159,7 +2159,7 @@ namespace N1
                     )
                 ))
                 .Apply((3.3D, Result.Zero));"
-            "__Call_partialNestedArgsOp__
+            "__Microsoft_Quantum_Testing_partialNestedArgsOp__
                 .Partial(new Func<(Int64,(Double,Result)), ((Int64,Int64,Int64),((Double,Double),(Result,Result,Result)))>((__arg16__) =>
                     (
                         (i, __arg16__.Item1, 1L),
@@ -2175,20 +2175,20 @@ namespace N1
                     )
                 ))
                 .Apply(3.3D);"
-            "__Call_partialGeneric1__
+            "__Microsoft_Quantum_Testing_partialGeneric1__
                 .Partial(new Func<Int64, (Int64, Result, (Int64, Result))>((__arg18__) =>
                     (0L, Result.Zero, (__arg18__, Result.One))
                 ))
                 .Apply(1L);"
-            "__Call_partialGeneric1__
+            "__Microsoft_Quantum_Testing_partialGeneric1__
                 .Partial(new Func<(Int64, Result), (Int64, Result, (Int64, Result))>((__arg19__) =>
                     (__arg19__.Item1, __arg19__.Item2, (1L, Result.One))
                 ))
                 .Apply((0L, Result.Zero));"
-            "__Call_partialGeneric1__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
-            "__Call_partialGeneric2__.Partial((0L, Result.Zero, (_, Result.One))).Apply(1L);"
-            "__Call_partialGeneric2__.Partial((_, _, (1L, Result.One))).Apply((0L, Result.Zero));"
-            "__Call_partialGeneric2__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
+            "__Microsoft_Quantum_Testing_partialGeneric1__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
+            "__Microsoft_Quantum_Testing_partialGeneric2__.Partial((0L, Result.Zero, (_, Result.One))).Apply(1L);"
+            "__Microsoft_Quantum_Testing_partialGeneric2__.Partial((_, _, (1L, Result.One))).Apply((0L, Result.Zero));"
+            "__Microsoft_Quantum_Testing_partialGeneric2__.Partial((0L, _, (1L, _))).Apply((Result.Zero, Result.One));"
             "partialInput
                 .Partial(new Func<(Double,(Result,Result)), (Int64,(Double,Double),(Result,Result,Result))>((__arg20__) =>
                     (
@@ -2203,7 +2203,7 @@ namespace N1
                 .Partial(new Func<IQArray<Qubit>, (Double,ICallable,IQArray<Qubit>)>((__arg21__) =>
                 (
                     1.1D,
-                    __Call_partialFunction__.Partial(new Func<(Int64,Double), (Int64,Double,Pauli)>((__arg22__) =>
+                    __Microsoft_Quantum_Testing_partialFunction__.Partial(new Func<(Int64,Double), (Int64,Double,Pauli)>((__arg22__) =>
                         (
                             __arg22__.Item1,
                             __arg22__.Item2,
@@ -2217,17 +2217,17 @@ namespace N1
         |> testOneBody (applyVisitor partialApplicationTest)
 
         [
-            "var r1 = __Call_partialFunction__
+            "var r1 = __Microsoft_Quantum_Testing_partialFunction__
                 .Partial(new Func<(Int64,Double,Pauli), (Int64,Double,Pauli)>((__arg1__) => (__arg1__.Item1, __arg1__.Item2, __arg1__.Item3)))
                 .Apply<Result>((2L, 2.2D, Pauli.PauliY));"
-            "var r2 = __Call_partialFunction__
+            "var r2 = __Microsoft_Quantum_Testing_partialFunction__
                 .Partial(new Func<(Double,Pauli), (Int64,Double,Pauli)>((__arg2__) => (1L, __arg2__.Item1, __arg2__.Item2)))
                 .Partial(new Func<Pauli, (Double,Pauli)>((__arg3__) => (3.3D, __arg3__)))
                 .Apply<Result>(Pauli.PauliZ);"
             "var (a,d) = t1;"
             "var (b,e) = t2;"
-            "var f = new F((d, e));"
-            "return op.Data.Partial(new Func<IQArray<Qubit>, (Double,F,IQArray<Qubit>)>((__arg4__) => (start, f, __arg4__)));"
+            "var f = new Microsoft.Quantum.Testing.F((d, e));"
+            "return op.Data.Partial(new Func<IQArray<Qubit>, (Double,Microsoft.Quantum.Testing.F,IQArray<Qubit>)>((__arg4__) => (start, f, __arg4__)));"
         ]
         |> testOneBody (applyVisitor partialFunctionTest)
 
@@ -2258,16 +2258,16 @@ namespace N1
         |> testOne oneQubitSelfAdjointAbstractOperation
 
 
-        "public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Qubit q1, Basis b, (Pauli, IQArray<IQArray<Double>>, Boolean) t, Int64 i)
+        "public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Qubit q1, Microsoft.Quantum.Testing.Basis b, (Pauli, IQArray<IQArray<Double>>, Boolean) t, Int64 i)
         {
-            return __m__.Run<randomAbstractOperation, (Qubit, Basis, (Pauli, IQArray<IQArray<Double>>, Boolean), Int64), QVoid>((q1,b,t,i));
+            return __m__.Run<randomAbstractOperation, (Qubit, Microsoft.Quantum.Testing.Basis, (Pauli, IQArray<IQArray<Double>>, Boolean), Int64), QVoid>((q1,b,t,i));
         }"
         |> testOne randomAbstractOperation
 
 
-        "public static System.Threading.Tasks.Task<IQArray<IQArray<Result>>> Run(IOperationFactory __m__, IQArray<Qubit> qubits, Qubits register, IQArray<IQArray<QRange>> indices, arrays_T3 t)
+        "public static System.Threading.Tasks.Task<IQArray<IQArray<Result>>> Run(IOperationFactory __m__, IQArray<Qubit> qubits, Microsoft.Quantum.Intrinsic.Qubits register, IQArray<IQArray<QRange>> indices, Microsoft.Quantum.Testing.arrays_T3 t)
         {
-            return __m__.Run<arraysOperations, (IQArray<Qubit>, Qubits, IQArray<IQArray<QRange>>, arrays_T3), IQArray<IQArray<Result>>>((qubits, register, indices, t));
+            return __m__.Run<arraysOperations, (IQArray<Qubit>, Microsoft.Quantum.Intrinsic.Qubits, IQArray<IQArray<QRange>>, Microsoft.Quantum.Testing.arrays_T3), IQArray<IQArray<Result>>>((qubits, register, indices, t));
         }"
         |> testOne arraysOperations
 
@@ -2371,15 +2371,15 @@ namespace N1
         |> testOneClass emptyOperation AssemblyConstants.HoneywellProcessor
 
         """
-    public abstract partial class randomAbstractOperation : Unitary<(Qubit,Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64)>, ICallable
+    public abstract partial class randomAbstractOperation : Unitary<(Qubit,Microsoft.Quantum.Testing.Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64)>, ICallable
     {
         public randomAbstractOperation(IOperationFactory m) : base(m)
         {
         }
 
-        public class In : QTuple<(Qubit,Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64)>, IApplyData
+        public class In : QTuple<(Qubit,Microsoft.Quantum.Testing.Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64)>, IApplyData
         {
-            public In((Qubit,Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64) data) : base(data)
+            public In((Qubit,Microsoft.Quantum.Testing.Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64) data) : base(data)
             {
             }
 
@@ -2395,15 +2395,15 @@ namespace N1
         String ICallable.Name => "randomAbstractOperation";
         String ICallable.FullName => "Microsoft.Quantum.Testing.randomAbstractOperation";
 
-        public static IonQEntryPointInfo<(Qubit, Basis, (Pauli, IQArray<IQArray<Double>>, Boolean), Int64), QVoid> Info => new IonQEntryPointInfo<(Qubit, Basis, (Pauli, IQArray<IQArray<Double>>, Boolean), Int64), QVoid>(typeof(randomAbstractOperation));
+        public static IonQEntryPointInfo<(Qubit, Microsoft.Quantum.Testing.Basis, (Pauli, IQArray<IQArray<Double>>, Boolean), Int64), QVoid> Info => new IonQEntryPointInfo<(Qubit, Microsoft.Quantum.Testing.Basis, (Pauli, IQArray<IQArray<Double>>, Boolean), Int64), QVoid>(typeof(randomAbstractOperation));
 
         public override void __Init__() { }
 
-        public override IApplyData __DataIn__((Qubit,Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64) data) => new In(data);
+        public override IApplyData __DataIn__((Qubit,Microsoft.Quantum.Testing.Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64) data) => new In(data);
         public override IApplyData __DataOut__(QVoid data) => data;
-        public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Qubit q1, Basis b, (Pauli,IQArray<IQArray<Double>>,Boolean) t, Int64 i)
+        public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Qubit q1, Microsoft.Quantum.Testing.Basis b, (Pauli,IQArray<IQArray<Double>>,Boolean) t, Int64 i)
         {
-            return __m__.Run<randomAbstractOperation, (Qubit,Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64), QVoid>((q1, b, t, i));
+            return __m__.Run<randomAbstractOperation, (Qubit,Microsoft.Quantum.Testing.Basis,(Pauli,IQArray<IQArray<Double>>,Boolean),Int64), QVoid>((q1, b, t, i));
         }
     }
 """
@@ -2425,12 +2425,12 @@ namespace N1
 
         public static QCIEntryPointInfo<Qubit, QVoid> Info => new QCIEntryPointInfo<Qubit, QVoid>(typeof(oneQubitOperation));
 
-        protected IUnitary<Qubit> __Call_X__ { get; set; }
+        protected IUnitary<Qubit> __Microsoft_Quantum_Intrinsic_X__ { get; set; }
 
         public override Func<Qubit, QVoid> __Body__ => (__in__) =>
         {
             var q1 = __in__;
-            __Call_X__.Apply(q1);
+            __Microsoft_Quantum_Intrinsic_X__.Apply(q1);
 #line hidden
             return QVoid.Instance;
         }
@@ -2439,7 +2439,7 @@ namespace N1
         public override Func<Qubit, QVoid> __AdjointBody__ => (__in__) =>
         {
             var q1 = __in__;
-            __Call_X__.Adjoint.Apply(q1);
+            __Microsoft_Quantum_Intrinsic_X__.Adjoint.Apply(q1);
 #line hidden
             return QVoid.Instance;
         }
@@ -2448,7 +2448,7 @@ namespace N1
         public override Func<(IQArray<Qubit>,Qubit), QVoid> __ControlledBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            __Call_X__.Controlled.Apply((c, q1));
+            __Microsoft_Quantum_Intrinsic_X__.Controlled.Apply((c, q1));
 #line hidden
             return QVoid.Instance;
         }
@@ -2457,7 +2457,7 @@ namespace N1
         public override Func<(IQArray<Qubit>,Qubit), QVoid> __ControlledAdjointBody__ => (__in__) =>
         {
             var (c,q1) = __in__;
-            __Call_X__.Controlled.Adjoint.Apply((c, q1));
+            __Microsoft_Quantum_Intrinsic_X__.Controlled.Adjoint.Apply((c, q1));
 #line hidden
             return QVoid.Instance;
         }
@@ -2466,7 +2466,7 @@ namespace N1
 
         public override void __Init__()
         {
-            this.__Call_X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
+            this.__Microsoft_Quantum_Intrinsic_X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
         }
 
         public override IApplyData __DataIn__(Qubit data) => data;
@@ -2672,17 +2672,17 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
     [<Fact>]
     let ``duplicatedDefinitionsCaller body`` () =
         [
-            "__Call_emptyFunction__.Apply(QVoid.Instance);"
-            "__Call_MicrosoftQuantumOverridesemptyFunction__.Apply(QVoid.Instance);"
+            "__Microsoft_Quantum_Testing_emptyFunction__.Apply(QVoid.Instance);"
+            "__Microsoft_Quantum_Overrides_emptyFunction__.Apply(QVoid.Instance);"
             """
             {
-                var qubits = __Call_Allocate__.Apply(1L);
+                var qubits = __Microsoft_Quantum_Intrinsic_Allocate__.Apply(1L);
 #line hidden
                 bool __arg1__ = true;
                 try
                 {
-                    __Call_H__.Apply(qubits[0L]);
-                    __Call_MicrosoftQuantumIntrinsicH__.Apply(qubits[0L]);
+                    __Microsoft_Quantum_Testing_H__.Apply(qubits[0L]);
+                    __Microsoft_Quantum_Intrinsic_H__.Apply(qubits[0L]);
                 }
 #line hidden
                 catch
@@ -2695,7 +2695,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
                 {
                     if (__arg1__)
                     {
-                        __Call_Release__.Apply(qubits);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(qubits);
                     }
                 }
             }"""
@@ -2705,17 +2705,17 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
 
     [<Fact>]
     let ``buildOpsProperties with duplicatedDefinitionsCaller`` () =
-        let t = sprintf @"protected %s __Call_%s__ { get; set; }"
+        let t = sprintf @"protected %s __%s__ { get; set; }"
         let template (sign: string) (name: string) = t sign name
 
         let expected =
             [
-                template "Allocate"                "Allocate"
-                template "IUnitary<Qubit>"         "MicrosoftQuantumIntrinsicH"
-                template "ICallable<Qubit, QVoid>" "H"
-                template "Release"                 "Release"
-                template "ICallable<QVoid, QVoid>" "MicrosoftQuantumOverridesemptyFunction"
-                template "ICallable<QVoid, QVoid>" "emptyFunction"
+                template "Allocate" "Microsoft_Quantum_Intrinsic_Allocate"
+                template "IUnitary<Qubit>" "Microsoft_Quantum_Intrinsic_H"
+                template "ICallable<Qubit, QVoid>" "Microsoft_Quantum_Testing_H"
+                template "Release" "Microsoft_Quantum_Intrinsic_Release"
+                template "ICallable<QVoid, QVoid>" "Microsoft_Quantum_Overrides_emptyFunction"
+                template "ICallable<QVoid, QVoid>" "Microsoft_Quantum_Testing_emptyFunction"
             ]
 
         let (_,op) = duplicatedDefinitionsCaller
@@ -2731,13 +2731,13 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
 
     [<Fact>]
     let ``buildOpsProperties - internal callables`` () =
-        let property = sprintf "private protected %s __Call_%s__ { get; set; }"
+        let property = sprintf "private protected %s __%s__ { get; set; }"
         let expected =
             [
-                property "ICallable<QVoid, QVoid>" "EmptyInternalFunction"
-                property "ICallable<QVoid, QVoid>" "EmptyInternalOperation"
-                property "ICallable<QVoid, InternalType>" "InternalType"
-                property "ICallable<QVoid, InternalType>" "MakeInternalType"
+                property "ICallable<QVoid, QVoid>" "Microsoft_Quantum_Compiler_Generics_EmptyInternalFunction"
+                property "ICallable<QVoid, QVoid>" "Microsoft_Quantum_Compiler_Generics_EmptyInternalOperation"
+                property "ICallable<QVoid, Microsoft.Quantum.Compiler.Generics.InternalType>" "Microsoft_Quantum_Compiler_Generics_InternalType"
+                property "ICallable<QVoid, Microsoft.Quantum.Compiler.Generics.InternalType>" "Microsoft_Quantum_Compiler_Generics_MakeInternalType"
             ]
         let op = snd useInternalCallables
         let actual =
@@ -2753,7 +2753,7 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
     let ``buildOperationClass - concrete functions`` () =
         """
     [SourceLocation("%%%", OperationFunctor.Body, 1306,1315)]
-    public partial class UpdateUdtItems : Function<MyType2, MyType2>, ICallable
+    public partial class UpdateUdtItems : Function<Microsoft.Quantum.Compiler.Generics.MyType2, Microsoft.Quantum.Compiler.Generics.MyType2>, ICallable
     {
         public UpdateUdtItems(IOperationFactorym) : base(m)
         {
@@ -2761,22 +2761,22 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
 
         String ICallable.Name => "UpdateUdtItems";
         String ICallable.FullName => "Microsoft.Quantum.Compiler.Generics.UpdateUdtItems";
-        public static EntryPointInfo<MyType2, MyType2> Info => new EntryPointInfo<MyType2, MyType2>(typeof(UpdateUdtItems));
+        public static EntryPointInfo<Microsoft.Quantum.Compiler.Generics.MyType2, Microsoft.Quantum.Compiler.Generics.MyType2> Info => new EntryPointInfo<Microsoft.Quantum.Compiler.Generics.MyType2, Microsoft.Quantum.Compiler.Generics.MyType2>(typeof(UpdateUdtItems));
 
-        public override Func<MyType2, MyType2> __Body__ => (__in__) =>
+        public override Func<Microsoft.Quantum.Compiler.Generics.MyType2, Microsoft.Quantum.Compiler.Generics.MyType2> __Body__ => (__in__) =>
         {
             var udt = __in__;
             vararr=QArray<Int64>.Create(10L);
-            return new MyType2((1L,udt.Data.Item2,(arr?.Copy(),udt.Data.Item3.Item2)));
+            return new Microsoft.Quantum.Compiler.Generics.MyType2((1L,udt.Data.Item2,(arr?.Copy(),udt.Data.Item3.Item2)));
         };
 
         public override void __Init__() { }
 
-        public override IApplyData __DataIn__(MyType2data) => data;
-        public override IApplyData __DataOut__(MyType2data) => data;
-        public static System.Threading.Tasks.Task<MyType2> Run(IOperationFactory __m__, MyType2 udt)
+        public override IApplyData __DataIn__(Microsoft.Quantum.Compiler.Generics.MyType2data) => data;
+        public override IApplyData __DataOut__(Microsoft.Quantum.Compiler.Generics.MyType2data) => data;
+        public static System.Threading.Tasks.Task<Microsoft.Quantum.Compiler.Generics.MyType2> Run(IOperationFactory __m__, Microsoft.Quantum.Compiler.Generics.MyType2 udt)
         {
-            return __m__.Run<UpdateUdtItems,MyType2,MyType2>(udt);
+            return __m__.Run<UpdateUdtItems,Microsoft.Quantum.Compiler.Generics.MyType2,Microsoft.Quantum.Compiler.Generics.MyType2>(udt);
         }
     }
         """
@@ -2949,13 +2949,13 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         |> testOneUdt udt_U
 
         """
-    public class AA : UDTBase<A>, IApplyData
+    public class AA : UDTBase<Microsoft.Quantum.Testing.A>, IApplyData
     {
-        public AA() : base(default(A))
+        public AA() : base(default(Microsoft.Quantum.Testing.A))
         {
         }
 
-        public AA(A data) : base(data)
+        public AA(Microsoft.Quantum.Testing.A data) : base(data)
         {
         }
 
@@ -3001,13 +3001,13 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         |> testOneUdt udt_Q
 
         """
-    public class QQ : UDTBase<Q>, IApplyData
+    public class QQ : UDTBase<Microsoft.Quantum.Testing.Q>, IApplyData
     {
-        public QQ() : base(default(Q))
+        public QQ() : base(default(Microsoft.Quantum.Testing.Q))
         {
         }
 
-        public QQ(Q data) : base(data)
+        public QQ(Microsoft.Quantum.Testing.Q data) : base(data)
         {
         }
 
@@ -3103,20 +3103,20 @@ internal partial class EmptyInternalOperation : Operation<QVoid, QVoid>, ICallab
         |> testOneUdt udt_Real
 
         """
-    public class udt_Complex : UDTBase<(udt_Real,udt_Real)>, IApplyData
+    public class udt_Complex : UDTBase<(Microsoft.Quantum.Testing.udt_Real,Microsoft.Quantum.Testing.udt_Real)>, IApplyData
     {
-        public udt_Complex() : base(default((udt_Real,udt_Real)))
+        public udt_Complex() : base(default((Microsoft.Quantum.Testing.udt_Real,Microsoft.Quantum.Testing.udt_Real)))
         {
         }
 
-        public udt_Complex((udt_Real,udt_Real) data) : base(data)
+        public udt_Complex((Microsoft.Quantum.Testing.udt_Real,Microsoft.Quantum.Testing.udt_Real) data) : base(data)
         {
         }
 
-        public udt_Real Item1 => Data.Item1;
-        public udt_Real Item2 => Data.Item2;
+        public Microsoft.Quantum.Testing.udt_Real Item1 => Data.Item1;
+        public Microsoft.Quantum.Testing.udt_Real Item2 => Data.Item2;
         System.Collections.Generic.IEnumerable<Qubit> IApplyData.Qubits => null;
-        public void Deconstruct(out udt_Real item1, out udt_Real item2)
+        public void Deconstruct(out Microsoft.Quantum.Testing.udt_Real item1, out Microsoft.Quantum.Testing.udt_Real item2)
         {
             item1 = Data.Item1;
             item2 = Data.Item2;
@@ -3270,7 +3270,7 @@ namespace Microsoft.Quantum
         }
     }
 
-    public abstract partial class emptyFunction : Function<Pair, QVoid>, ICallable
+    public abstract partial class emptyFunction : Function<Microsoft.Quantum.Pair, QVoid>, ICallable
     {
         public emptyFunction(IOperationFactory m) : base(m)
         {
@@ -3279,11 +3279,11 @@ namespace Microsoft.Quantum
         String ICallable.Name => "emptyFunction";
         String ICallable.FullName => "Microsoft.Quantum.emptyFunction";
         public override void __Init__() { }
-        public override IApplyData __DataIn__(Pair data) => data;
+        public override IApplyData __DataIn__(Microsoft.Quantum.Pair data) => data;
         public override IApplyData __DataOut__(QVoid data) => data;
-        public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Pair p)
+        public static System.Threading.Tasks.Task<QVoid> Run(IOperationFactory __m__, Microsoft.Quantum.Pair p)
         {
-            return __m__.Run<emptyFunction, Pair, QVoid>(p);
+            return __m__.Run<emptyFunction, Microsoft.Quantum.Pair, QVoid>(p);
         }
     }
 
@@ -3490,19 +3490,19 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 
         String ICallable.Name => "TestLineInBlocks";
         String ICallable.FullName => "Microsoft.Quantum.Tests.LineNumbers.TestLineInBlocks";
-        protected Allocate __Call_Allocate__
+        protected Allocate __Microsoft_Quantum_Intrinsic_Allocate__
         {
             get;
             set;
         }
 
-        protected Release __Call_Release__
+        protected Release __Microsoft_Quantum_Intrinsic_Release__
         {
             get;
             set;
         }
 
-        protected IUnitary<Qubit> __Call_X__
+        protected IUnitary<Qubit> __Microsoft_Quantum_Intrinsic_X__
         {
             get;
             set;
@@ -3516,7 +3516,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 #line hidden
             {
 #line 13 "%%"
-                var (ctrls,q) = (__Call_Allocate__.Apply(r), __Call_Allocate__.Apply());
+                var (ctrls,q) = (__Microsoft_Quantum_Intrinsic_Allocate__.Apply(r), __Microsoft_Quantum_Intrinsic_Allocate__.Apply());
 #line hidden
                 bool __arg1__ = true;
                 try
@@ -3525,7 +3525,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
                     if ((n == 0L))
                     {
 #line 16 "%%"
-                        __Call_X__.Apply(q);
+                        __Microsoft_Quantum_Intrinsic_X__.Apply(q);
                     }
                     else
                     {
@@ -3534,7 +3534,7 @@ namespace Microsoft.Quantum.Tests.LineNumbers
 #line hidden
                         {
 #line 21 "%%"
-                            __Call_X__.Controlled.Apply((new QArray<Qubit>(c), q));
+                            __Microsoft_Quantum_Intrinsic_X__.Controlled.Apply((new QArray<Qubit>(c), q));
                         }
                     }
                 }
@@ -3550,9 +3550,9 @@ namespace Microsoft.Quantum.Tests.LineNumbers
                     if (__arg1__)
                     {
 #line hidden
-                        __Call_Release__.Apply(ctrls);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(ctrls);
 #line hidden
-                        __Call_Release__.Apply(q);
+                        __Microsoft_Quantum_Intrinsic_Release__.Apply(q);
                     }
                 }
             }
@@ -3564,9 +3564,9 @@ namespace Microsoft.Quantum.Tests.LineNumbers
         ;
         public override void __Init__()
         {
-            this.__Call_Allocate__ = this.Factory.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
-            this.__Call_Release__ = this.Factory.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
-            this.__Call_X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
+            this.__Microsoft_Quantum_Intrinsic_Allocate__ = this.Factory.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
+            this.__Microsoft_Quantum_Intrinsic_Release__ = this.Factory.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
+            this.__Microsoft_Quantum_Intrinsic_X__ = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
         }
 
         public override IApplyData __DataIn__(Int64 data) => new QTuple<Int64>(data);

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -882,7 +882,7 @@ module SimulationCode =
                 statement (lhs <-- rhs)
             operations
             |> List.map buildOne
-        ``method`` "void"  "Init" ``<<`` [] ``>>``
+        ``method`` "void"  "__Init__" ``<<`` [] ``>>``
             ``(`` parameters ``)``
             [  ``public``; ``override``  ]
             ``{`` body ``}``

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1014,9 +1014,9 @@ module SimulationCode =
 
         match body with
         | Some body ->
-            let bodyName = if bodyName = "Body" then bodyName else bodyName + "Body"
+            let bodyName = if bodyName = "Body" then "__Body__" else "__" + bodyName + "Body__"
             let impl =
-                ``property-arrow_get`` propertyType ("__" + bodyName + "__") [``public``; ``override``]
+                ``property-arrow_get`` propertyType bodyName [``public``; ``override``]
                     ``get``
                     (``=>`` body)
             Some (impl, attributes)

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -979,10 +979,10 @@ module SimulationCode =
         | Generated SelfInverse ->
             let adjointedBodyName =
                 match sp.Kind with
-                | QsAdjoint           -> "Body"
-                | QsControlledAdjoint -> "ControlledBody"
+                | QsAdjoint           -> "__Body__"
+                | QsControlledAdjoint -> "__ControlledBody__"
 //TODO: diagnostics.
-                | _ -> "Body"
+                | _ -> "__Body__"
             Some (``ident`` adjointedBodyName :> ExpressionSyntax)
         | _ ->
             None
@@ -1023,7 +1023,7 @@ module SimulationCode =
         | Some body ->
             let bodyName = if bodyName = "Body" then bodyName else bodyName + "Body"
             let impl =
-                ``property-arrow_get`` propertyType bodyName [``public``; ``override``]
+                ``property-arrow_get`` propertyType ("__" + bodyName + "__") [``public``; ``override``]
                     ``get``
                     (``=>`` body)
             Some (impl, attributes)

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -203,9 +203,10 @@ module SimulationCode =
         sprintf "__arg%d__" count
 
     let getOpName context name =
-        if needsFullPath context name then "__" + prependNamespaceString name + "__"
+        // Callable names need their own prefix to avoid name collisions with other members of the generated class.
+        if needsFullPath context name then "__Call_" + prependNamespaceString name + "__"
         else if isCurrentOp context name then Directives.Self
-        else "__" + name.Name.Value + "__"
+        else "__Call_" + name.Name.Value + "__"
 
     type ExpressionSeeker(parent : SyntaxTreeTransformation<HashSet<QsQualifiedName>>) =
         inherit ExpressionTransformation<HashSet<QsQualifiedName>>(parent, TransformationOptions.NoRebuild)
@@ -763,8 +764,8 @@ module SimulationCode =
         override this.OnQubitScope (using:QsQubitScope) =
             let (alloc, release) =
                 match using.Kind with
-                | Allocate -> ("__Allocate__", "__Release__")
-                | Borrow   -> ("__Borrow__", "__Return__")
+                | Allocate -> ("__Call_Allocate__", "__Call_Release__")
+                | Borrow   -> ("__Call_Borrow__", "__Call_Return__")
             let rec removeDiscarded sym =
                 match sym with
                 | VariableName _         -> sym

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -203,11 +203,9 @@ module SimulationCode =
         sprintf "__arg%d__" count
 
     let getOpName context name =
-        let name' =
-            if needsFullPath context name then prependNamespaceString name
-            else if isCurrentOp context name then Directives.Self
-            else name.Name.Value
-        "__" + name' + "__"
+        if needsFullPath context name then "__" + prependNamespaceString name + "__"
+        else if isCurrentOp context name then Directives.Self
+        else "__" + name.Name.Value + "__"
 
     type ExpressionSeeker(parent : SyntaxTreeTransformation<HashSet<QsQualifiedName>>) =
         inherit ExpressionTransformation<HashSet<QsQualifiedName>>(parent, TransformationOptions.NoRebuild)
@@ -420,7 +418,7 @@ module SimulationCode =
             | LocalVariable n-> n.Value |> ``ident`` :> ExpressionSyntax
             | GlobalCallable n ->
                 if isCurrentOp context n
-                then upcast ("__" + Directives.Self + "__" |> ``ident``)
+                then upcast ``ident`` Directives.Self
                 else upcast (getOpName context n |> ``ident``)
 // TODO: Diagnostics
             | InvalidIdentifier ->

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1273,7 +1273,7 @@ module SimulationCode =
         let buildMethod t body =
             let baseType = (roslynTypeName context t)
             let args     = [ (``param`` "data" ``of`` (``type`` (roslynTypeName context t)) ) ]
-            ``arrow_method`` "IApplyData" (sprintf "__data%s" name) ``<<`` [] ``>>``
+            ``arrow_method`` "IApplyData" (sprintf "__Data%s__" name) ``<<`` [] ``>>``
                 ``(`` args ``)``
                 [``public``; ``override``]
                 ( Some ( ``=>`` body) )

--- a/src/Simulation/QsharpCore/Bitwise/Bitwise.cs
+++ b/src/Simulation/QsharpCore/Bitwise/Bitwise.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Quantum.Bitwise
         public class Native : Xor
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(long, long), long> Body => (arg) => (arg.Item1 ^ arg.Item2);
+            public override Func<(long, long), long> __Body__ => (arg) => (arg.Item1 ^ arg.Item2);
         }
     }
 
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Bitwise
         public class Native : And
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(long, long), long> Body => (arg) => (arg.Item1 & arg.Item2);
+            public override Func<(long, long), long> __Body__ => (arg) => (arg.Item1 & arg.Item2);
         }
     }
 
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Bitwise
         public class Native : Or
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(long, long), long> Body => (arg) => (arg.Item1 | arg.Item2);
+            public override Func<(long, long), long> __Body__ => (arg) => (arg.Item1 | arg.Item2);
         }
     }
 
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.Bitwise
         public class Native : Not
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<long, long> Body => (arg) => (~arg);
+            public override Func<long, long> __Body__ => (arg) => (~arg);
         }
     }
 
@@ -57,7 +57,7 @@ namespace Microsoft.Quantum.Bitwise
             }
 
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<long, long> Body => ParityFunc;
+            public override Func<long, long> __Body__ => ParityFunc;
         }
     }
 
@@ -81,7 +81,7 @@ namespace Microsoft.Quantum.Bitwise
             }
 
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<IQArray<Pauli>, long> Body => XBitsFunc;
+            public override Func<IQArray<Pauli>, long> __Body__ => XBitsFunc;
         }
     }
 
@@ -105,7 +105,7 @@ namespace Microsoft.Quantum.Bitwise
             }
 
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<IQArray<Pauli>, long> Body => ZBitsFunc;
+            public override Func<IQArray<Pauli>, long> __Body__ => ZBitsFunc;
         }
     }
 }

--- a/src/Simulation/QsharpCore/Convert/Convert.cs
+++ b/src/Simulation/QsharpCore/Convert/Convert.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.Convert
         public class Native : IntAsDouble
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<long, double> Body => (arg) => System.Convert.ToDouble(arg);
+            public override Func<long, double> __Body__ => (arg) => System.Convert.ToDouble(arg);
         }
     }
 
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Convert
         public class Native : IntAsBigInt
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<long, BigInteger> Body => (arg) => new BigInteger(arg);
+            public override Func<long, BigInteger> __Body__ => (arg) => new BigInteger(arg);
         }
     }
 
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Convert
             }
 
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<BigInteger, (long, bool)> Body => MaybeBigIntAsIntFunc;
+            public override Func<BigInteger, (long, bool)> __Body__ => MaybeBigIntAsIntFunc;
         }
     }
 
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.Convert
             }
 
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<BigInteger, IQArray<bool>> Body => BigIntAsBoolArrayFunc;
+            public override Func<BigInteger, IQArray<bool>> __Body__ => BigIntAsBoolArrayFunc;
         }
     }
 
@@ -110,7 +110,7 @@ namespace Microsoft.Quantum.Convert
             }
 
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<IQArray<bool>, BigInteger> Body => BoolArrayAsBigIntFunc;
+            public override Func<IQArray<bool>, BigInteger> __Body__ => BoolArrayAsBigIntFunc;
         }
     }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Quantum.Convert
         public class Native : BoolAsString
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<bool, string> Body => (arg) => System.Convert.ToString(arg);
+            public override Func<bool, string> __Body__ => (arg) => System.Convert.ToString(arg);
         }
     }
 
@@ -128,7 +128,7 @@ namespace Microsoft.Quantum.Convert
         public class Native : DoubleAsString
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, string> Body => (arg) => System.Convert.ToString(arg);
+            public override Func<double, string> __Body__ => (arg) => System.Convert.ToString(arg);
         }
     }
 
@@ -137,7 +137,7 @@ namespace Microsoft.Quantum.Convert
         public class Native : DoubleAsStringWithFormat
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(double, string), string> Body => (arg) => arg.Item1.ToString(arg.Item2);
+            public override Func<(double, string), string> __Body__ => (arg) => arg.Item1.ToString(arg.Item2);
         }
     }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Quantum.Convert
         public class Native : IntAsString
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<long, string> Body => (arg) => System.Convert.ToString(arg);
+            public override Func<long, string> __Body__ => (arg) => System.Convert.ToString(arg);
         }
     }
 
@@ -155,7 +155,7 @@ namespace Microsoft.Quantum.Convert
         public class Native : IntAsStringWithFormat
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(long, string), string> Body => (arg) => arg.Item1.ToString(arg.Item2);
+            public override Func<(long, string), string> __Body__ => (arg) => arg.Item1.ToString(arg.Item2);
         }
     }
 
@@ -194,7 +194,7 @@ namespace Microsoft.Quantum.Convert
             }
 
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<IQArray<Pauli>, long> Body => PauliBitsFunc;
+            public override Func<IQArray<Pauli>, long> __Body__ => PauliBitsFunc;
         }
     }
 }

--- a/src/Simulation/QsharpCore/Core.cs
+++ b/src/Simulation/QsharpCore/Core.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Quantum.Core
         public class Native : Length<__T__>
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<IQArray<__T__>, long> Body => (arg) => (arg.Length);
+            public override Func<IQArray<__T__>, long> __Body__ => (arg) => (arg.Length);
         }
     }
 
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Core
         public class Native : RangeStart
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<QRange, long> Body => (arg) => (arg.Start);
+            public override Func<QRange, long> __Body__ => (arg) => (arg.Start);
         }
     }
 
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Core
         public class Native : RangeEnd
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<QRange, long> Body => (arg) => (arg.End);
+            public override Func<QRange, long> __Body__ => (arg) => (arg.End);
         }
     }
 
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.Core
         public class Native : RangeStep
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<QRange, long> Body => (arg) => (arg.Step);
+            public override Func<QRange, long> __Body__ => (arg) => (arg.Step);
         }
     }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.Core
         public class Native : RangeReverse
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<QRange, QRange> Body => (arg) => (arg.Reverse());
+            public override Func<QRange, QRange> __Body__ => (arg) => (arg.Reverse());
         }
     }
 }

--- a/src/Simulation/QsharpCore/Math/Math.cs
+++ b/src/Simulation/QsharpCore/Math/Math.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.Math
         public class Native : AbsD
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Abs;
+            public override Func<double, double> __Body__ => System.Math.Abs;
         }
     }
 
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Math
         public class Native : AbsI
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<long, long> Body => System.Math.Abs;
+            public override Func<long, long> __Body__ => System.Math.Abs;
         }
     }
 
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Math
         public class Native : AbsL
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<BigInteger, BigInteger> Body => BigInteger.Abs;
+            public override Func<BigInteger, BigInteger> __Body__ => BigInteger.Abs;
         }
     }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.Math
         public class Native : ArcCos
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Acos;
+            public override Func<double, double> __Body__ => System.Math.Acos;
         }
     }
 
@@ -48,7 +48,7 @@ namespace Microsoft.Quantum.Math
         public class Native : ArcSin
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Asin;
+            public override Func<double, double> __Body__ => System.Math.Asin;
         }
     }
 
@@ -57,7 +57,7 @@ namespace Microsoft.Quantum.Math
         public class Native : ArcTan
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Atan;
+            public override Func<double, double> __Body__ => System.Math.Atan;
         }
     }
 
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Math
         public class Native : ArcTan2
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(double, double), double> Body => (args) => System.Math.Atan2(args.Item1, args.Item2);
+            public override Func<(double, double), double> __Body__ => (args) => System.Math.Atan2(args.Item1, args.Item2);
         }
     }
 
@@ -76,7 +76,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Ceiling
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, long> Body => (arg) => System.Convert.ToInt64(System.Math.Ceiling(arg));
+            public override Func<double, long> __Body__ => (arg) => System.Convert.ToInt64(System.Math.Ceiling(arg));
         }
     }
 
@@ -85,7 +85,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Cos
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Cos;
+            public override Func<double, double> __Body__ => System.Math.Cos;
         }
     }
 
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Cosh
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Cosh;
+            public override Func<double, double> __Body__ => System.Math.Cosh;
         }
     }
 
@@ -110,7 +110,7 @@ namespace Microsoft.Quantum.Math
                 var div = BigInteger.DivRem(arg.Item1, arg.Item2, out rem);
                 return (div, rem);
             }
-            public override Func<(BigInteger, BigInteger), (BigInteger, BigInteger)> Body => Impl;
+            public override Func<(BigInteger, BigInteger), (BigInteger, BigInteger)> __Body__ => Impl;
         }
     }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Quantum.Math
         public class Native : E
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<QVoid, double> Body => (arg) => System.Math.E;
+            public override Func<QVoid, double> __Body__ => (arg) => System.Math.E;
         }
     }
 
@@ -128,7 +128,7 @@ namespace Microsoft.Quantum.Math
         public class Native : ExpD
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Exp;
+            public override Func<double, double> __Body__ => System.Math.Exp;
         }
     }
 
@@ -137,7 +137,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Floor
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, long> Body => (arg) => System.Convert.ToInt64(System.Math.Floor(arg));
+            public override Func<double, long> __Body__ => (arg) => System.Convert.ToInt64(System.Math.Floor(arg));
         }
     }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Quantum.Math
         public class Native : IEEERemainder
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(double, double), double> Body => (arg) => System.Math.IEEERemainder(arg.Item1, arg.Item2);
+            public override Func<(double, double), double> __Body__ => (arg) => System.Math.IEEERemainder(arg.Item1, arg.Item2);
         }
     }
 
@@ -155,7 +155,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Log
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Log;
+            public override Func<double, double> __Body__ => System.Math.Log;
         }
     }
 
@@ -164,7 +164,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Log10
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => System.Math.Log10;
+            public override Func<double, double> __Body__ => System.Math.Log10;
         }
     }
 
@@ -173,7 +173,7 @@ namespace Microsoft.Quantum.Math
         public class Native : MaxD
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(double, double), double> Body => (args) => System.Math.Max(args.Item1, args.Item2);
+            public override Func<(double, double), double> __Body__ => (args) => System.Math.Max(args.Item1, args.Item2);
         }
     }
 
@@ -182,7 +182,7 @@ namespace Microsoft.Quantum.Math
         public class Native : MaxI
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(long, long), long> Body => (args) => System.Math.Max(args.Item1, args.Item2);
+            public override Func<(long, long), long> __Body__ => (args) => System.Math.Max(args.Item1, args.Item2);
         }
     }
 
@@ -191,7 +191,7 @@ namespace Microsoft.Quantum.Math
         public class Native : MaxL
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(BigInteger, BigInteger), BigInteger> Body => (args) => BigInteger.Max(args.Item1, args.Item2);
+            public override Func<(BigInteger, BigInteger), BigInteger> __Body__ => (args) => BigInteger.Max(args.Item1, args.Item2);
         }
     }
 
@@ -200,7 +200,7 @@ namespace Microsoft.Quantum.Math
         public class Native : MinD
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(double, double), double> Body => (args) => System.Math.Min(args.Item1, args.Item2);
+            public override Func<(double, double), double> __Body__ => (args) => System.Math.Min(args.Item1, args.Item2);
         }
     }
 
@@ -209,7 +209,7 @@ namespace Microsoft.Quantum.Math
         public class Native : MinI
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(long, long), long> Body => (args) => System.Math.Min(args.Item1, args.Item2);
+            public override Func<(long, long), long> __Body__ => (args) => System.Math.Min(args.Item1, args.Item2);
         }
     }
 
@@ -218,7 +218,7 @@ namespace Microsoft.Quantum.Math
         public class Native : MinL
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(BigInteger, BigInteger), BigInteger> Body => (args) => BigInteger.Min(args.Item1, args.Item2);
+            public override Func<(BigInteger, BigInteger), BigInteger> __Body__ => (args) => BigInteger.Min(args.Item1, args.Item2);
         }
     }
 
@@ -227,7 +227,7 @@ namespace Microsoft.Quantum.Math
         public class Native : ModPowL
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(BigInteger, BigInteger, BigInteger), BigInteger> Body => (args) => BigInteger.ModPow(args.Item1, args.Item2, args.Item3);
+            public override Func<(BigInteger, BigInteger, BigInteger), BigInteger> __Body__ => (args) => BigInteger.ModPow(args.Item1, args.Item2, args.Item3);
         }
     }
 
@@ -236,7 +236,7 @@ namespace Microsoft.Quantum.Math
         public class Native : PI
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<QVoid, double> Body => (arg) => System.Math.PI;
+            public override Func<QVoid, double> __Body__ => (arg) => System.Math.PI;
         }
     }
 
@@ -245,7 +245,7 @@ namespace Microsoft.Quantum.Math
         public class Native : PowD
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<(double, double), double> Body => (arg) => System.Math.Pow(arg.Item1, arg.Item2);
+            public override Func<(double, double), double> __Body__ => (arg) => System.Math.Pow(arg.Item1, arg.Item2);
         }
     }
 
@@ -254,7 +254,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Round
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, long> Body => (arg) => System.Convert.ToInt64(System.Math.Round(arg));
+            public override Func<double, long> __Body__ => (arg) => System.Convert.ToInt64(System.Math.Round(arg));
         }
     }
 
@@ -263,7 +263,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Sin
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => (theta) => System.Math.Sin(theta);
+            public override Func<double, double> __Body__ => (theta) => System.Math.Sin(theta);
         }
     }
 
@@ -272,7 +272,7 @@ namespace Microsoft.Quantum.Math
         public class Native : SignD
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, long> Body => (arg) => System.Math.Sign(arg);
+            public override Func<double, long> __Body__ => (arg) => System.Math.Sign(arg);
         }
     }
 
@@ -281,7 +281,7 @@ namespace Microsoft.Quantum.Math
         public class Native : SignI
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<long, long> Body => (arg) => System.Math.Sign(arg);
+            public override Func<long, long> __Body__ => (arg) => System.Math.Sign(arg);
         }
     }
 
@@ -290,7 +290,7 @@ namespace Microsoft.Quantum.Math
         public class Native : SignL
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<BigInteger, long> Body => (arg) => arg.Sign;
+            public override Func<BigInteger, long> __Body__ => (arg) => arg.Sign;
         }
     }
 
@@ -299,7 +299,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Sinh
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => (theta) => System.Math.Sinh(theta);
+            public override Func<double, double> __Body__ => (theta) => System.Math.Sinh(theta);
         }
     }
 
@@ -308,7 +308,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Sqrt
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => (arg) => System.Math.Sqrt(arg);
+            public override Func<double, double> __Body__ => (arg) => System.Math.Sqrt(arg);
         }
     }
 
@@ -317,7 +317,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Tan
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => (theta) => System.Math.Tan(theta);
+            public override Func<double, double> __Body__ => (theta) => System.Math.Tan(theta);
         }
     }
 
@@ -326,7 +326,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Tanh
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, double> Body => (theta) => System.Math.Tanh(theta);
+            public override Func<double, double> __Body__ => (theta) => System.Math.Tanh(theta);
         }
     }
 
@@ -335,8 +335,7 @@ namespace Microsoft.Quantum.Math
         public class Native : Truncate
         {
             public Native(IOperationFactory m) : base(m) { }
-            public override Func<double, long> Body => (arg) => System.Convert.ToInt64(System.Math.Truncate(arg));
+            public override Func<double, long> __Body__ => (arg) => System.Convert.ToInt64(System.Math.Truncate(arg));
         }
     }
 }
-

--- a/src/Simulation/QsharpCore/Statements/Allocate.cs
+++ b/src/Simulation/QsharpCore/Statements/Allocate.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Quantum.Intrinsic
 
         public abstract IQArray<Qubit> Apply(long count);
 
-        public override void Init() { }
+        public override void __Init__() { }
     }
 }

--- a/src/Simulation/QsharpCore/Statements/Borrow.cs
+++ b/src/Simulation/QsharpCore/Statements/Borrow.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Quantum.Intrinsic
 
         public abstract IQArray<Qubit> Apply(long count);
 
-        public override void Init() { }
+        public override void __Init__() { }
     }
 }
 

--- a/src/Simulation/QsharpCore/Statements/Release.cs
+++ b/src/Simulation/QsharpCore/Statements/Release.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Quantum.Intrinsic
 
         public abstract void Apply(IQArray<Qubit> qubits);
 
-        public override void Init() { }
+        public override void __Init__() { }
     }
 }

--- a/src/Simulation/QsharpCore/Statements/Return.cs
+++ b/src/Simulation/QsharpCore/Statements/Return.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Quantum.Intrinsic
 
         public abstract void Apply(IQArray<Qubit> qubits);
 
-        public override void Init() { }
+        public override void __Init__() { }
     }
 }

--- a/src/Simulation/Simulators.Tests/Circuits/AssertEqual.cs
+++ b/src/Simulation/Simulators.Tests/Circuits/AssertEqual.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits
         {
             public Native(IOperationFactory m) : base(m) { }
 
-            public override Func<(__T__, __T__), QVoid> Body => (_args) =>
+            public override Func<(__T__, __T__), QVoid> __Body__ => (_args) =>
             {
                 var (expected, actual) = _args;
                 Assert.Equal(expected, actual);

--- a/src/Simulation/Simulators.Tests/Circuits/CSharpMembers.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/CSharpMembers.qs
@@ -24,5 +24,15 @@
         Init();
         __dataIn();
         __dataOut();
+        FooBar.Baz();
+        Foo.Bar.Baz();
     }
+}
+
+namespace FooBar {
+    function Baz() : Unit { }
+}
+
+namespace Foo.Bar {
+    function Baz() : Unit { }
 }

--- a/src/Simulation/Simulators.Tests/Circuits/CSharpMembers.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/CSharpMembers.qs
@@ -1,0 +1,28 @@
+﻿namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
+    open Microsoft.Quantum.Diagnostics;
+
+    operation Body() : Unit { }
+
+    operation AdjointBody() : Unit is Adj { }
+
+    operation ControlledBody() : Unit is Ctl { }
+
+    operation ControlledAdjointBody() : Unit is Adj + Ctl { }
+
+    operation Init() : Unit { }
+
+    operation __dataIn() : Unit { }
+
+    operation __dataOut() : Unit { }
+
+    @Test("QuantumSimulator")
+    operation CSharpMembers() : Unit {
+        Body();
+        AdjointBody();
+        ControlledBody();
+        ControlledAdjointBody();
+        Init();
+        __dataIn();
+        __dataOut();
+    }
+}

--- a/src/Simulation/Simulators.Tests/Circuits/NativeOperations.cs
+++ b/src/Simulation/Simulators.Tests/Circuits/NativeOperations.cs
@@ -20,7 +20,7 @@ namespace NativeOperations
         {
             public Native(IOperationFactory m) : base(m) { }
 
-            public override Func<QVoid, String> Body => (arg) =>
+            public override Func<QVoid, String> __Body__ => (arg) =>
             {
                 return RESULT;
             };
@@ -34,7 +34,7 @@ namespace NativeOperations
         {
             public Native(IOperationFactory m) : base(m) { }
 
-            public override Func<QVoid, String> Body => (arg) =>
+            public override Func<QVoid, String> __Body__ => (arg) =>
             {
                 if (this.Factory is QuantumSimulator)
                 {
@@ -45,7 +45,7 @@ namespace NativeOperations
                     return "Toffoli";
                 }
 
-                return base.Body(arg);
+                return base.__Body__(arg);
             };
         }
     }
@@ -58,7 +58,7 @@ namespace NativeOperations
         {
             public Other1(IOperationFactory m) : base(m) { }
 
-            public override Func<__T__, string> Body => throw new NotImplementedException();
+            public override Func<__T__, string> __Body__ => throw new NotImplementedException();
         }
 
         // This one should not be used, it has the same number of Type parameters,
@@ -70,7 +70,7 @@ namespace NativeOperations
         {
             public Emulation(IOperationFactory m) : base(m) { }
 
-            public override Func<__T__, string> Body => (arg) =>
+            public override Func<__T__, string> __Body__ => (arg) =>
             {
                 if (arg is string s)
                 {
@@ -92,7 +92,7 @@ namespace NativeOperations
         {
             public Emulation(IOperationFactory m) : base(m) { }
 
-            public override Func<__T__, __T__> Body => (arg) =>
+            public override Func<__T__, __T__> __Body__ => (arg) =>
             {
                 if (arg is string s)
                 {
@@ -100,7 +100,7 @@ namespace NativeOperations
                 }
                 else
                 {
-                    return base.Body(arg);
+                    return base.__Body__(arg);
                 }
             };
         }

--- a/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
@@ -26,5 +26,9 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
             HOp(q);
         }
     }
+
+    operation TwoQubitOp (q1 : Qubit, q2 : Qubit) : Unit {
+        // ...
+    }
     
 }

--- a/src/Simulation/Simulators.Tests/GetQubitsTests.cs
+++ b/src/Simulation/Simulators.Tests/GetQubitsTests.cs
@@ -24,25 +24,25 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
         public override void __Init__() { }
 
-        public override Func<(IQArray<Qubit>, TInput), QVoid> ControlledAdjointBody => (arg) =>
+        public override Func<(IQArray<Qubit>, TInput), QVoid> __ControlledAdjointBody__ => (arg) =>
         {
             Debug.Write("NoOp:ControlledAdjointBody:" + typeof(TInput).FullName);
             return QVoid.Instance;
         };
 
-        public override Func<TInput, QVoid> AdjointBody => (arg) =>
+        public override Func<TInput, QVoid> __AdjointBody__ => (arg) =>
         {
             Debug.Write("NoOp:AdjointBody:" + typeof(TInput).FullName);
             return QVoid.Instance;
         };
 
-        public override Func<(IQArray<Qubit>, TInput), QVoid> ControlledBody => (arg) =>
+        public override Func<(IQArray<Qubit>, TInput), QVoid> __ControlledBody__ => (arg) =>
         {
             Debug.Write("NoOp:ControlledBody:" + typeof(TInput).FullName);
             return QVoid.Instance;
         };
 
-        public override Func<TInput, QVoid> Body => (TInput arg) =>
+        public override Func<TInput, QVoid> __Body__ => (TInput arg) =>
         {
             Debug.Write("NoOp:Body:" + typeof(TInput).FullName);
             return QVoid.Instance;

--- a/src/Simulation/Simulators.Tests/GetQubitsTests.cs
+++ b/src/Simulation/Simulators.Tests/GetQubitsTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
     {
         public UnitaryNoOp() : base(null) { }
 
-        public override void Init() { }
+        public override void __Init__() { }
 
         public override Func<(IQArray<Qubit>, TInput), QVoid> ControlledAdjointBody => (arg) =>
         {

--- a/src/Simulation/Simulators.Tests/OperationsTestHelper.cs
+++ b/src/Simulation/Simulators.Tests/OperationsTestHelper.cs
@@ -103,10 +103,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 this.Log = new Log<string>();
             }
 
-            public override Func<string, QVoid> Body => (tag) => this.Log.Record(OperationFunctor.Body, tag);
-            public override Func<string, QVoid> AdjointBody => (tag) => this.Log.Record(OperationFunctor.Adjoint, tag);
-            public override Func<(IQArray<Qubit>, string), QVoid> ControlledBody => (args) => this.Log.Record(OperationFunctor.Controlled, args.Item2);
-            public override Func<(IQArray<Qubit>, string), QVoid> ControlledAdjointBody => (args) => this.Log.Record(OperationFunctor.ControlledAdjoint, args.Item2);
+            public override Func<string, QVoid> __Body__ => (tag) => this.Log.Record(OperationFunctor.Body, tag);
+            public override Func<string, QVoid> __AdjointBody__ => (tag) => this.Log.Record(OperationFunctor.Adjoint, tag);
+            public override Func<(IQArray<Qubit>, string), QVoid> __ControlledBody__ => (args) => this.Log.Record(OperationFunctor.Controlled, args.Item2);
+            public override Func<(IQArray<Qubit>, string), QVoid> __ControlledAdjointBody__ => (args) => this.Log.Record(OperationFunctor.ControlledAdjoint, args.Item2);
 
             public Log<string> Log { get; }
         }
@@ -118,10 +118,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 this.Log = new Log<T>();
             }
 
-            public override Func<T, QVoid> Body => (tag) => this.Log.Record(OperationFunctor.Body, tag);
-            public override Func<T, QVoid> AdjointBody => (tag) => this.Log.Record(OperationFunctor.Adjoint, tag);
-            public override Func<(IQArray<Qubit>, T), QVoid> ControlledBody => (args) => this.Log.Record(OperationFunctor.Controlled, args.Item2);
-            public override Func<(IQArray<Qubit>, T), QVoid> ControlledAdjointBody => (args) => this.Log.Record(OperationFunctor.ControlledAdjoint, args.Item2);
+            public override Func<T, QVoid> __Body__ => (tag) => this.Log.Record(OperationFunctor.Body, tag);
+            public override Func<T, QVoid> __AdjointBody__ => (tag) => this.Log.Record(OperationFunctor.Adjoint, tag);
+            public override Func<(IQArray<Qubit>, T), QVoid> __ControlledBody__ => (args) => this.Log.Record(OperationFunctor.Controlled, args.Item2);
+            public override Func<(IQArray<Qubit>, T), QVoid> __ControlledAdjointBody__ => (args) => this.Log.Record(OperationFunctor.ControlledAdjoint, args.Item2);
 
             public int GetNumberOfCalls(OperationFunctor functor, T tag) => this.Log.GetNumberOfCalls(functor, tag);
 

--- a/src/Simulation/Simulators.Tests/PartialMapperTests.cs
+++ b/src/Simulation/Simulators.Tests/PartialMapperTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             string ICallable.FullName => "NoOp";
 
-            public override Func<TestTuple, QVoid> Body => (a) => QVoid.Instance;
+            public override Func<TestTuple, QVoid> __Body__ => (a) => QVoid.Instance;
 
             public override void __Init__() { }
         }

--- a/src/Simulation/Simulators.Tests/PartialMapperTests.cs
+++ b/src/Simulation/Simulators.Tests/PartialMapperTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public override Func<TestTuple, QVoid> Body => (a) => QVoid.Instance;
 
-            public override void Init() { }
+            public override void __Init__() { }
         }
 
         private void TestOneTupleNoSubstitution<I>(I original, params object[] expected)

--- a/src/Simulation/Simulators.Tests/QuantumSimulatorTests/BasicTests.cs
+++ b/src/Simulation/Simulators.Tests/QuantumSimulatorTests/BasicTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 var measure = sim.Get<Intrinsic.M>();
                 var set = sim.Get<SetQubit>();
 
-                var ctrlX = x.ControlledBody.AsAction();
+                var ctrlX = x.__ControlledBody__.AsAction();
                 OperationsTestHelper.ctrlTestShell(sim, ctrlX, (enabled, ctrls, q) =>
                 {
                     set.Apply((Result.Zero, q));
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                     var expected = Result.Zero;
                     Assert.Equal(expected, result);
 
-                    x.ControlledBody((ctrls, q));
+                    x.__ControlledBody__((ctrls, q));
                     result = measure.Apply(q);
                     expected = (enabled) ? Result.One : Result.Zero;
                     Assert.Equal(expected, result);

--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var control = new FreeQubit(1);
             var target = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Intrinsic.CNOT>();
-            var args = op.__dataIn((control, target));
+            var args = op.__DataIn__((control, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "X",
@@ -213,7 +213,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var control2 = new FreeQubit(2);
             var target = new FreeQubit(1);
             var op = new QuantumSimulator().Get<Intrinsic.CCNOT>();
-            var args = op.__dataIn((control1, control2, target));
+            var args = op.__DataIn__((control1, control2, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "X",
@@ -236,7 +236,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var q1 = new FreeQubit(0);
             var q2 = new FreeQubit(1);
             var op = new QuantumSimulator().Get<Intrinsic.SWAP>();
-            var args = op.__dataIn((q1, q2));
+            var args = op.__DataIn__((q1, q2));
             var expected = new RuntimeMetadata()
             {
                 Label = "SWAP",
@@ -258,7 +258,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             var target = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Intrinsic.Ry>();
-            var args = op.__dataIn((2.1, target));
+            var args = op.__DataIn__((2.1, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "Ry",
@@ -280,7 +280,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             var measureQubit = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Intrinsic.M>();
-            var args = op.__dataIn(measureQubit);
+            var args = op.__DataIn__(measureQubit);
             var expected = new RuntimeMetadata()
             {
                 Label = "M",
@@ -302,7 +302,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             var target = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Intrinsic.Reset>();
-            var args = op.__dataIn(target);
+            var args = op.__DataIn__(target);
             var expected = new RuntimeMetadata()
             {
                 Label = "Reset",
@@ -324,7 +324,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             IQArray<Qubit> targets = new QArray<Qubit>(new[] { new FreeQubit(0) });
             var op = new QuantumSimulator().Get<Intrinsic.ResetAll>();
-            var args = op.__dataIn(targets);
+            var args = op.__DataIn__(targets);
             var expected = new RuntimeMetadata()
             {
                 Label = "ResetAll",
@@ -349,7 +349,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             var measureQubit = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Measurement.MResetX>();
-            var args = op.__dataIn(measureQubit);
+            var args = op.__DataIn__(measureQubit);
             var expected = new RuntimeMetadata()
             {
                 Label = "MResetX",
@@ -371,7 +371,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             var measureQubit = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Measurement.MResetY>();
-            var args = op.__dataIn(measureQubit);
+            var args = op.__DataIn__(measureQubit);
             var expected = new RuntimeMetadata()
             {
                 Label = "MResetY",
@@ -393,7 +393,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             var measureQubit = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Measurement.MResetZ>();
-            var args = op.__dataIn(measureQubit);
+            var args = op.__DataIn__(measureQubit);
             var expected = new RuntimeMetadata()
             {
                 Label = "MResetZ",
@@ -418,7 +418,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             var measureQubit = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Circuits.Empty>();
-            var args = op.__dataIn(QVoid.Instance);
+            var args = op.__DataIn__(QVoid.Instance);
             var expected = new RuntimeMetadata()
             {
                 Label = "Empty",
@@ -441,7 +441,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var q = new FreeQubit(0);
             var opArg = new QuantumSimulator().Get<Circuits.HOp>();
             var op = new QuantumSimulator().Get<Circuits.WrapperOp>();
-            var args = op.__dataIn((opArg, q));
+            var args = op.__DataIn__((opArg, q));
             var expected = new RuntimeMetadata()
             {
                 Label = "WrapperOp",
@@ -462,7 +462,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         public void NestedOperation()
         {
             var op = new QuantumSimulator().Get<Circuits.NestedOp>();
-            var args = op.__dataIn(QVoid.Instance);
+            var args = op.__DataIn__(QVoid.Instance);
             var expected = new RuntimeMetadata()
             {
                 Label = "NestedOp",
@@ -484,7 +484,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             var q = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Circuits.TwoQubitOp>();
-            var args = op.__dataIn((q, q));
+            var args = op.__DataIn__((q, q));
             var expected = new RuntimeMetadata()
             {
                 Label = "TwoQubitOp",
@@ -509,7 +509,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             Qubit target = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Tests.Circuits.FooUDTOp>();
-            var args = op.__dataIn(new Circuits.FooUDT(("bar", (target, 2.1))));
+            var args = op.__DataIn__(new Circuits.FooUDT(("bar", (target, 2.1))));
             var expected = new RuntimeMetadata()
             {
                 Label = "FooUDTOp",
@@ -535,7 +535,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             IQArray<Qubit> controls = new QArray<Qubit>(new[] { new FreeQubit(0) });
             Qubit target = new FreeQubit(1);
             var op = new QuantumSimulator().Get<Intrinsic.H>().Controlled;
-            var args = op.__dataIn((controls, target));
+            var args = op.__DataIn__((controls, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "H",
@@ -558,7 +558,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             IQArray<Qubit> controls = new QArray<Qubit>(new[] { new FreeQubit(0) });
             Qubit target = new FreeQubit(1);
             var op = new QuantumSimulator().Get<Intrinsic.X>().Controlled;
-            var args = op.__dataIn((controls, target));
+            var args = op.__DataIn__((controls, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "X",
@@ -582,7 +582,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Qubit control = new FreeQubit(1);
             Qubit target = new FreeQubit(2);
             var op = new QuantumSimulator().Get<Intrinsic.CNOT>().Controlled;
-            var args = op.__dataIn((controls, (control, target)));
+            var args = op.__DataIn__((controls, (control, target)));
             var expected = new RuntimeMetadata()
             {
                 Label = "X",
@@ -608,7 +608,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Qubit target = new FreeQubit(3);
             IQArray<Qubit> controls = new QArray<Qubit>(new[] { control1 });
             var op = new QuantumSimulator().Get<Intrinsic.CCNOT>().Controlled;
-            var args = op.__dataIn((controls, (control2, control3, target)));
+            var args = op.__DataIn__((controls, (control2, control3, target)));
             var expected = new RuntimeMetadata()
             {
                 Label = "X",
@@ -633,7 +633,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             Qubit target = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Intrinsic.H>().Adjoint;
-            var args = op.__dataIn(target);
+            var args = op.__DataIn__(target);
             var expected = new RuntimeMetadata()
             {
                 Label = "H",
@@ -655,7 +655,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             Qubit target = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Intrinsic.X>().Adjoint;
-            var args = op.__dataIn(target);
+            var args = op.__DataIn__(target);
             var expected = new RuntimeMetadata()
             {
                 Label = "X",
@@ -677,7 +677,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         {
             Qubit target = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Intrinsic.H>().Adjoint.Adjoint;
-            var args = op.__dataIn(target);
+            var args = op.__DataIn__(target);
             var expected = new RuntimeMetadata()
             {
                 Label = "H",
@@ -701,7 +701,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Qubit target = new FreeQubit(1);
             var op1 = new QuantumSimulator().Get<Intrinsic.H>().Controlled.Adjoint;
             var op2 = new QuantumSimulator().Get<Intrinsic.H>().Adjoint.Controlled;
-            var args = op1.__dataIn((controls, target));
+            var args = op1.__DataIn__((controls, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "H",
@@ -727,7 +727,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var op1 = new QuantumSimulator().Get<Intrinsic.H>().Controlled.Adjoint.Adjoint;
             var op2 = new QuantumSimulator().Get<Intrinsic.H>().Adjoint.Controlled.Adjoint;
             var op3 = new QuantumSimulator().Get<Intrinsic.H>().Adjoint.Adjoint.Controlled;
-            var args = op1.__dataIn((controls, target));
+            var args = op1.__DataIn__((controls, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "H",
@@ -756,7 +756,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var target = new FreeQubit(0);
             var op = new QuantumSimulator().Get<Intrinsic.Ry>().Partial((double d) =>
                 new ValueTuple<double, Qubit>(d, target));
-            var args = op.__dataIn(2.1);
+            var args = op.__DataIn__(2.1);
             var expected = new RuntimeMetadata()
             {
                 Label = "Ry",

--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -409,7 +409,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             Assert.Equal(op.GetRuntimeMetadata(args), expected);
         }
+    }
 
+    public class CustomCircuitTests
+    {
         [Fact]
         public void EmptyOperation()
         {
@@ -471,6 +474,28 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 Children = null,
                 Controls = new List<Qubit>() { },
                 Targets = new List<Qubit>() { },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
+
+        [Fact]
+        public void DuplicateQubitArgs()
+        {
+            var q = new FreeQubit(0);
+            var op = new QuantumSimulator().Get<Circuits.TwoQubitOp>();
+            var args = op.__dataIn((q, q));
+            var expected = new RuntimeMetadata()
+            {
+                Label = "TwoQubitOp",
+                FormattedNonQubitArgs = "",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = new List<Qubit>() { q },
             };
 
             Assert.Equal(op.GetRuntimeMetadata(args), expected);

--- a/src/Simulation/Simulators.Tests/SimulatorBaseTests.cs
+++ b/src/Simulation/Simulators.Tests/SimulatorBaseTests.cs
@@ -328,9 +328,9 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             {
             }
 
-            public override Func<Qubit, QVoid> Body => throw new NotImplementedException();
+            public override Func<Qubit, QVoid> __Body__ => throw new NotImplementedException();
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => throw new NotImplementedException();
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => throw new NotImplementedException();
         }
 
         /// <summary>
@@ -343,7 +343,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             {
             }
 
-            public override Func<Qubit, Result> Body => throw new NotImplementedException();
+            public override Func<Qubit, Result> __Body__ => throw new NotImplementedException();
 
             public override void __Init__()
             {
@@ -368,7 +368,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 this.X = this.Factory.Get<IUnitary<Qubit>, Intrinsic.X>();
             }
 
-            public override Func<QVoid, QVoid> Body => throw new NotImplementedException();
+            public override Func<QVoid, QVoid> __Body__ => throw new NotImplementedException();
         }
 
         /// <summary>
@@ -386,13 +386,13 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public override void __Init__() { }
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => throw new NotImplementedException();
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => throw new NotImplementedException();
 
-            public override Func<Qubit, QVoid> AdjointBody => throw new NotImplementedException();
+            public override Func<Qubit, QVoid> __AdjointBody__ => throw new NotImplementedException();
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => throw new NotImplementedException();
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => throw new NotImplementedException();
 
-            public override Func<Qubit, QVoid> Body => throw new NotImplementedException();
+            public override Func<Qubit, QVoid> __Body__ => throw new NotImplementedException();
         }
 
 
@@ -414,7 +414,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             string ICallable.FullName => "A";
 
-            public override Func<QVoid, QVoid> Body => (_) => { return QVoid.Instance; };
+            public override Func<QVoid, QVoid> __Body__ => (_) => { return QVoid.Instance; };
         }
 
         /// <summary>
@@ -435,7 +435,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 this.A = this.Factory.Get<ICallable, A>();
             }
 
-            public override Func<QVoid, QVoid> Body => (_) => { return QVoid.Instance; };
+            public override Func<QVoid, QVoid> __Body__ => (_) => { return QVoid.Instance; };
         }
 
         public class Gen<T> : Operation<T, QVoid>, ICallable
@@ -446,7 +446,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             string ICallable.FullName => "Gen";
 
-            public override Func<T, QVoid> Body => (_) => { return QVoid.Instance; };
+            public override Func<T, QVoid> __Body__ => (_) => { return QVoid.Instance; };
 
             public ICallable A { get; set; }
 
@@ -470,7 +470,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public ICallable Gen { get; set; }
 
-            public override Func<QVoid, QVoid> Body => (_) => { return QVoid.Instance; };
+            public override Func<QVoid, QVoid> __Body__ => (_) => { return QVoid.Instance; };
 
             public override void __Init__()
             {

--- a/src/Simulation/Simulators.Tests/SimulatorBaseTests.cs
+++ b/src/Simulation/Simulators.Tests/SimulatorBaseTests.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public override Func<Qubit, Result> Body => throw new NotImplementedException();
 
-            public override void Init()
+            public override void __Init__()
             {
             }
         }
@@ -363,7 +363,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public IUnitary<Qubit> X { get; set; }
 
-            public override void Init()
+            public override void __Init__()
             {
                 this.X = this.Factory.Get<IUnitary<Qubit>, Intrinsic.X>();
             }
@@ -384,7 +384,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             string ICallable.FullName => "LikeX";
 
-            public override void Init() { }
+            public override void __Init__() { }
 
             public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => throw new NotImplementedException();
 
@@ -407,7 +407,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public ICallable B { get; set; }
 
-            public override void Init()
+            public override void __Init__()
             {
                 this.B = this.Factory.Get<ICallable, B>();
             }
@@ -430,7 +430,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public ICallable A { get; set; }
 
-            public override void Init()
+            public override void __Init__()
             {
                 this.A = this.Factory.Get<ICallable, A>();
             }
@@ -452,7 +452,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public IUnitary<Qubit> X { get; set; }
 
-            public override void Init()
+            public override void __Init__()
             {
                 this.A = this.Factory.Get<ICallable, A>();
                 this.X = this.Factory.Get<IUnitary<Qubit>, Intrinsic.X>();
@@ -472,7 +472,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             public override Func<QVoid, QVoid> Body => (_) => { return QVoid.Instance; };
 
-            public override void Init()
+            public override void __Init__()
             {
                 this.Gen = this.Factory.Get<ICallable>(typeof(Gen<>));
             }

--- a/src/Simulation/Simulators.Tests/StartOperationTests.cs
+++ b/src/Simulation/Simulators.Tests/StartOperationTests.cs
@@ -141,11 +141,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 var p1 = basic.Partial(m1);
                 var p2 = p1.Partial(m2);
 
-                AssertTuple(expected, p1.__dataIn((q2, q3)).Value);
-                AssertTuple(expected, p2.__dataIn((q2)).Value);
+                AssertTuple(expected, p1.__DataIn__((q2, q3)).Value);
+                AssertTuple(expected, p2.__DataIn__((q2)).Value);
 
-                Assert.Equal(new Qubit[] { q1, q2, q3 }, p1.__dataIn((q2, q3)).Qubits);
-                Assert.Equal(new Qubit[] { q1, q2, q3 }, p2.__dataIn(q2).Qubits);
+                Assert.Equal(new Qubit[] { q1, q2, q3 }, p1.__DataIn__((q2, q3)).Qubits);
+                Assert.Equal(new Qubit[] { q1, q2, q3 }, p2.__DataIn__(q2).Qubits);
 
                 Assert.Null(((IApplyData)basic).Qubits);
                 Assert.Equal(new Qubit[] { q1, null, null }, ((IApplyData)p1).Qubits);
@@ -169,11 +169,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 var p1 = ((Basic)basic.Data).Partial(m1);
                 var p2 = p1.Partial(m2);
 
-                AssertTuple(expected, p1.__dataIn((q2, q3)).Value);
-                AssertTuple(expected, p2.__dataIn((q2)).Value);
+                AssertTuple(expected, p1.__DataIn__((q2, q3)).Value);
+                AssertTuple(expected, p2.__DataIn__((q2)).Value);
 
-                Assert.Equal(new Qubit[] { q1, q2, q3 }, p1.__dataIn((q2, q3)).Qubits);
-                Assert.Equal(new Qubit[] { q1, q2, q3 }, p2.__dataIn(q2).Qubits);
+                Assert.Equal(new Qubit[] { q1, q2, q3 }, p1.__DataIn__((q2, q3)).Qubits);
+                Assert.Equal(new Qubit[] { q1, q2, q3 }, p2.__DataIn__(q2).Qubits);
 
                 Assert.Null(((IApplyData)basic).Qubits);
                 Assert.Equal(new Qubit[] { q1, null, null }, ((IApplyData)p1).Qubits);

--- a/src/Simulation/Simulators.Tests/ToffoliSimulatorTests.cs
+++ b/src/Simulation/Simulators.Tests/ToffoliSimulatorTests.cs
@@ -113,12 +113,12 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var measure = sim.Get<Intrinsic.M>();
             var set = sim.Get<SetQubit>();
 
-            var ctrlX = x.ControlledBody.AsAction();
+            var ctrlX = x.__ControlledBody__.AsAction();
 
             OperationsTestHelper.ctrlTestShell(sim, ctrlX, (enabled, ctrls, q) =>
             {
                 set.Apply((Result.Zero, q));
-                x.ControlledBody((ctrls, q));
+                x.__ControlledBody__((ctrls, q));
 
                 var result = measure.Apply(q);
                 var expected = (enabled) ? Result.One : Result.Zero;

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.ClassicalControl.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.ClassicalControl.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 this.tracerCore = m;
             }
 
-            public override Func<(Result, ICallable, ICallable), QVoid> Body => (q) =>
+            public override Func<(Result, ICallable, ICallable), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, OperationFunctor.Body, null);
@@ -139,7 +139,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 this.tracerCore = m;
             }
 
-            public override Func<(Result, IAdjointable, IAdjointable), QVoid> Body => (q) =>
+            public override Func<(Result, IAdjointable, IAdjointable), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, OperationFunctor.Adjoint, null);
@@ -155,7 +155,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 this.tracerCore = m;
             }
 
-            public override Func<(IQArray<Qubit>, Result, IControllable, IControllable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Qubit>, Result, IControllable, IControllable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.Controlled, ctrls);
@@ -172,7 +172,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 this.tracerCore = m;
             }
 
-            public override Func<(IQArray<Qubit>, Result, IUnitary, IUnitary), QVoid> Body => (q) =>
+            public override Func<(IQArray<Qubit>, Result, IUnitary, IUnitary), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.ControlledAdjoint, ctrls);
@@ -193,7 +193,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 this.tracerCore = m;
             }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, ICallable, ICallable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, ICallable, ICallable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
@@ -209,7 +209,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 this.tracerCore = m;
             }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, OperationFunctor.Adjoint, null);
@@ -225,7 +225,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 this.tracerCore = m;
             }
 
-            public override Func<(IQArray<Qubit>, IQArray<Result>, IQArray<Result>, IControllable, IControllable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Qubit>, IQArray<Result>, IQArray<Result>, IControllable, IControllable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.Controlled, ctrls);
@@ -242,7 +242,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 this.tracerCore = m;
             }
 
-            public override Func<(IQArray<Qubit>, IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> Body => (q) =>
+            public override Func<(IQArray<Qubit>, IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.Controlled, ctrls);

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Diagnostics.Dump.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Diagnostics.Dump.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 core = m;
             }
 
-            public override Func<T, QVoid> Body => (location) =>
+            public override Func<T, QVoid> __Body__ => (location) =>
             {
                 if (location == null) { throw new ArgumentNullException(nameof(location)); }
                 var filename = (location is QVoid) ? "" : location.ToString();
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 core = m;
             }
 
-            public override Func<(T, IQArray<Qubit>), QVoid> Body => (__in) =>
+            public override Func<(T, IQArray<Qubit>), QVoid> __Body__ => (__in) =>
             {
                 var (location, qubits) = __in;
 

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.CX.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.CX.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 tracerCore = m;
             }
 
-            public override Func<(Qubit, Qubit), QVoid> Body
+            public override Func<(Qubit, Qubit), QVoid> __Body__
                 => (arg) =>
                 {
                     (Qubit control, Qubit target) = arg;

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.Clifford.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.Clifford.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 tracerCore = m;
             }
 
-            public override Func<(long, Pauli, Qubit), QVoid> Body
+            public override Func<(long, Pauli, Qubit), QVoid> __Body__
                 => (arg) =>
                 {
                     (long id , Pauli pauli, Qubit target) = arg;

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.ForceMeasure.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.ForceMeasure.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 tracerCore = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result), QVoid> Body
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result), QVoid> __Body__
                 => (arg) =>
                 {
                     (IQArray<Pauli> observable, IQArray<Qubit> target, Result result) = arg;

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.R.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.R.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
             }
 
             public override Func<(Pauli, double, Qubit), QVoid>
-                Body => (arg) =>
+                __Body__ => (arg) =>
                 {
                     (Pauli axis, double angle, Qubit target) = arg;
                     tracerCore.R(axis, angle, target);

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.RFrac.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Interface.RFrac.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 tracerCore = m;
             }
 
-            public override Func<(Pauli, long, long, Qubit), QVoid> Body
+            public override Func<(Pauli, long, long, Qubit), QVoid> __Body__
                 => (arg) =>
                 {
                     (Pauli axis, long numerator, long denomPower, Qubit target) = arg;

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Primitive.Assert.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Primitive.Assert.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 core = m.tracingCore;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> Body
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __Body__
                 => (arg) =>
                 {
                     (IQArray<Pauli> observable, IQArray<Qubit> target, Result result, string msg) = arg;
@@ -25,11 +25,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                     return QVoid.Instance;
                 };
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Primitive.AssertProb.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Primitive.AssertProb.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 core = m.tracingCore;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> Body
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __Body__
                 => (args) =>
                 {
                     (IQArray<Pauli> observable,
@@ -29,11 +29,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                     return QVoid.Instance;
                 };
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Primitive.Measure.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Primitive.Measure.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
             }
 
             public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result>
-                Body => (args) =>
+                __Body__ => (args) =>
                 {
                     (IQArray<Pauli> observable, IQArray<Qubit> target) = args;
                     return core.Measure(observable, target);

--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Primitive.random.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulator.Primitive.random.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
                 core = m;
             }
 
-            public override Func<IQArray<double>, Int64> Body => (p) =>
+            public override Func<IQArray<double>, Int64> __Body__ => (p) =>
             {
                 return CommonUtils.SampleDistribution(p, core.random.NextDouble());
             };

--- a/src/Simulation/Simulators/QuantumProcessor/Assert.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Assert.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __Body__ => (_args) =>
             {
                 (IQArray<Pauli> paulis, IQArray<Qubit> qubits, Result result, string msg) = _args;
                 if (paulis.Length != qubits.Length)
@@ -33,11 +33,11 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/QuantumProcessor/AssertProb.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/AssertProb.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __Body__ => (_args) =>
             {
                 (IQArray<Pauli> paulis, IQArray<Qubit> qubits, Result result, double expectedPr, string msg, double tol) = _args;
                 if (paulis.Length != qubits.Length)
@@ -33,11 +33,11 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/QuantumProcessor/ClassicalControl.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/ClassicalControl.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorApplyIfElse(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(Result, ICallable, ICallable), QVoid> Body => (q) =>
+            public override Func<(Result, ICallable, ICallable), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
@@ -102,13 +102,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorApplyIfElseA(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(Result, IAdjointable, IAdjointable), QVoid> Body => (q) =>
+            public override Func<(Result, IAdjointable, IAdjointable), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
             };
 
-            public override Func<(Result, IAdjointable, IAdjointable), QVoid> AdjointBody => (q) =>
+            public override Func<(Result, IAdjointable, IAdjointable), QVoid> __AdjointBody__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Adjoint, null);
@@ -121,13 +121,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorApplyIfElseC(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(Result, IControllable, IControllable), QVoid> Body => (q) =>
+            public override Func<(Result, IControllable, IControllable), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
             };
 
-            public override Func<(IQArray<Qubit>, (Result, IControllable, IControllable)), QVoid> ControlledBody => (q) =>
+            public override Func<(IQArray<Qubit>, (Result, IControllable, IControllable)), QVoid> __ControlledBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
                 if ((ctrls == null) || (ctrls.Count == 0))
@@ -147,19 +147,19 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorApplyIfElseCA(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(Result, IUnitary, IUnitary), QVoid> Body => (q) =>
+            public override Func<(Result, IUnitary, IUnitary), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Body, null);
             };
 
-            public override Func<(Result, IUnitary, IUnitary), QVoid> AdjointBody => (q) =>
+            public override Func<(Result, IUnitary, IUnitary), QVoid> __AdjointBody__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResult, Result.Zero, onZero, onOne, OperationFunctor.Adjoint, null);
             };
 
-            public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> ControlledBody => (q) =>
+            public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> __ControlledBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
 
@@ -173,7 +173,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 }
             };
 
-            public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> ControlledAdjointBody => (q) =>
+            public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> __ControlledAdjointBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
 
@@ -196,7 +196,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorApplyConditionally(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, ICallable, ICallable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, ICallable, ICallable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
@@ -209,13 +209,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorApplyConditionallyA(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> AdjointBody => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> __AdjointBody__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Adjoint, null);
@@ -228,13 +228,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorApplyConditionallyC(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IControllable, IControllable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IControllable, IControllable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IControllable, IControllable)), QVoid> ControlledBody => (q) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IControllable, IControllable)), QVoid> __ControlledBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
 
@@ -255,19 +255,19 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorApplyConditionallyCA(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> AdjointBody => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> __AdjointBody__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(Simulator, measurementResults, resultsValues, onEqualOp, onNonEqualOp, OperationFunctor.Adjoint, null);
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> ControlledBody => (q) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> __ControlledBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
 
@@ -281,7 +281,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 }
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> ControlledAdjointBody => (q) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> __ControlledAdjointBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> resultsValues, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
 

--- a/src/Simulation/Simulators/QuantumProcessor/Dump.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Dump.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<T, QVoid> Body => (location) =>
+            public override Func<T, QVoid> __Body__ => (location) =>
             {
                 if (location == null) { throw new ArgumentNullException(nameof(location)); }
 
@@ -36,7 +36,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(T, IQArray<Qubit>), QVoid> Body => (__in) =>
+            public override Func<(T, IQArray<Qubit>), QVoid> __Body__ => (__in) =>
             {
                 var (location, qubits) = __in;
 

--- a/src/Simulation/Simulators/QuantumProcessor/Exp.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Exp.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> __Body__ => (_args) =>
             {
                 (IQArray<Pauli> paulis, double angle, IQArray<Qubit> qubits) = _args;
 
@@ -35,14 +35,14 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> AdjointBody => (_args) =>
+            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> __AdjointBody__ => (_args) =>
             {
                 (IQArray<Pauli> paulis, double angle, IQArray<Qubit> qubits) = _args;
                 
-                return this.Body.Invoke((paulis, -angle, qubits));
+                return this.__Body__.Invoke((paulis, -angle, qubits));
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (IQArray<Pauli> paulis, double angle, IQArray<Qubit> qubits)) = _args;
 
@@ -66,11 +66,11 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (IQArray<Pauli> paulis, double angle, IQArray<Qubit> qubits)) = _args;
 
-                return this.ControlledBody.Invoke((ctrls, (paulis, -angle, qubits)));
+                return this.__ControlledBody__.Invoke((ctrls, (paulis, -angle, qubits)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumProcessor/ExpFrac.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/ExpFrac.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
 
             public QuantumProcessorDispatcherExpFrac(QuantumProcessorDispatcher m) : base(m) { this.Simulator = m; }
 
-            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __Body__ => (_args) =>
             {
                 (IQArray<Pauli> paulis, long nom, long den, IQArray<Qubit> qubits) = _args;
 
@@ -31,15 +31,15 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> AdjointBody => (_args) =>
+            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __AdjointBody__ => (_args) =>
             {
                 (IQArray<Pauli> paulis, long nom, long den, IQArray<Qubit> qubits) = _args;
                 
-                return this.Body.Invoke((paulis, -nom, den, qubits));
+                return this.__Body__.Invoke((paulis, -nom, den, qubits));
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid>
-                ControlledBody => (_args) =>
+                __ControlledBody__ => (_args) =>
                 {
                     (IQArray<Qubit> ctrls, (IQArray<Pauli> paulis, long nom, long den, IQArray<Qubit> qubits)) = _args;
 
@@ -64,11 +64,11 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid>
-                ControlledAdjointBody => (_args) =>
+                __ControlledAdjointBody__ => (_args) =>
                 {
                     (IQArray<Qubit> ctrls, (IQArray<Pauli> paulis, long nom, long den, IQArray<Qubit> qubits)) = _args;
 
-                    return this.ControlledBody.Invoke((ctrls, (paulis, -nom, den, qubits)));
+                    return this.__ControlledBody__.Invoke((ctrls, (paulis, -nom, den, qubits)));
                 };
         }
     }

--- a/src/Simulation/Simulators/QuantumProcessor/H.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/H.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.QuantumProcessor.H(q1);
                 return QVoid.Instance;
             };
 
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = args;
 

--- a/src/Simulation/Simulators/QuantumProcessor/M.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/M.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, Result> Body => (q) =>
+            public override Func<Qubit, Result> __Body__ => (q) =>
             {
                 return Simulator.QuantumProcessor.M(q);
             };

--- a/src/Simulation/Simulators/QuantumProcessor/Measure.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Measure.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> __Body__ => (_args) =>
             {
                 (IQArray<Pauli> paulis, IQArray<Qubit> qubits) = _args;
 

--- a/src/Simulation/Simulators/QuantumProcessor/R.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/R.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(Pauli, double, Qubit), QVoid> Body => (_args) =>
+            public override Func<(Pauli, double, Qubit), QVoid> __Body__ => (_args) =>
             {
                 (Pauli basis, double angle, Qubit q1) = _args;
                 if (basis != Pauli.PauliI)
@@ -29,13 +29,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(Pauli, double, Qubit), QVoid> AdjointBody => (_args) =>
+            public override Func<(Pauli, double, Qubit), QVoid> __AdjointBody__ => (_args) =>
             {
                 (Pauli basis, double angle, Qubit q1) = _args;
-                return this.Body.Invoke((basis, -angle, q1));
+                return this.__Body__.Invoke((basis, -angle, q1));
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (Pauli basis, double angle, Qubit q1)) = _args;
 
@@ -52,10 +52,10 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
             };
 
 
-            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (Pauli basis, double angle, Qubit q1)) = _args;
-                return this.ControlledBody.Invoke((ctrls, (basis, -angle, q1)));
+                return this.__ControlledBody__.Invoke((ctrls, (basis, -angle, q1)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumProcessor/R1.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/R1.cs
@@ -18,20 +18,20 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(double, Qubit), QVoid> Body => (_args) =>
+            public override Func<(double, Qubit), QVoid> __Body__ => (_args) =>
             {
                 (double angle, Qubit q1) = _args;
                 Simulator.QuantumProcessor.R1(angle, q1);
                 return QVoid.Instance;
             };
 
-            public override Func<(double, Qubit), QVoid> AdjointBody => (_args) =>
+            public override Func<(double, Qubit), QVoid> __AdjointBody__ => (_args) =>
             {
                 (double angle, Qubit q1) = _args;
-                return this.Body.Invoke((-angle, q1));
+                return this.__Body__.Invoke((-angle, q1));
             };
 
-            public override Func<(IQArray<Qubit>, ( double, Qubit)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, ( double, Qubit)), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (double angle, Qubit q1)) = _args;
 
@@ -48,10 +48,10 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
             };
 
 
-            public override Func<(IQArray<Qubit>, (double, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (double, Qubit)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (double angle, Qubit q1)) = _args;
-                return this.ControlledBody.Invoke((ctrls, (-angle, q1)));
+                return this.__ControlledBody__.Invoke((ctrls, (-angle, q1)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumProcessor/R1Frac.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/R1Frac.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(long, long, Qubit), QVoid> Body => (_args) =>
+            public override Func<(long, long, Qubit), QVoid> __Body__ => (_args) =>
             {
                 (long num, long denom, Qubit q1) = _args;
                 (long numNew, long denomNew) = CommonUtils.Reduce(num, denom);
@@ -27,13 +27,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(long, long, Qubit), QVoid> AdjointBody => (_args) =>
+            public override Func<(long, long, Qubit), QVoid> __AdjointBody__ => (_args) =>
             {
                 (long num, long denom, Qubit q1) = _args;
-                return this.Body.Invoke((-num, denom, q1));
+                return this.__Body__.Invoke((-num, denom, q1));
             };
 
-            public override Func<(IQArray<Qubit>, (long, long, Qubit)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (long, long, Qubit)), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (long num, long denom, Qubit q1)) = _args;
                 (long numNew, long denomNew) = CommonUtils.Reduce(num, denom);
@@ -50,10 +50,10 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, (long, long, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (long, long, Qubit)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (long num, long denom, Qubit q1)) = _args;
-                return this.ControlledBody.Invoke((ctrls, (-num, denom, q1)));
+                return this.__ControlledBody__.Invoke((ctrls, (-num, denom, q1)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumProcessor/RFrac.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/RFrac.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(Pauli, long, long, Qubit), QVoid> Body => (_args) =>
+            public override Func<(Pauli, long, long, Qubit), QVoid> __Body__ => (_args) =>
             {
                 (Pauli basis, long num, long denom, Qubit q1) = _args;
                 if (basis != Pauli.PauliI)
@@ -31,13 +31,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(Pauli, long, long, Qubit), QVoid> AdjointBody => (_args) =>
+            public override Func<(Pauli, long, long, Qubit), QVoid> __AdjointBody__ => (_args) =>
             {
                 (Pauli basis, long num, long denom, Qubit q1) = _args;
-                return this.Body.Invoke((basis, -num, denom, q1));
+                return this.__Body__.Invoke((basis, -num, denom, q1));
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (Pauli basis, long num, long denom, Qubit q1)) = _args;
                 (long numNew, long denomNew) = CommonUtils.Reduce(num, denom);
@@ -54,10 +54,10 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, (Pauli basis, long num, long denom, Qubit q1)) = _args;
-                return this.ControlledBody.Invoke((ctrls, (basis, -num, denom, q1)));
+                return this.__ControlledBody__.Invoke((ctrls, (basis, -num, denom, q1)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumProcessor/Reset.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Reset.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.QuantumProcessor.Reset(q1);
                 return QVoid.Instance;

--- a/src/Simulation/Simulators/QuantumProcessor/S.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/S.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.QuantumProcessor.S(q1);
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
@@ -39,13 +39,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<Qubit, QVoid> AdjointBody => (q1) =>
+            public override Func<Qubit, QVoid> __AdjointBody__ => (q1) =>
             {
                 Simulator.QuantumProcessor.SAdjoint(q1);
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 

--- a/src/Simulation/Simulators/QuantumProcessor/SWAP.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/SWAP.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<(Qubit,Qubit), QVoid> Body => (q1) =>
+            public override Func<(Qubit,Qubit), QVoid> __Body__ => (q1) =>
             {
                 Simulator.QuantumProcessor.SWAP(q1.Item1, q1.Item2);
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, (Qubit, Qubit)), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit)), QVoid> __ControlledBody__ => (args) =>
             {
                 (IQArray<Qubit> ctrls, (Qubit q1, Qubit q2) ) = args;
 

--- a/src/Simulation/Simulators/QuantumProcessor/T.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/T.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.QuantumProcessor.T(q1);
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
@@ -32,13 +32,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 return QVoid.Instance;
             };
 
-            public override Func<Qubit, QVoid> AdjointBody => (q1) =>
+            public override Func<Qubit, QVoid> __AdjointBody__ => (q1) =>
             {
                 Simulator.QuantumProcessor.TAdjoint(q1);
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 

--- a/src/Simulation/Simulators/QuantumProcessor/X.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/X.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.QuantumProcessor.X(q1);
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = args;
 

--- a/src/Simulation/Simulators/QuantumProcessor/Y.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Y.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.QuantumProcessor.Y(q1);
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 

--- a/src/Simulation/Simulators/QuantumProcessor/Z.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/Z.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.QuantumProcessor.Z(q1);
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 

--- a/src/Simulation/Simulators/QuantumProcessor/random.cs
+++ b/src/Simulation/Simulators/QuantumProcessor/random.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor
                 Simulator = m;
             }
 
-            public override Func<IQArray<double>, Int64> Body => (p) =>
+            public override Func<IQArray<double>, Int64> __Body__ => (p) =>
             {
                 return CommonUtils.SampleDistribution(p, Simulator.random.NextDouble());
             };            

--- a/src/Simulation/Simulators/QuantumSimulator/Assert.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/Assert.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __Body__ => (_args) =>
             {
                 var (paulis, qubits, result, msg) = _args;
 
@@ -50,11 +50,11 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/QuantumSimulator/AssertProb.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/AssertProb.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __Body__ => (_args) =>
             {
                 var (paulis, qubits, result, expectedPr, msg, tol) = _args;
 
@@ -68,11 +68,11 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/QuantumSimulator/ClassicalControl.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/ClassicalControl.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(Result, ICallable, ICallable), QVoid> Body => (q) =>
+            public override Func<(Result, ICallable, ICallable), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, OperationFunctor.Body, null);
@@ -138,13 +138,13 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(Result, IAdjointable, IAdjointable), QVoid> Body => (q) =>
+            public override Func<(Result, IAdjointable, IAdjointable), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, OperationFunctor.Body, null);
             };
 
-            public override Func<(Result, IAdjointable, IAdjointable), QVoid> AdjointBody => (q) =>
+            public override Func<(Result, IAdjointable, IAdjointable), QVoid> __AdjointBody__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, OperationFunctor.Adjoint, null);
@@ -160,13 +160,13 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(Result, IControllable, IControllable), QVoid> Body => (q) =>
+            public override Func<(Result, IControllable, IControllable), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, OperationFunctor.Body, null);
             };
 
-            public override Func<(IQArray<Qubit>, (Result, IControllable, IControllable)), QVoid> ControlledBody => (q) =>
+            public override Func<(IQArray<Qubit>, (Result, IControllable, IControllable)), QVoid> __ControlledBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.Controlled, ctrls);
@@ -183,26 +183,26 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(Result, IUnitary, IUnitary), QVoid> Body => (q) =>
+            public override Func<(Result, IUnitary, IUnitary), QVoid> __Body__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, OperationFunctor.Body, null);
             };
 
-            public override Func<(Result, IUnitary, IUnitary), QVoid> AdjointBody => (q) =>
+            public override Func<(Result, IUnitary, IUnitary), QVoid> __AdjointBody__ => (q) =>
             {
                 (Result measurementResult, ICallable onZero, ICallable onOne) = q;
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, OperationFunctor.Adjoint, null);
             };
 
-            public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> ControlledBody => (q) =>
+            public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> __ControlledBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.Controlled, ctrls);
                 return ExecuteConditionalStatement(measurementResult, onZero, onOne, type, ctrls);
             };
 
-            public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> ControlledAdjointBody => (q) =>
+            public override Func<(IQArray<Qubit>, (Result, IUnitary, IUnitary)), QVoid> __ControlledAdjointBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (Result measurementResult, ICallable onZero, ICallable onOne)) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.ControlledAdjoint, ctrls);
@@ -223,7 +223,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, ICallable, ICallable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, ICallable, ICallable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
@@ -239,13 +239,13 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> AdjointBody => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IAdjointable, IAdjointable), QVoid> __AdjointBody__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, OperationFunctor.Adjoint, null);
@@ -261,13 +261,13 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IControllable, IControllable), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IControllable, IControllable), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IControllable, IControllable)), QVoid> ControlledBody => (q) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IControllable, IControllable)), QVoid> __ControlledBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.Controlled, ctrls);
@@ -284,26 +284,26 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> Body => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> __Body__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, OperationFunctor.Body, null);
             };
 
-            public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> AdjointBody => (q) =>
+            public override Func<(IQArray<Result>, IQArray<Result>, IUnitary, IUnitary), QVoid> __AdjointBody__ => (q) =>
             {
                 (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp) = q;
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, OperationFunctor.Adjoint, null);
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> ControlledBody => (q) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> __ControlledBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.Controlled, ctrls);
                 return ExecuteConditionalStatement(measurementResults, comparisonResults, onEqualOp, onNonEqualOp, type, ctrls);
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> ControlledAdjointBody => (q) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Result>, IQArray<Result>, IUnitary, IUnitary)), QVoid> __ControlledAdjointBody__ => (q) =>
             {
                 (IQArray<Qubit> ctrls, (IQArray<Result> measurementResults, IQArray<Result> comparisonResults, ICallable onEqualOp, ICallable onNonEqualOp)) = q;
                 OperationFunctor type = AdjustForNoControls(OperationFunctor.ControlledAdjoint, ctrls);

--- a/src/Simulation/Simulators/QuantumSimulator/Dump.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/Dump.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<T, QVoid> Body => (location) =>
+            public override Func<T, QVoid> __Body__ => (location) =>
             {
                 if (location == null) { throw new ArgumentNullException(nameof(location)); }
 
@@ -91,7 +91,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(T, IQArray<Qubit>), QVoid> Body => (__in) =>
+            public override Func<(T, IQArray<Qubit>), QVoid> __Body__ => (__in) =>
             {
                 var (location, qubits) = __in;
 

--- a/src/Simulation/Simulators/QuantumSimulator/Exp.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/Exp.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> __Body__ => (_args) =>
             {
                 var (paulis, theta, qubits) = _args;
 
@@ -43,14 +43,14 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> AdjointBody => (_args) =>
+            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> __AdjointBody__ => (_args) =>
             {
                 var (paulis, angle, qubits) = _args;
 
-                return this.Body.Invoke((paulis, -angle, qubits));
+                return this.__Body__.Invoke((paulis, -angle, qubits));
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> __ControlledBody__ => (_args) =>
             {
                 var (ctrls, (paulis, angle, qubits)) = _args;
 
@@ -63,17 +63,17 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 }
 
                 SafeControlled(ctrls,
-                    () => this.Body.Invoke((paulis, angle, qubits)),
+                    () => this.__Body__.Invoke((paulis, angle, qubits)),
                     (count, ids) => MCExp(Simulator.Id, (uint)paulis.Length, paulis.ToArray(), angle, count, ids, qubits.GetIds()));
 
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 var (ctrls, (paulis, angle, qubits)) = _args;
 
-                return this.ControlledBody.Invoke((ctrls, (paulis, -angle, qubits)));
+                return this.__ControlledBody__.Invoke((ctrls, (paulis, -angle, qubits)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/ExpFrac.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/ExpFrac.cs
@@ -19,28 +19,28 @@ namespace Microsoft.Quantum.Simulation.Simulators
             public static double Angle(long numerator, long power) =>
                 (System.Math.PI * numerator) / (1 << (int)power);
 
-            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> Body => (args) =>
+            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __Body__ => (args) =>
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
                 return Exp.Apply((paulis, angle, qubits));
             };
 
-            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> AdjointBody => (args) =>
+            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __AdjointBody__ => (args) =>
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
                 return Exp.Adjoint.Apply((paulis, angle, qubits));
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
                 return Exp.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> ControlledAdjointBody => (args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);

--- a/src/Simulation/Simulators/QuantumSimulator/ExpFrac.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/ExpFrac.cs
@@ -23,28 +23,28 @@ namespace Microsoft.Quantum.Simulation.Simulators
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
-                return __Exp__.Apply((paulis, angle, qubits));
+                return __Call_Exp__.Apply((paulis, angle, qubits));
             };
 
             public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __AdjointBody__ => (args) =>
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
-                return __Exp__.Adjoint.Apply((paulis, angle, qubits));
+                return __Call_Exp__.Adjoint.Apply((paulis, angle, qubits));
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
-                return __Exp__.Controlled.Apply((ctrls, (paulis, angle, qubits)));
+                return __Call_Exp__.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
-                return __Exp__.Adjoint.Controlled.Apply((ctrls, (paulis, angle, qubits)));
+                return __Call_Exp__.Adjoint.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/ExpFrac.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/ExpFrac.cs
@@ -23,28 +23,28 @@ namespace Microsoft.Quantum.Simulation.Simulators
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
-                return Exp.Apply((paulis, angle, qubits));
+                return __Exp__.Apply((paulis, angle, qubits));
             };
 
             public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __AdjointBody__ => (args) =>
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
-                return Exp.Adjoint.Apply((paulis, angle, qubits));
+                return __Exp__.Adjoint.Apply((paulis, angle, qubits));
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
-                return Exp.Controlled.Apply((ctrls, (paulis, angle, qubits)));
+                return __Exp__.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
-                return Exp.Adjoint.Controlled.Apply((ctrls, (paulis, angle, qubits)));
+                return __Exp__.Adjoint.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/ExpFrac.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/ExpFrac.cs
@@ -23,28 +23,28 @@ namespace Microsoft.Quantum.Simulation.Simulators
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
-                return __Call_Exp__.Apply((paulis, angle, qubits));
+                return __Microsoft_Quantum_Intrinsic_Exp__.Apply((paulis, angle, qubits));
             };
 
             public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __AdjointBody__ => (args) =>
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
-                return __Call_Exp__.Adjoint.Apply((paulis, angle, qubits));
+                return __Microsoft_Quantum_Intrinsic_Exp__.Adjoint.Apply((paulis, angle, qubits));
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
-                return __Call_Exp__.Controlled.Apply((ctrls, (paulis, angle, qubits)));
+                return __Microsoft_Quantum_Intrinsic_Exp__.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
 
             public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
-                return __Call_Exp__.Adjoint.Controlled.Apply((ctrls, (paulis, angle, qubits)));
+                return __Microsoft_Quantum_Intrinsic_Exp__.Adjoint.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/H.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/H.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             };
 
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, q1) = args;
 

--- a/src/Simulation/Simulators/QuantumSimulator/M.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/M.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, Result> Body => (q) =>
+            public override Func<Qubit, Result> __Body__ => (q) =>
             {
                 Simulator.CheckQubit(q);
                 //setting qubit as measured to allow for release

--- a/src/Simulation/Simulators/QuantumSimulator/Measure.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/Measure.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> __Body__ => (_args) =>
             {
                 var (paulis, qubits) = _args;
 

--- a/src/Simulation/Simulators/QuantumSimulator/R.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/R.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<(Pauli, double, Qubit), QVoid> Body => (_args) =>
+            public override Func<(Pauli, double, Qubit), QVoid> __Body__ => (_args) =>
             {
                 var (basis, angle, q1) = _args;
 
@@ -38,14 +38,14 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(Pauli, double, Qubit), QVoid> AdjointBody => (_args) =>
+            public override Func<(Pauli, double, Qubit), QVoid> __AdjointBody__ => (_args) =>
             {
                 var (basis, angle, q1) = _args;
 
-                return this.Body.Invoke((basis, -angle, q1));
+                return this.__Body__.Invoke((basis, -angle, q1));
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> __ControlledBody__ => (_args) =>
             {
                 var (ctrls, (basis, angle, q1)) = _args;
 
@@ -53,18 +53,18 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 CheckAngle(angle);
 
                 SafeControlled(ctrls,
-                    () => this.Body.Invoke((basis, angle, q1)),
+                    () => this.__Body__.Invoke((basis, angle, q1)),
                     (count, ids) => MCR(Simulator.Id, basis, angle, count, ids, (uint)q1.Id));
 
                 return QVoid.Instance;
             };
 
 
-            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 var (ctrls, (basis, angle, q1)) = _args;
 
-                return this.ControlledBody.Invoke((ctrls, (basis, -angle, q1)));
+                return this.__ControlledBody__.Invoke((ctrls, (basis, -angle, q1)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/RFrac.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/RFrac.cs
@@ -23,28 +23,28 @@ namespace Microsoft.Quantum.Simulation.Simulators
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
-                return R.Apply((pauli, angle, qubit));
+                return __R__.Apply((pauli, angle, qubit));
             };
 
             public override Func<(Pauli, long, long, Qubit), QVoid> __AdjointBody__ => (args) =>
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
-                return R.Adjoint.Apply((pauli, angle, qubit));
+                return __R__.Adjoint.Apply((pauli, angle, qubit));
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
-                return R.Controlled.Apply((ctrls, (pauli, angle, qubit)));
+                return __R__.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
-                return R.Adjoint.Controlled.Apply((ctrls, (pauli, angle, qubit)));
+                return __R__.Adjoint.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/RFrac.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/RFrac.cs
@@ -23,28 +23,28 @@ namespace Microsoft.Quantum.Simulation.Simulators
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
-                return __Call_R__.Apply((pauli, angle, qubit));
+                return __Microsoft_Quantum_Intrinsic_R__.Apply((pauli, angle, qubit));
             };
 
             public override Func<(Pauli, long, long, Qubit), QVoid> __AdjointBody__ => (args) =>
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
-                return __Call_R__.Adjoint.Apply((pauli, angle, qubit));
+                return __Microsoft_Quantum_Intrinsic_R__.Adjoint.Apply((pauli, angle, qubit));
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
-                return __Call_R__.Controlled.Apply((ctrls, (pauli, angle, qubit)));
+                return __Microsoft_Quantum_Intrinsic_R__.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
-                return __Call_R__.Adjoint.Controlled.Apply((ctrls, (pauli, angle, qubit)));
+                return __Microsoft_Quantum_Intrinsic_R__.Adjoint.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/RFrac.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/RFrac.cs
@@ -23,28 +23,28 @@ namespace Microsoft.Quantum.Simulation.Simulators
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
-                return __R__.Apply((pauli, angle, qubit));
+                return __Call_R__.Apply((pauli, angle, qubit));
             };
 
             public override Func<(Pauli, long, long, Qubit), QVoid> __AdjointBody__ => (args) =>
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
-                return __R__.Adjoint.Apply((pauli, angle, qubit));
+                return __Call_R__.Adjoint.Apply((pauli, angle, qubit));
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
-                return __R__.Controlled.Apply((ctrls, (pauli, angle, qubit)));
+                return __Call_R__.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
 
             public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
-                return __R__.Adjoint.Controlled.Apply((ctrls, (pauli, angle, qubit)));
+                return __Call_R__.Adjoint.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/RFrac.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/RFrac.cs
@@ -19,28 +19,28 @@ namespace Microsoft.Quantum.Simulation.Simulators
             public static double Angle(long numerator, long power) =>
                 (-2.0 * System.Math.PI * numerator) / (1 << (int)power);
 
-            public override Func<(Pauli, long, long, Qubit), QVoid> Body => (args) =>
+            public override Func<(Pauli, long, long, Qubit), QVoid> __Body__ => (args) =>
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
                 return R.Apply((pauli, angle, qubit));
             };
 
-            public override Func<(Pauli, long, long, Qubit), QVoid> AdjointBody => (args) =>
+            public override Func<(Pauli, long, long, Qubit), QVoid> __AdjointBody__ => (args) =>
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
                 return R.Adjoint.Apply((pauli, angle, qubit));
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
                 return R.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledAdjointBody => (args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);

--- a/src/Simulation/Simulators/QuantumSimulator/S.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/S.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<Qubit, QVoid> AdjointBody => (q1) =>
+            public override Func<Qubit, QVoid> __AdjointBody__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -62,14 +62,14 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
                 Simulator.CheckQubits(ctrls, q1);
 
                 SafeControlled(ctrls,
-                    () => this.AdjointBody(q1),
+                    () => this.__AdjointBody__(q1),
                     (count, ids) => MCAdjS(Simulator.Id, count, ids, (uint)q1.Id));
 
                 return QVoid.Instance;

--- a/src/Simulation/Simulators/QuantumSimulator/T.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/T.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
@@ -52,7 +52,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<Qubit, QVoid> AdjointBody => (q1) =>
+            public override Func<Qubit, QVoid> __AdjointBody__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
                 
@@ -60,14 +60,14 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
                 Simulator.CheckQubits(ctrls, q1);
 
                 SafeControlled(ctrls,
-                    () => this.AdjointBody(q1),
+                    () => this.__AdjointBody__(q1),
                     (count, ids) => MCAdjT(Simulator.Id, count, ids, (uint)q1.Id));
 
                 return QVoid.Instance;

--- a/src/Simulation/Simulators/QuantumSimulator/X.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/X.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, q1) = args;
 

--- a/src/Simulation/Simulators/QuantumSimulator/Y.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/Y.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 

--- a/src/Simulation/Simulators/QuantumSimulator/Z.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/Z.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1); ;
 
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 

--- a/src/Simulation/Simulators/QuantumSimulator/random.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/random.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 this.SimulatorId = m.Id;
             }
 
-            public override Func<IQArray<double>, Int64> Body => (p) =>
+            public override Func<IQArray<double>, Int64> __Body__ => (p) =>
             {
                 return random_choice(this.SimulatorId, p.Length, p.ToArray());
             };            

--- a/src/Simulation/Simulators/ToffoliSimulator/Assert.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/Assert.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// <summary>
             /// The implementation of the operation.
             /// </summary>
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __Body__ => (_args) =>
             {
                 Qubit? f(Pauli p, Qubit q) =>
                     p switch {
@@ -60,19 +60,19 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the adjoint specialization of the operation.
             /// The current definition is that this is a no-op.
             /// </summary>
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
             /// <summary>
             /// The implementation of the controlled specialization of the operation.
             /// The current definition is that this is a no-op.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
             /// <summary>
             /// The implementation of the controlled adjoint specialization of the operation.
             /// The current definition is that this is a no-op.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/ToffoliSimulator/AssertProb.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/AssertProb.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// <summary>
             /// The implementation of the operation.
             /// </summary>
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __Body__ => (_args) =>
             {
 
                 Qubit? f(Pauli p, Qubit q) =>
@@ -82,19 +82,19 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the adjoint specialization of the operation.
             /// The current definition is that this is a no-op.
             /// </summary>
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
             /// <summary>
             /// The implementation of the controlled specialization of the operation.
             /// The current definition is that this is a no-op.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
             /// <summary>
             /// The implementation of the controlled adjoint specialization of the operation.
             /// The current definition is that this is a no-op.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/ToffoliSimulator/Dump.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/Dump.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// <summary>
             /// The implementation of the operation.
             /// </summary>
-            public override Func<T, QVoid> Body => (location) =>
+            public override Func<T, QVoid> __Body__ => (location) =>
             {
                 if (location == null) { throw new ArgumentNullException(nameof(location)); }
 
@@ -60,7 +60,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// <summary>
             /// The implementation of the operation.
             /// </summary>
-            public override Func<(T, IQArray<Qubit>), QVoid> Body => (__in) =>
+            public override Func<(T, IQArray<Qubit>), QVoid> __Body__ => (__in) =>
             {
                 var (location, qubits) = __in;
 

--- a/src/Simulation/Simulators/ToffoliSimulator/Exp.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/Exp.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// For the Toffoli simulator, the implementation flips a target qubit
             /// if the respective rotation is effectively an X gate.
             /// </summary>
-            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> __Body__ => (_args) =>
             {
                 var (bases, angle, qubits) = _args;
 
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the adjoint specialization of the operation.
             /// For the Toffoli simulator *only*, this operation is self-adjoint.
             /// </summary>
-            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> AdjointBody => Body;
+            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> __AdjointBody__ => __Body__;
 
             /// <summary>
             /// The implementation of the controlled specialization of the operation.
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// if the rotation is effectively an X gate and all of the control qubits
             /// are in the One state.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> __ControlledBody__ => (_args) =>
             {
                 var (ctrls, (bases, angle, qubits)) = _args;
 
@@ -96,7 +96,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the controlled adjoint specialization of the operation.
             /// For the Toffoli simulator *only*, the controlled specialization is self-adjoint.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledAdjointBody => ControlledBody;
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => __ControlledBody__;
         }
     }
 }

--- a/src/Simulation/Simulators/ToffoliSimulator/ExpFrac.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/ExpFrac.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// For the Toffoli simulator, the implementation flips a target qubit
             /// if the respective rotation is effectively an X gate.
             /// </summary>
-            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __Body__ => (_args) =>
             {
                 var (bases, num, den, qubits) = _args;
 
@@ -59,7 +59,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the adjoint specialization of the operation.
             /// For the Toffoli simulator *only*, this operation is self-adjoint.
             /// </summary>
-            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> AdjointBody => Body;
+            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __AdjointBody__ => __Body__;
 
             /// <summary>
             /// The implementation of the controlled specialization of the operation.
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// if the rotation is effectively an X gate and all of the control qubits
             /// are in the One state.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledBody__ => (_args) =>
             {
                 var (ctrls, (bases, num, den, qubits)) = _args;
 
@@ -97,7 +97,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the controlled adjoint specialization of the operation.
             /// For the Toffoli simulator *only*, the controlled specialization is self-adjoint.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> ControlledAdjointBody => ControlledBody;
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => __ControlledBody__;
         }
     }
 }

--- a/src/Simulation/Simulators/ToffoliSimulator/H.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/H.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the operation.
             /// For the Toffoli simulator, the implementation throws a run-time error.
             /// </summary>
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 throw new NotImplementedException();
             };

--- a/src/Simulation/Simulators/ToffoliSimulator/M.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/M.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// For the Toffoli simulator, the implementation returns the state of the measured qubit.
             /// That is, Result.One is returned if the measured qubit is in the One state.
             /// </summary>
-            public override Func<Qubit, Result> Body => (q1) =>
+            public override Func<Qubit, Result> __Body__ => (q1) =>
             {
                 if (q1 == null) return Result.Zero;
 

--- a/src/Simulation/Simulators/ToffoliSimulator/Measure.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/Measure.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// That is, Result.One is returned if an odd number of the measured qubits are
             /// in the One state.
             /// </summary>
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> __Body__ => (_args) =>
             {
                 Qubit? f(Pauli p, Qubit q) =>
                     p switch {

--- a/src/Simulation/Simulators/ToffoliSimulator/R.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/R.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// For the Toffoli simulator, the implementation flips the target qubit
             /// if the rotation is effectively an X gate.
             /// </summary>
-            public override Func<(Pauli, double, Qubit), QVoid> Body => (_args) =>
+            public override Func<(Pauli, double, Qubit), QVoid> __Body__ => (_args) =>
             {
                 var (basis, angle, q1) = _args;
 
@@ -50,7 +50,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the adjoint specialization of the operation.
             /// For the Toffoli simulator *only*, this operation is self-adjoint.
             /// </summary>
-            public override Func<(Pauli, double, Qubit), QVoid> AdjointBody => Body;
+            public override Func<(Pauli, double, Qubit), QVoid> __AdjointBody__ => __Body__;
 
             /// <summary>
             /// The implementation of the controlled specialization of the operation.
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// if the rotation is effectively an X gate and all of the control qubits
             /// are in the One state.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> __ControlledBody__ => (_args) =>
             {
                 var (ctrls, (basis, angle, q1)) = _args;
 
@@ -80,7 +80,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the controlled adjoint specialization of the operation.
             /// For the Toffoli simulator *only*, the controlled specialization is self-adjoint.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledAdjointBody => ControlledBody;
+            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> __ControlledAdjointBody__ => __ControlledBody__;
         }
     }
 }

--- a/src/Simulation/Simulators/ToffoliSimulator/RFrac.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/RFrac.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// For the Toffoli simulator, the implementation flips the target qubit
             /// if the rotation is effectively an X gate.
             /// </summary>
-            public override Func<(Pauli, long, long, Qubit), QVoid> Body => (_args) =>
+            public override Func<(Pauli, long, long, Qubit), QVoid> __Body__ => (_args) =>
             {
                 var (basis, num, den, q1) = _args;
 
@@ -50,7 +50,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the adjoint specialization of the operation.
             /// For the Toffoli simulator *only*, this operation is self-adjoint.
             /// </summary>
-            public override Func<(Pauli, long, long, Qubit), QVoid> AdjointBody => Body;
+            public override Func<(Pauli, long, long, Qubit), QVoid> __AdjointBody__ => __Body__;
 
             /// <summary>
             /// The implementation of the controlled specialization of the operation.
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// if the rotation is effectively an X gate and all of the control qubits
             /// are in the One state.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledBody__ => (_args) =>
             {
                 var (ctrls, (basis, num, den, q1)) = _args;
 
@@ -80,7 +80,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the controlled adjoint specialization of the operation.
             /// For the Toffoli simulator *only*, the controlled specialization is self-adjoint.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledAdjointBody => ControlledBody;
+            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledAdjointBody__ => __ControlledBody__;
         }
     }
 }

--- a/src/Simulation/Simulators/ToffoliSimulator/Random.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/Random.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// <summary>
             /// The implementation of the operation.
             /// </summary>
-            public override Func<IQArray<double>, Int64> Body => (probs) =>
+            public override Func<IQArray<double>, Int64> __Body__ => (probs) =>
             {
                 if (probs.Any(d => d < 0.0))
                 {

--- a/src/Simulation/Simulators/ToffoliSimulator/S.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/S.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the operation.
             /// For the Toffoli simulator, the implementation throws a run-time error.
             /// </summary>
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 throw new NotImplementedException();
             };

--- a/src/Simulation/Simulators/ToffoliSimulator/SWAP.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/SWAP.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the operation.
             /// For the Toffoli simulator, the implementation swaps the states of the two qubits.
             /// </summary>
-            public override Func<(Qubit, Qubit), QVoid> Body => (args) =>
+            public override Func<(Qubit, Qubit), QVoid> __Body__ => (args) =>
             {
                 var (q1, q2) = args;
 
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// For the Toffoli simulator, the implementation swaps the states of the
             /// target qubits if all of the control qubits are 1.
             /// </summary>
-            public override Func<(IQArray<Qubit>, (Qubit, Qubit)), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (q1, q2)) = args;
 

--- a/src/Simulation/Simulators/ToffoliSimulator/T.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/T.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the operation.
             /// For the Toffoli simulator, the implementation throws a run-time error.
             /// </summary>
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 throw new NotImplementedException();
             };

--- a/src/Simulation/Simulators/ToffoliSimulator/X.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/X.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the operation.
             /// For the Toffoli simulator, the implementation flips the target qubit.
             /// </summary>
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 if (q1 == null) return QVoid.Instance;
 
@@ -44,7 +44,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// For the Toffoli simulator, the implementation flips the target qubit 
             /// if all of the control qubits are 1.
             /// </summary>
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, q) = args;
                 if (q == null) return QVoid.Instance;

--- a/src/Simulation/Simulators/ToffoliSimulator/Y.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/Y.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the operation.
             /// For the Toffoli simulator, the implementation throws a run-time error.
             /// </summary>
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 throw new NotImplementedException();
             };

--- a/src/Simulation/Simulators/ToffoliSimulator/Z.cs
+++ b/src/Simulation/Simulators/ToffoliSimulator/Z.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators
             /// The implementation of the operation.
             /// For the Toffoli simulator, the implementation throws a run-time error.
             /// </summary>
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 throw new NotImplementedException();
             };


### PR DESCRIPTION
This fixes part of #241 by renaming all non-static member names in generated callables to start and end with `__`, so the Q# callable name will no longer clash with any of its members. The static members `Run` and `Info` aren't renamed in this PR.

This PR allows you to define operations like `Body`, but it would not be possible to call operations with these names unless the autogenerated reference properties are also renamed (otherwise the reference for a call to `Body` would clash with the `Body` specialization property). To fix that, all reference properties use fully-qualified names, where `_` is replaced with `__` and `.` is replaced with `_`. As long as none of the built-in properties contain underscores (other than the start and ending `__`s), a conflict is not possible. This fixes #243.

- [x] Add tests for problem cases in #241.
- [ ] Use a namespace encoding with no overlaps (e.g. `_.` and `._` both map to `___`).
- [ ] Decide whether to add backwards compatibility shims for the renamed members.