### PR TITLE
Fix stackoverflow error for QArray args

### DIFF
--- a/src/Simulation/Core/TypeExtensions.cs
+++ b/src/Simulation/Core/TypeExtensions.cs
@@ -165,12 +165,6 @@ namespace Microsoft.Quantum.Simulation.Core
                 return op.Name;
             }
 
-            // If object is an IApplyData, recursively extract arguments
-            if (o is IApplyData data)
-            {
-                return data.Value?.GetNonQubitArgumentsAsString();
-            }
-
             // If object is a string, enclose it in quotations
             if (o is string s)
             {
@@ -195,6 +189,15 @@ namespace Microsoft.Quantum.Simulation.Core
                     .Select(f => f.GetValue(o).GetNonQubitArgumentsAsString())
                     .WhereNotNull();
                 return (items.Any()) ? $"({string.Join(", ", items)})" : null;
+            }
+
+            // If object is an IApplyData, recursively extract arguments
+            if (o is IApplyData data)
+            {
+                if (data.Value != data)
+                {
+                    return data.Value?.GetNonQubitArgumentsAsString();
+                }
             }
 
             // Otherwise, return argument as a string

--- a/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/RuntimeMetadataTest.qs
@@ -30,5 +30,9 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
     operation TwoQubitOp (q1 : Qubit, q2 : Qubit) : Unit {
         // ...
     }
+
+    operation BoolArrayOp (bits : Bool[]) : Unit {
+        // ...
+    }
     
 }

--- a/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
+++ b/src/Simulation/Simulators.Tests/RuntimeMetadataTests.cs
@@ -500,6 +500,28 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
 
             Assert.Equal(op.GetRuntimeMetadata(args), expected);
         }
+
+        [Fact]
+        public void QArrayArgs()
+        {
+            var op = new QuantumSimulator().Get<Circuits.BoolArrayOp>();
+            IQArray<Boolean> bits = new QArray<Boolean>(new bool[] { false, true });
+            var args = op.__dataIn(bits);
+            var expected = new RuntimeMetadata()
+            {
+                Label = "BoolArrayOp",
+                FormattedNonQubitArgs = "[False, True]",
+                IsAdjoint = false,
+                IsControlled = false,
+                IsMeasurement = false,
+                IsComposite = false,
+                Children = null,
+                Controls = new List<Qubit>() { },
+                Targets = new List<Qubit>() { },
+            };
+
+            Assert.Equal(op.GetRuntimeMetadata(args), expected);
+        }
     }
 
     public class UDTTests

--- a/src/Simulation/Simulators.Tests/TypeExtensionsTest.cs
+++ b/src/Simulation/Simulators.Tests/TypeExtensionsTest.cs
@@ -94,6 +94,9 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 (new FreeQubit(1), "bar"),
             };
             Assert.Equal("[(\"foo\"), (\"bar\")]", qTupleArr.GetNonQubitArgumentsAsString());
+
+            var qArrayBool = new QArray<Boolean>(new[] { false, true });
+            Assert.Equal("[False, True]", qArrayBool.GetNonQubitArgumentsAsString());
         }
 
         [Fact]


### PR DESCRIPTION
This PR fixes the StackOverflow error encountered in [\#270](https://github.com/microsoft/iqsharp/issues/270). This is because arguments of type `bool[]` in Q# are represented as `IQArray<Boolean>` in the simulator which should get matched to an array type within `GetNonQubitArgsAsString` but instead matches the `IApplyData` type. When that happens, we encounter an infinite loop: `IQArray<Boolean>` -> `System.RuntimeType` -> `System.RuntimeType` -> ...

To fix this, we move the check for `IApplyData` to the bottom so that we match that case last (as it's the culprit for stack overflow errors). As further precaution, we also add a check to see if `IApplyData.Value` is the same as the original value, preventing possible infinite recursion.