### PR TITLE
Improving the logging of WorkspaceClientException to include more actionable information

### DIFF
--- a/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
@@ -89,8 +89,7 @@ namespace Microsoft.Azure.Quantum.Exceptions
                 formattedException += $"Server Error: {ex.Message}{Environment.NewLine}";
 
                 // Handle specific types of exceptions for additional data
-                RestErrorException restErrorException = ex as RestErrorException;
-                if (restErrorException != null)
+                if (ex is RestErrorException restErrorException)
                 {
                     formattedException += $"Error code: {restErrorException?.Body?.Code}{Environment.NewLine}" +
                         $"Server message: {restErrorException?.Body?.Message}{Environment.NewLine}";

--- a/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Rest;
 using Microsoft.Azure.Quantum.Client.Models;
 using System;
 

--- a/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
@@ -91,8 +91,14 @@ namespace Microsoft.Azure.Quantum.Exceptions
                 // Handle specific types of exceptions for additional data
                 if (ex is RestErrorException restErrorException)
                 {
-                    formattedException += $"Error code: {restErrorException?.Body?.Code}{Environment.NewLine}" +
+                    formattedException += $"Error Code: {restErrorException?.Body?.Code}{Environment.NewLine}" +
                         $"Server message: {restErrorException?.Body?.Message}{Environment.NewLine}";
+
+                    var headers = restErrorException?.Response?.Headers;
+                    if (headers != null && headers.ContainsKey("x-ms-request-id"))
+                    {
+                        formattedException += $"Server Request Id: {headers["x-ms-request-id"]}{Environment.NewLine}";
+                    }
                 }
             }
 

--- a/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
+++ b/src/Azure/Azure.Quantum.Client/Exceptions/WorkspaceClientException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Rest;
+using Microsoft.Azure.Quantum.Client.Models;
 using System;
 
 namespace Microsoft.Azure.Quantum.Exceptions
@@ -67,9 +69,36 @@ namespace Microsoft.Azure.Quantum.Exceptions
                   $"WorkspaceName: {workspaceName}{Environment.NewLine}" +
                   $"BaseUri: {baseUri}{Environment.NewLine}" +
                   $"JobId: {jobId}{Environment.NewLine}" +
-                  (inner != null ? $"Inner Exception: {inner}" : string.Empty),
+                  FormatInnerException(inner),
                   inner)
         {
+        }
+
+        /// <summary>
+        /// Formats the contents of the inner exception in <see cref="WorkspaceClientException"/> so it can be included in the
+        /// exception message and presented in an informative way.
+        /// </summary>
+        /// <param name="ex">Inner exception that we want to include in the outer exception message.</param>
+        /// <return>
+        /// A string representing the contents of the inner exception.
+        /// </return>
+        private static string FormatInnerException(Exception ex)
+        {
+            string formattedException = string.Empty;
+            if (ex != null)
+            {
+                formattedException += $"Server Error: {ex.Message}{Environment.NewLine}";
+
+                // Handle specific types of exceptions for additional data
+                RestErrorException restErrorException = ex as RestErrorException;
+                if (restErrorException != null)
+                {
+                    formattedException += $"Error code: {restErrorException?.Body?.Code}{Environment.NewLine}" +
+                        $"Server message: {restErrorException?.Body?.Message}{Environment.NewLine}";
+                }
+            }
+
+            return formattedException;
         }
     }
 }


### PR DESCRIPTION
Improving the logging of WorkspaceClientException to include more informative data in its message from its inner exception.

This is a follow up to #378 . 
 - Instead of providing the full stack of the exception in the output, we extract more relevant fields from the source RestErrorException and provide them to the user.