### PR TITLE
Fix bug in logic for releasing qubits after joint measurement

### DIFF
--- a/src/Simulation/Simulators.Tests/Circuits/CoreOperations.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/CoreOperations.qs
@@ -342,6 +342,7 @@ namespace Microsoft.Quantum.Tests.CoreOperations {
 
 // Using a different namespace, so tests can be auto-discovered.
 namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
+    open Microsoft.Quantum.Simulation.Simulators.Tests.Circuits.Generics;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Diagnostics;
@@ -556,6 +557,14 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
             X(q);
             let r = M(q);
             // Should not raise an exception
+        }
+    }
+
+    operation ReleaseMeasureMultipleQubitCheck() : Unit {
+        using (qs = Qubit[2]) {
+            ApplyToEach(H, qs);
+            let r = Measure([PauliZ, PauliZ], qs);
+            // Should raise an exception
         }
     }
 

--- a/src/Simulation/Simulators.Tests/QuantumSimulatorTests/QubitReleaseTest.cs
+++ b/src/Simulation/Simulators.Tests/QuantumSimulatorTests/QubitReleaseTest.cs
@@ -33,6 +33,15 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             await ReleaseMeasuredQubitCheck.Run(sim);
         }
 
+        //test to check that qubits cannot be released after multiple qubit measure
+        [Fact]
+        public async Task MeasuredMultipleQubitsReleaseTest()
+        {
+            var sim = new QuantumSimulator();
+
+            await Assert.ThrowsAsync<ReleasedQubitsAreNotInZeroState>(() => ReleaseMeasureMultipleQubitCheck.Run(sim));
+        }
+
         //test to check that qubit that is released and reallocated is in state |0>
         [Fact]
         public async Task ReallocateQubitInGroundStateTest()

--- a/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/Program.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/Program.qs
@@ -10,6 +10,7 @@
         let arr = Default<Qubit[]>();
         using (qs = Qubit[2])  {
             Ignore(Measure([PauliX, PauliX], qs));
+            ResetAll(qs);
             return "TargetedExe";
         }
     }

--- a/src/Simulation/Simulators/QuantumSimulator/Measure.cs
+++ b/src/Simulation/Simulators/QuantumSimulator/Measure.cs
@@ -31,10 +31,11 @@ namespace Microsoft.Quantum.Simulation.Simulators
                 {
                     throw new InvalidOperationException($"Both input arrays for {this.GetType().Name} (paulis,qubits), must be of same size");
                 }
-                foreach (Qubit q in qubits)
+                if (qubits.Length == 1)
                 {
-                    //setting qubit as measured to allow for release
-                    q.IsMeasured = true;
+                    // When we are operating on a single qubit we will collapse the state, so mark
+                    // that qubit as measured.
+                    qubits[0].IsMeasured = true;
                 }
                 return Measure(Simulator.Id, (uint)paulis.Length, paulis.ToArray(), qubits.GetIds()).ToResult();
             };


### PR DESCRIPTION

To allow release of qubits that have been collapsed by measurement, we mark them with `IsMeasured` equal to true (see #206). However, joint measurement does not collapse the states of the input qubits and might actually create additional entanglement, so those qubits should not be marked as valid for release.

This change fixes the logic by only marking the input to `Measure` when it is a single qubit, and adds a test that validates the exception that should be thrown when trying to release qubits after joint measurement.