### PR TITLE
Include inner exception in message of WorkspaceClientException

### DIFF
--- a/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Azure.Quantum.Exceptions
                   $"ResourceGroupName: {resourceGroupName}{Environment.NewLine}" +
                   $"WorkspaceName: {workspaceName}{Environment.NewLine}" +
                   $"BaseUri: {baseUri}{Environment.NewLine}" +
-                  $"JobId: {jobId}",
+                  $"JobId: {jobId}{Environment.NewLine}" +
+                  (inner != null ? $"Inner Exception: {inner}" : string.Empty),
                   inner)
         {
         }


### PR DESCRIPTION
Extending the message in WorkspaceClientException to include the inner exception as well if present.

This exception message is provided to the user through the console during execution (e.g. when using the Azure CLI) and should include this information to be more actionable.
