### PR TITLE
Skip Csharp Generation of references with test names if not using test name

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2715,7 +2715,7 @@ SOFTWARE.
 
 -------------------------------------------------------------------
 
-Microsoft.Quantum.Compiler 0.12.20072031 - MIT
+Microsoft.Quantum.Compiler 0.12.20082209-beta - MIT
 
 
 (c) 2008 VeriSign, Inc.

--- a/src/Simulation/CsharpGeneration/Context.fs
+++ b/src/Simulation/CsharpGeneration/Context.fs
@@ -119,6 +119,11 @@ type CodegenContext = {
         | true, name -> name
         | false, _ -> null
 
+    member public this.ExposeReferencesViaTestNames = 
+        match this.assemblyConstants.TryGetValue AssemblyConstants.ExposeReferencesViaTestNames with 
+        | true, propVal -> propVal = "true"
+        | false, _ -> false
+
     member internal this.GenerateCodeForSource (fileName : NonNullable<string>) = 
         let targetsQuantumProcessor = 
             match this.assemblyConstants.TryGetValue AssemblyConstants.ProcessorArchitecture with

--- a/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
+++ b/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20072031" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20082209-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1624,8 +1624,8 @@ module SimulationCode =
             if globalContext.ExposeReferencesViaTestNames then
                 let asOption = function | Value _ -> Some nsElement | _ -> None
                 match nsElement with
-                | QsCallable c as e -> SymbolResolution.TryGetTestName c.Attributes
-                | QsCustomType t as e -> SymbolResolution.TryGetTestName t.Attributes
+                | QsCallable c -> SymbolResolution.TryGetTestName c.Attributes
+                | QsCustomType t -> SymbolResolution.TryGetTestName t.Attributes
                 |> asOption
             else None
         let context = {globalContext with fileName = Some dllName.Value}

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1619,13 +1619,15 @@ module SimulationCode =
     /// Builds the SyntaxTree for callables and types loaded via test names,
     /// formats it and returns it as a string.
     /// Returns null if no elements have been loaded via test name.
-    let loadedViaTestNames (dllName : NonNullable<string>) globalContext =
+    let loadedViaTestNames (dllName : NonNullable<string>) (globalContext : CodegenContext) =
         let isLoadedViaTestName nsElement =
-            let asOption = function | Value _ -> Some nsElement | _ -> None
-            match nsElement with
-            | QsCallable c as e -> SymbolResolution.TryGetTestName c.Attributes
-            | QsCustomType t as e -> SymbolResolution.TryGetTestName t.Attributes
-            |> asOption
+            if globalContext.ExposeReferencesViaTestNames then
+                let asOption = function | Value _ -> Some nsElement | _ -> None
+                match nsElement with
+                | QsCallable c as e -> SymbolResolution.TryGetTestName c.Attributes
+                | QsCustomType t as e -> SymbolResolution.TryGetTestName t.Attributes
+                |> asOption
+            else None
         let context = {globalContext with fileName = Some dllName.Value}
         let localElements = findLocalElements isLoadedViaTestName dllName context.allQsElements
 

--- a/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\Simulators.Dev.props" />

--- a/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
+++ b/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CsharpGeneration>false</CsharpGeneration>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />


### PR DESCRIPTION
This takes advantage of the functionality introduced in https://github.com/microsoft/qsharp-compiler/pull/581 that allows rewrite steps to know if `ExposeReferencesViaTestNames` was specified for the current compilation. Then CsharpGeneration rewrite step can only re-generate C# for references that both have a test name defined AND are being loaded by that test name. This fixes a bug where callables with a test name attribute would end up colliding with themselves if they were referenced without test name.

This was tested by temporarily adding a test name attribute to `Microsoft.Quantum.Intrinsic.Measure`, which would cause a compilation failure without these changes and compiles successfully with these changes.