### PR TITLE
Fixing circuit in test_gates to be deterministic

### DIFF
--- a/src/Simulation/Native/src/simulator/capi_test.cpp
+++ b/src/Simulation/Native/src/simulator/capi_test.cpp
@@ -112,9 +112,10 @@ void test_gates()
     assert(M(sim_id, 1)==false);
 
     X(sim_id, 0);
+     CRx(sim_id, 1.0, 0, 1);
+
     H(sim_id, 1);
-    CRx(sim_id, 1.0, 0, 1);
-    CRx(sim_id, -1.0, 0, 1);
+    CRz(sim_id, -1.0, 0, 1);
     H(sim_id, 1);
 
     assert(M(sim_id, 1)==false);

--- a/src/Simulation/Native/src/simulator/capi_test.cpp
+++ b/src/Simulation/Native/src/simulator/capi_test.cpp
@@ -112,9 +112,8 @@ void test_gates()
     assert(M(sim_id, 1)==false);
 
     X(sim_id, 0);
-     CRx(sim_id, 1.0, 0, 1);
-
     H(sim_id, 1);
+    CRx(sim_id, 1.0, 0, 1);
     CRx(sim_id, -1.0, 0, 1);
     H(sim_id, 1);
 


### PR DESCRIPTION

`test_gates` in capi_test.cpp had a low but non-zero chance of measuring One instead of Zero, resulting in a test crash due to assertion failure. This changes the instructions to ensure the test correctly unprepares the state so that measurement is as deterministic as possible.

Fixes #262