### PR TITLE
Use culture-dependent string for decimals in RuntimeMetadataTests

### DIFF
--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var expected = new RuntimeMetadata()
             {
                 Label = "Ry",
-                FormattedNonQubitArgs = "(2.1)",
+                FormattedNonQubitArgs = "(" + 2.1 + ")",
                 IsAdjoint = false,
                 IsControlled = false,
                 IsMeasurement = false,
@@ -513,7 +513,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var expected = new RuntimeMetadata()
             {
                 Label = "FooUDTOp",
-                FormattedNonQubitArgs = "(\"bar\", (2.1))",
+                FormattedNonQubitArgs = "(\"bar\", (" + 2.1 + "))",
                 IsAdjoint = false,
                 IsControlled = false,
                 IsMeasurement = false,
@@ -760,7 +760,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var expected = new RuntimeMetadata()
             {
                 Label = "Ry",
-                FormattedNonQubitArgs = "(2.1)",
+                FormattedNonQubitArgs = "(" + 2.1 + ")",
                 IsAdjoint = false,
                 IsControlled = false,
                 IsMeasurement = false,
@@ -783,7 +783,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             var expected = new RuntimeMetadata()
             {
                 Label = "FooUDT",
-                FormattedNonQubitArgs = "(\"bar\", (2.1))",
+                FormattedNonQubitArgs = "(\"bar\", (" + 2.1 + "))",
                 IsAdjoint = false,
                 IsControlled = false,
                 IsMeasurement = false,


### PR DESCRIPTION
`GetRuntimeMetadata` returns strings containing decimals in the format of the current culture, so `2.1` would become `"2.1"` in an English culture but `"2,1"` in a German culture, for example. However, the tests use a hard-coded string `"2.1"`, causing the tests to fail when the current culture uses a comma for decimals. While the tests pass on the build servers because they use an English culture, they can fail when run locally during development.

This PR might not be the best solution - maybe `GetRuntimeMetadata` should return a culture-invariant string, or all the unit tests should automatically run in the invariant culture regardless of local settings - but it does work around the immediate issue for me.