### PR TITLE
Fixing csproj QDK versions

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2715,7 +2715,7 @@ SOFTWARE.
 
 -------------------------------------------------------------------
 
-Microsoft.Quantum.Compiler 0.12.20082209-beta - MIT
+Microsoft.Quantum.Compiler 0.12.20082705-beta - MIT
 
 
 (c) 2008 VeriSign, Inc.

--- a/src/Simulation/QsharpFoundation/Microsoft.Quantum.QSharp.Foundation.csproj
+++ b/src/Simulation/QsharpFoundation/Microsoft.Quantum.QSharp.Foundation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators.Type2.Tests/Tests.Microsoft.Quantum.Simulators.Type2.csproj
+++ b/src/Simulation/Simulators.Type2.Tests/Tests.Microsoft.Quantum.Simulators.Type2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.csproj
+++ b/src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082209-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />


### PR DESCRIPTION
Compiling individual projects (instead of solution) was failing because those newly introduced projects were still targeting an older QDK version.