### PR TITLE
Improve Error Messaging in Q# Unit Tests

### DIFF
--- a/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
+++ b/src/Simulation/CsharpGeneration.Tests/SimulationCodeTests.fs
@@ -3685,10 +3685,21 @@ namespace Microsoft.Quantum.Tests.UnitTests
                     baseSim.OnLog += this.Output.WriteLine;
                 }
 
-                sim.Run<UnitTest1, QVoid, QVoid>(QVoid.Instance).Wait();
-                if (sim is IDisposable disposeSim)
+                try
                 {
-                    disposeSim.Dispose();
+                    sim.Execute<UnitTest1, QVoid, QVoid>(QVoid.Instance);
+                }
+                catch (Exception e)
+                {
+#line 22 "%%"
+                    Xunit.Assert.True(false, "Q# Test failed. For details see the Standard output below.");
+                }
+                finally
+                {
+                    if (sim is IDisposable disposeSim)
+                    {
+                        disposeSim.Dispose();
+                    }
                 }
             }
         }
@@ -3717,10 +3728,21 @@ namespace Microsoft.Quantum.Tests.UnitTests
                     baseSim.OnLog += this.Output.WriteLine;
                 }
 
-                sim.Run<UnitTest1, QVoid, QVoid>(QVoid.Instance).Wait();
-                if (sim is IDisposable disposeSim)
+                try
                 {
-                    disposeSim.Dispose();
+                    sim.Execute<UnitTest1, QVoid, QVoid>(QVoid.Instance);
+                }
+                catch (Exception e)
+                {
+#line 22 "%%"
+                    Xunit.Assert.True(false, "Q# Test failed. For details see the Standard output below.");
+                }
+                finally
+                {
+                    if (sim is IDisposable disposeSim)
+                    {
+                        disposeSim.Dispose();
+                    }
                 }
             }
         }
@@ -3778,10 +3800,21 @@ namespace Microsoft.Quantum.Tests.UnitTests
                     baseSim.OnLog += this.Output.WriteLine;
                 }
 
-                sim.Run<UnitTest2, QVoid, QVoid>(QVoid.Instance).Wait();
-                if (sim is IDisposable disposeSim)
+                try
                 {
-                    disposeSim.Dispose();
+                    sim.Execute<UnitTest2, QVoid, QVoid>(QVoid.Instance);
+                }
+                catch (Exception e)
+                {
+#line 26 "%%"
+                    Xunit.Assert.True(false, "Q# Test failed. For details see the Standard output below.");
+                }
+                finally
+                {
+                    if (sim is IDisposable disposeSim)
+                    {
+                        disposeSim.Dispose();
+                    }
                 }
             }
         }

--- a/src/Simulation/CsharpGeneration/SimulationCode.fs
+++ b/src/Simulation/CsharpGeneration/SimulationCode.fs
@@ -1240,7 +1240,7 @@ module SimulationCode =
         let disposeSim = ``ident`` "disposeSim"
         let ``this.Output`` = ``ident`` "this" <|.|> ``ident`` "Output"
         let ``sim.OnLog`` = baseSim <|.|> ``ident`` "OnLog"
-        let Run = generic "Run" ``<<`` [opName; "QVoid"; "QVoid"] ``>>``
+        let Execute = generic "Execute" ``<<`` [opName; "QVoid"; "QVoid"] ``>>``
 
         let simCond = sim |> ``is assign`` "Microsoft.Quantum.Simulation.Common.SimulatorBase" baseSim .&&. ``this.Output`` .!=. ``null``
 
@@ -1248,10 +1248,28 @@ module SimulationCode =
         let assignLogEvent =
             ``if`` ``(`` simCond ``)``
                 [ ``sim.OnLog`` <+=> (``this.Output`` <|.|> ``ident`` "WriteLine") ] None
-        let ``sim.Run.Wait`` = sim <.> (Run, [ ``ident`` "QVoid" <|.|> ``ident`` "Instance"]) <.> ((``ident`` "Wait"), []) |> statement
+        let ``sim.Execute`` = sim <.> (Execute, [ ``ident`` "QVoid" <|.|> ``ident`` "Instance"]) |> statement
         let disposeOfRun =
             ``if`` ``(`` (sim |> ``is assign`` "IDisposable" disposeSim) ``)``
                 [ disposeSim <.> ((``ident`` "Dispose"), []) |> statement ] None
+
+        let errMsg = ``literal`` "Q# Test failed. For details see the Standard output below."
+
+        let tryRunCatch =
+            ``try``
+                [
+                    ``sim.Execute``
+                ]
+                [
+                    ``catch`` (Some ("Exception", "e"))
+                        [
+                            (``ident`` "Xunit.Assert") <.> ((``ident`` "True"), [``false`` :> ExpressionSyntax; errMsg]) |> (statement >> ``#line`` (opStart + 1) opSourceFile)
+                        ]
+                ]
+                (Some (``finally`` 
+                    [
+                        ``disposeOfRun``
+                    ]))
 
         ``attributes``
             [
@@ -1261,7 +1279,7 @@ module SimulationCode =
             ]
             (``method`` "void" opName ``<<`` [] ``>>`` ``(`` [] ``)`` [``public``]
                 ``{``
-                    [getSimulator; assignLogEvent; ``sim.Run.Wait``; disposeOfRun]
+                    [getSimulator; assignLogEvent; tryRunCatch]
                 ``}``
                 |> ``with trivia`` (``#lineNr`` (opStart + 1) opSourceFile) // we need 1-based line numbers here, and opStart is zero-based
             )


### PR DESCRIPTION
This creates clearer error messages when an Assert fails in Q# unit tests. This partially addresses #141 .