### PR TITLE
Fixing namespace references using "global::"

### DIFF
--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -878,27 +878,27 @@ namespace N1
         |> testOne genU2
 
         [
-            template "Allocate"                               "Allocate"                        "Microsoft.Quantum.Intrinsic.Allocate"
-            template "MicrosoftQuantumIntrinsicH"             "IUnitary<Qubit>"                 "Microsoft.Quantum.Intrinsic.H"
+            template "Allocate"                               "Allocate"                        "global::Microsoft.Quantum.Intrinsic.Allocate"
+            template "MicrosoftQuantumIntrinsicH"             "IUnitary<Qubit>"                 "global::Microsoft.Quantum.Intrinsic.H"
             template "H"                                      "ICallable<Qubit, QVoid>"         "H"
-            template "Release"                                "Release"                         "Microsoft.Quantum.Intrinsic.Release"
-            template "MicrosoftQuantumOverridesemptyFunction" "ICallable<QVoid, QVoid>"         "Microsoft.Quantum.Overrides.emptyFunction"
+            template "Release"                                "Release"                         "global::Microsoft.Quantum.Intrinsic.Release"
+            template "MicrosoftQuantumOverridesemptyFunction" "ICallable<QVoid, QVoid>"         "global::Microsoft.Quantum.Overrides.emptyFunction"
             template "emptyFunction"                          "ICallable<QVoid, QVoid>"         "emptyFunction"
         ]
         |> testOne duplicatedDefinitionsCaller
 
         [
-            template "Allocate"                             "Allocate"                          "Microsoft.Quantum.Intrinsic.Allocate"
-            template "CNOT"                                 "IAdjointable<(Qubit, Qubit)>"      "Microsoft.Quantum.Intrinsic.CNOT"
-            template "MicrosoftQuantumTestingHold"          "ICallable"                         "Microsoft.Quantum.Testing.Hold<>"
-            template "Release"                              "Release"                           "Microsoft.Quantum.Intrinsic.Release"
+            template "Allocate"                             "Allocate"                          "global::Microsoft.Quantum.Intrinsic.Allocate"
+            template "CNOT"                                 "IAdjointable<(Qubit, Qubit)>"      "global::Microsoft.Quantum.Intrinsic.CNOT"
+            template "MicrosoftQuantumTestingHold"          "ICallable"                         "global::Microsoft.Quantum.Testing.Hold<>"
+            template "Release"                              "Release"                           "global::Microsoft.Quantum.Intrinsic.Release"
             template "ResultToString"                       "ICallable<Result,String>"          "ResultToString"
-            template "X"                                    "IUnitary<Qubit>"                   "Microsoft.Quantum.Intrinsic.X"
+            template "X"                                    "IUnitary<Qubit>"                   "global::Microsoft.Quantum.Intrinsic.X"
             template "genIter"                              "IUnitary"                          "genIter<>"
             template "genMapper"                            "ICallable"                         "genMapper<,>"
             template "genU1"                                "IUnitary"                          "genU1<>"
-            template "MicrosoftQuantumTestingnoOpGeneric"   "IUnitary"                          "Microsoft.Quantum.Testing.noOpGeneric<>"
-            template "MicrosoftQuantumTestingnoOpResult"    "IUnitary<Result>"                  "Microsoft.Quantum.Testing.noOpResult"
+            template "MicrosoftQuantumTestingnoOpGeneric"   "IUnitary"                          "global::Microsoft.Quantum.Testing.noOpGeneric<>"
+            template "MicrosoftQuantumTestingnoOpResult"    "IUnitary<Result>"                  "global::Microsoft.Quantum.Testing.noOpResult"
         ]
         |> testOne usesGenerics
 
@@ -908,7 +908,7 @@ namespace N1
         |> testOne callsGenericWithMultipleTypeParams
 
         [
-            template "Z"                                    "IUnitary<Qubit>"                   "Microsoft.Quantum.Intrinsic.Z"
+            template "Z"                                    "IUnitary<Qubit>"                   "global::Microsoft.Quantum.Intrinsic.Z"
             "this.self = this;"
         ]
         |> testOne selfInvokingOperation
@@ -930,17 +930,17 @@ namespace N1
 
         let template = sprintf "typeof(%s)"
         [
-            template "Microsoft.Quantum.Intrinsic.Allocate"
-            template "Microsoft.Quantum.Intrinsic.CNOT"
-            template "Microsoft.Quantum.Testing.Hold<>"
-            template "Microsoft.Quantum.Intrinsic.Release"
+            template "global::Microsoft.Quantum.Intrinsic.Allocate"
+            template "global::Microsoft.Quantum.Intrinsic.CNOT"
+            template "global::Microsoft.Quantum.Testing.Hold<>"
+            template "global::Microsoft.Quantum.Intrinsic.Release"
             template "ResultToString"
-            template "Microsoft.Quantum.Intrinsic.X"
+            template "global::Microsoft.Quantum.Intrinsic.X"
             template "genIter<>"
             template "genMapper<,>"
             template "genU1<>"
-            template "Microsoft.Quantum.Testing.noOpGeneric<>"
-            template "Microsoft.Quantum.Testing.noOpResult"
+            template "global::Microsoft.Quantum.Testing.noOpGeneric<>"
+            template "global::Microsoft.Quantum.Testing.noOpResult"
         ]
         |> List.sort
         |> testOne usesGenerics
@@ -961,7 +961,7 @@ namespace N1
         |> testOne genRecursion
 
         [
-            template "Microsoft.Quantum.Intrinsic.Z"
+            template "global::Microsoft.Quantum.Intrinsic.Z"
             template "selfInvokingOperation"
         ]
         |> testOne selfInvokingOperation
@@ -2465,7 +2465,7 @@ namespace N1
 
         public override void Init()
         {
-            this.X = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
+            this.X = this.Factory.Get<IUnitary<Qubit>>(typeof(global::Microsoft.Quantum.Intrinsic.X));
         }
 
         public override IApplyData __dataIn(Qubit data) => data;
@@ -3563,9 +3563,9 @@ namespace Microsoft.Quantum.Tests.LineNumbers
         ;
         public override void Init()
         {
-            this.Allocate = this.Factory.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
-            this.Release = this.Factory.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
-            this.X = this.Factory.Get<IUnitary<Qubit>>(typeof(Microsoft.Quantum.Intrinsic.X));
+            this.Allocate = this.Factory.Get<Allocate>(typeof(global::Microsoft.Quantum.Intrinsic.Allocate));
+            this.Release = this.Factory.Get<Release>(typeof(global::Microsoft.Quantum.Intrinsic.Release));
+            this.X = this.Factory.Get<IUnitary<Qubit>>(typeof(global::Microsoft.Quantum.Intrinsic.X));
         }
 
         public override IApplyData __dataIn(Int64 data) => new QTuple<Int64>(data);

--- a/src/Simulation/CsharpGeneration/EntryPoint.fs
+++ b/src/Simulation/CsharpGeneration/EntryPoint.fs
@@ -112,7 +112,7 @@ let private createArgument context entryPoint =
 
 /// A tuple of the callable's name, argument type name, and return type name.
 let private callableTypeNames context (callable : QsCallable) =
-    let callableName = sprintf "%s.%s" callable.FullName.Namespace.Value callable.FullName.Name.Value
+    let callableName = sprintf "global::%s.%s" callable.FullName.Namespace.Value callable.FullName.Name.Value
     let argTypeName = SimulationCode.roslynTypeName context callable.Signature.ArgumentType
     let returnTypeName = SimulationCode.roslynTypeName context callable.Signature.ReturnType
     callableName, argTypeName, returnTypeName

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -856,7 +856,7 @@ module SimulationCode =
     let getTypeOfOp context (n: QsQualifiedName) =
         let name =
             let sameNamespace = match context.current with | None -> false | Some o -> o.Namespace = n.Namespace
-            let opName = if sameNamespace then n.Name.Value else n.Namespace.Value + "." + n.Name.Value
+            let opName = if sameNamespace then n.Name.Value else "global::" + n.Namespace.Value + "." + n.Name.Value
             if isGeneric context n then
                 let signature = context.allCallables.[n].Signature
                 let count = signature.TypeParameters.Length

--- a/src/Simulation/Simulators.Tests/Circuits/Namespaces.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/Namespaces.qs
@@ -1,0 +1,22 @@
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
+
+// Will cause compilation failure if callable type references in generated C# aren't
+// prepended with "global::".
+namespace Issue46 {
+
+    operation ReturnZero () : Result {
+        
+        return Zero;
+    }
+
+}
+
+namespace Microsoft.Quantum.Tests.Namespaces.Issue46 {
+
+    operation TestOp () : Result {
+        
+        return Issue46.ReturnZero();
+    }
+
+}


### PR DESCRIPTION

Fixes Code generation failure when mapping Q# namespaces to C# namespaces  #46