### PR TITLE
Native Simulator refactors (mostly in wavefunction.hpp)

### DIFF
--- a/src/Simulation/Native/.clang-format
+++ b/src/Simulation/Native/.clang-format
@@ -1,0 +1,37 @@
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+---
+Language: Cpp
+BasedOnStyle: Microsoft
+
+# page width
+ColumnLimit: 120
+ReflowComments: true
+
+# tabs and indents
+UseTab: Never
+IndentWidth: 4
+TabWidth: 4
+NamespaceIndentation: None
+
+# line and statements layout
+BreakBeforeBraces: Allman
+BinPackParameters: false
+AlignAfterOpenBracket: AlwaysBreak
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortFunctionsOnASingleLine: Empty
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+AlwaysBreakTemplateDeclarations: Yes
+
+# misc
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+SpaceBeforeInheritanceColon : true
+SpaceBeforeParens: ControlStatements
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/src/Simulation/Native/src/simulator/gates.hpp
+++ b/src/Simulation/Native/src/simulator/gates.hpp
@@ -16,453 +16,476 @@
 
 namespace Microsoft
 {
-    namespace Quantum
+namespace Quantum
+{
+namespace SIMULATOR
+{
+namespace Gates
+{
+
+/// a type for runtime basis specification
+enum Basis
+{
+    PauliI = 0,
+    PauliX = 1,
+    PauliY = 3,
+    PauliZ = 2
+};
+
+/// a general one qubit gate, storing the qubit number
+class OneQubitGate
+{
+  public:
+    OneQubitGate(logical_qubit_id q)
+        : qubit_(q)
     {
-        namespace SIMULATOR
-        {
-            namespace Gates
-            {
-
-                /// a type for runtime basis specification
-                enum Basis
-                {
-                    PauliI = 0,
-                    PauliX = 1,
-                    PauliY = 3,
-                    PauliZ = 2
-                };
-
-                /// a general one qubit gate, storing the qubit number
-                class OneQubitGate
-                {
-                public:
-                    OneQubitGate(unsigned q) : qubit_(q)
-                    {
-                    }
-                    unsigned qubit() const
-                    {
-                        return qubit_;
-                    }
-
-                    virtual TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        throw "Calling overriden function";
-                    }
-
-                private:
-                    unsigned qubit_;
-                };
-
-                /// a general one qubit roitation gate, storing the qubit number and angle
-                class RotationGate : public OneQubitGate
-                {
-                public:
-                    RotationGate(double phi, unsigned q) : OneQubitGate(q), angle_(phi)
-                    {
-                    }
-                    double angle() const
-                    {
-                        return angle_;
-                    }
-
-                private:
-                    double angle_;
-                };
-
-                /// The Pauli X gate
-                class X : public OneQubitGate
-                {
-                public:
-                    X(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "X";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        RealType mat[2][2] = { {0., 1.}, {1., 0.} };
-                        return TinyMatrix<RealType, 2>(mat);
-                    }
-                };
-
-                /// The Pauli Y gate
-                class Y : public OneQubitGate
-                {
-                public:
-                    Y(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Y";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        val_t mat[2][2] = { {val_t(0.), val_t(0.)}, {val_t(0.), val_t(0.)} };
-                        mat[0][1] = val_t(0., -1.);
-                        mat[1][0] = val_t(0., 1.);
-                        return TinyMatrix<val_t, 2>(mat);
-                    }
-                };
-
-                /// The Pauli Z gate
-                class Z : public OneQubitGate
-                {
-                public:
-                    Z(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Z";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        RealType diag[2] = { 1., -1. };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<RealType, 2>(diag));
-                    }
-                };
-
-                /// The Hadamard gate
-                class H : public OneQubitGate
-                {
-                public:
-                    H(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "H";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        RealType r = std::sqrt(0.5);
-                        RealType mat[2][2] = { {r, r}, {r, -r} };
-                        return TinyMatrix<ComplexType, 2>(TinyMatrix<RealType, 2, 2>(mat));
-                    }
-                };
-
-                /// The Y-version of a Hadamard gate
-                class HY : public OneQubitGate
-                {
-                public:
-                    HY(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "HY";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        ComplexType r(std::sqrt(0.5), 0.);
-                        ComplexType i(0., std::sqrt(0.5));
-                        ComplexType mat[2][2] = { {r, r}, {i, -i} };
-                        return TinyMatrix<ComplexType, 2>(mat);
-                    }
-                };
-
-                /// The adjoint Y-version of a Hadamard gate
-                class AdjHY : public OneQubitGate
-                {
-                public:
-                    AdjHY(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "AdjHY";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        ComplexType r(std::sqrt(0.5), 0.);
-                        ComplexType i(0., std::sqrt(0.5));
-                        ComplexType mat[2][2] = { {r, -i}, {r, i} };
-                        return TinyMatrix<ComplexType, 2>(mat);
-                    }
-                };
-
-                /// The S (phase) gate
-                class S : public OneQubitGate
-                {
-                public:
-                    S(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "S";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        val_t diag[2] = { val_t(1.), val_t(0., 1.) };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
-                    }
-                };
-
-                /// The adjoint of the S (phase) gate
-                class AdjS : public OneQubitGate
-                {
-                public:
-                    AdjS(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "AdjS";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        val_t diag[2] = { val_t(1.), val_t(0., -1.) };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
-                    }
-                };
-
-                /// The T (pi/8) gate
-                class T : public OneQubitGate
-                {
-                public:
-                    T(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "T";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        RealType r = std::sqrt(0.5);
-                        val_t diag[2] = { val_t(1.), val_t(r, r) };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
-                    }
-                };
-
-                /// The T (pi/8) gate
-                class AdjT : public OneQubitGate
-                {
-                public:
-                    AdjT(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "AdjT";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        RealType r = std::sqrt(0.5);
-                        val_t diag[2] = { val_t(1.), val_t(r, -r) };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
-                    }
-                };
-
-                /// The G gate
-                class G : public RotationGate
-                {
-                public:
-                    G(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "G";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        DiagMatrix<ComplexType, 2> d;
-                        ComplexType arg(0., 0.5 * angle());
-                        d(0, 0) = d(1, 1) = std::exp(-arg);
-                        return TinyMatrix<ComplexType, 2>(d);
-                    }
-                };
-
-                /// The Rx gate
-                class Rx : public RotationGate
-                {
-                public:
-                    Rx(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Rx";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        val_t s(0., -std::sin(0.5 * angle()));
-                        val_t c = std::cos(0.5 * angle());
-                        val_t mat[2][2] = { {c, s}, {s, c} };
-                        return TinyMatrix<val_t, 2>(mat);
-                    }
-                };
-
-                /// The Ry gate
-                class Ry : public RotationGate
-                {
-                public:
-                    Ry(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Ry";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        RealType s = std::sin(0.5 * angle());
-                        RealType c = std::cos(0.5 * angle());
-                        RealType mat[2][2] = { {c, -s}, {s, c} };
-                        ;
-                        return TinyMatrix<ComplexType, 2>(TinyMatrix<RealType, 2>(mat));
-                    }
-                };
-
-                /// The Rz gate
-                class Rz : public RotationGate
-                {
-                public:
-                    Rz(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Rz";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        DiagMatrix<ComplexType, 2> d;
-                        ComplexType arg(0., 0.5 * angle());
-                        d(0, 0) = std::exp(-arg);
-                        d(1, 1) = std::exp(arg);
-                        return TinyMatrix<ComplexType, 2>(d);
-                    }
-                };
-
-                /// The R1 gate
-                class R1 : public RotationGate
-                {
-                public:
-                    R1(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "R1";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        DiagMatrix<ComplexType, 2> d;
-                        ComplexType arg(0., angle());
-                        d(0, 0) = 1.;
-                        d(1, 1) = std::exp(-arg);
-                        return TinyMatrix<ComplexType, 2>(d);
-                    }
-                };
-
-                /// The R1 gate
-                class R1Frac : public R1
-                {
-                public:
-                    R1Frac(int k, int n, unsigned q) : R1(M_PI* static_cast<RealType>(k) / static_cast<RealType>(1ll << n), q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "R1Frac";
-                    }
-                };
-
-                /// The R gate for rotation around an arbitrary basis
-                class R : public RotationGate
-                {
-                public:
-                    R(Basis b, RealType phi, unsigned q) : RotationGate(phi, q), b_(b)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "R";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        switch (b_)
-                        {
-                        case PauliI:
-                            return G(angle(), qubit()).matrix();
-                            break;
-                        case PauliX:
-                            return Rx(angle(), qubit()).matrix();
-                            break;
-                        case PauliY:
-                            return Ry(angle(), qubit()).matrix();
-                            break;
-                        case PauliZ:
-                            return Rz(angle(), qubit()).matrix();
-                            break;
-                        default:
-                            assert(false);
-                        }
-                        // dummy return
-                        return TinyMatrix<ComplexType, 2>();
-                    }
-
-                private:
-                    Basis b_;
-                };
-
-                class RFrac : public R
-                {
-                public:
-                    RFrac(Basis b, int k, int n, unsigned q) : R(b, -2. * M_PI * static_cast<RealType>(k) / static_cast<RealType>(1ll << n), q)
-                    {
-                    }
-                    std::string name() const
-                    {
-                        return "RFrac";
-                    }
-                };
-            }
-        }
     }
-}
+    logical_qubit_id qubit() const
+    {
+        return qubit_;
+    }
+
+    virtual TinyMatrix<ComplexType, 2> matrix() const
+    {
+        throw "Calling overriden function";
+    }
+
+  private:
+    logical_qubit_id qubit_;
+};
+
+/// a general one qubit roitation gate, storing the qubit number and angle
+class RotationGate : public OneQubitGate
+{
+  public:
+    RotationGate(double phi, logical_qubit_id q)
+        : OneQubitGate(q)
+        , angle_(phi)
+    {
+    }
+    double angle() const
+    {
+        return angle_;
+    }
+
+  private:
+    double angle_;
+};
+
+/// The Pauli X gate
+class X : public OneQubitGate
+{
+  public:
+    X(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "X";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        RealType mat[2][2] = {{0., 1.}, {1., 0.}};
+        return TinyMatrix<RealType, 2>(mat);
+    }
+};
+
+/// The Pauli Y gate
+class Y : public OneQubitGate
+{
+  public:
+    Y(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Y";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        val_t mat[2][2] = {{val_t(0.), val_t(0.)}, {val_t(0.), val_t(0.)}};
+        mat[0][1] = val_t(0., -1.);
+        mat[1][0] = val_t(0., 1.);
+        return TinyMatrix<val_t, 2>(mat);
+    }
+};
+
+/// The Pauli Z gate
+class Z : public OneQubitGate
+{
+  public:
+    Z(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Z";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        RealType diag[2] = {1., -1.};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<RealType, 2>(diag));
+    }
+};
+
+/// The Hadamard gate
+class H : public OneQubitGate
+{
+  public:
+    H(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "H";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        RealType r = std::sqrt(0.5);
+        RealType mat[2][2] = {{r, r}, {r, -r}};
+        return TinyMatrix<ComplexType, 2>(TinyMatrix<RealType, 2, 2>(mat));
+    }
+};
+
+/// The Y-version of a Hadamard gate
+class HY : public OneQubitGate
+{
+  public:
+    HY(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "HY";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        ComplexType r(std::sqrt(0.5), 0.);
+        ComplexType i(0., std::sqrt(0.5));
+        ComplexType mat[2][2] = {{r, r}, {i, -i}};
+        return TinyMatrix<ComplexType, 2>(mat);
+    }
+};
+
+/// The adjoint Y-version of a Hadamard gate
+class AdjHY : public OneQubitGate
+{
+  public:
+    AdjHY(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "AdjHY";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        ComplexType r(std::sqrt(0.5), 0.);
+        ComplexType i(0., std::sqrt(0.5));
+        ComplexType mat[2][2] = {{r, -i}, {r, i}};
+        return TinyMatrix<ComplexType, 2>(mat);
+    }
+};
+
+/// The S (phase) gate
+class S : public OneQubitGate
+{
+  public:
+    S(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "S";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        val_t diag[2] = {val_t(1.), val_t(0., 1.)};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
+    }
+};
+
+/// The adjoint of the S (phase) gate
+class AdjS : public OneQubitGate
+{
+  public:
+    AdjS(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "AdjS";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        val_t diag[2] = {val_t(1.), val_t(0., -1.)};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
+    }
+};
+
+/// The T (pi/8) gate
+class T : public OneQubitGate
+{
+  public:
+    T(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "T";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        RealType r = std::sqrt(0.5);
+        val_t diag[2] = {val_t(1.), val_t(r, r)};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
+    }
+};
+
+/// The T (pi/8) gate
+class AdjT : public OneQubitGate
+{
+  public:
+    AdjT(logical_qubit_id q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "AdjT";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        RealType r = std::sqrt(0.5);
+        val_t diag[2] = {val_t(1.), val_t(r, -r)};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
+    }
+};
+
+/// The G gate
+class G : public RotationGate
+{
+  public:
+    G(RealType phi, logical_qubit_id q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "G";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        DiagMatrix<ComplexType, 2> d;
+        ComplexType arg(0., 0.5 * angle());
+        d(0, 0) = d(1, 1) = std::exp(-arg);
+        return TinyMatrix<ComplexType, 2>(d);
+    }
+};
+
+/// The Rx gate
+class Rx : public RotationGate
+{
+  public:
+    Rx(RealType phi, logical_qubit_id q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Rx";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        val_t s(0., -std::sin(0.5 * angle()));
+        val_t c = std::cos(0.5 * angle());
+        val_t mat[2][2] = {{c, s}, {s, c}};
+        return TinyMatrix<val_t, 2>(mat);
+    }
+};
+
+/// The Ry gate
+class Ry : public RotationGate
+{
+  public:
+    Ry(RealType phi, logical_qubit_id q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Ry";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        RealType s = std::sin(0.5 * angle());
+        RealType c = std::cos(0.5 * angle());
+        RealType mat[2][2] = {{c, -s}, {s, c}};
+        ;
+        return TinyMatrix<ComplexType, 2>(TinyMatrix<RealType, 2>(mat));
+    }
+};
+
+/// The Rz gate
+class Rz : public RotationGate
+{
+  public:
+    Rz(RealType phi, logical_qubit_id q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Rz";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        DiagMatrix<ComplexType, 2> d;
+        ComplexType arg(0., 0.5 * angle());
+        d(0, 0) = std::exp(-arg);
+        d(1, 1) = std::exp(arg);
+        return TinyMatrix<ComplexType, 2>(d);
+    }
+};
+
+/// The R1 gate
+class R1 : public RotationGate
+{
+  public:
+    R1(RealType phi, logical_qubit_id q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "R1";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        DiagMatrix<ComplexType, 2> d;
+        ComplexType arg(0., angle());
+        d(0, 0) = 1.;
+        d(1, 1) = std::exp(-arg);
+        return TinyMatrix<ComplexType, 2>(d);
+    }
+};
+
+/// The R1 gate
+class R1Frac : public R1
+{
+  public:
+    R1Frac(int k, int n, logical_qubit_id q)
+        : R1(M_PI * static_cast<RealType>(k) / static_cast<RealType>(1ll << n), q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "R1Frac";
+    }
+};
+
+/// The R gate for rotation around an arbitrary basis
+class R : public RotationGate
+{
+  public:
+    R(Basis b, RealType phi, logical_qubit_id q)
+        : RotationGate(phi, q)
+        , b_(b)
+    {
+    }
+
+    std::string name() const
+    {
+        return "R";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        switch (b_)
+        {
+        case PauliI:
+            return G(angle(), qubit()).matrix();
+            break;
+        case PauliX:
+            return Rx(angle(), qubit()).matrix();
+            break;
+        case PauliY:
+            return Ry(angle(), qubit()).matrix();
+            break;
+        case PauliZ:
+            return Rz(angle(), qubit()).matrix();
+            break;
+        default:
+            assert(false);
+        }
+        // dummy return
+        return TinyMatrix<ComplexType, 2>();
+    }
+
+  private:
+    Basis b_;
+};
+
+class RFrac : public R
+{
+  public:
+    RFrac(Basis b, int k, int n, logical_qubit_id q)
+        : R(b, -2. * M_PI * static_cast<RealType>(k) / static_cast<RealType>(1ll << n), q)
+    {
+    }
+    std::string name() const
+    {
+        return "RFrac";
+    }
+};
+
+} // namespace Gates
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/simulator.hpp
+++ b/src/Simulation/Native/src/simulator/simulator.hpp
@@ -19,112 +19,126 @@ namespace Quantum
 namespace SIMULATOR
 {
 
-  
-  template <class WFN>
-  class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
-  {
+template <class WFN>
+class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
+{
   public:
-    
     using WaveFunctionType = WFN;
-    
-    Simulator(unsigned maxlocal=0u)
-    : psi(maxlocal)
-    {}
-    
+
+    Simulator(unsigned maxlocal = 0u)
+        : psi()
+    {
+    }
+
     std::size_t random(std::vector<double> const& d)
     {
-      recursive_lock_type l(mutex());
-      std::discrete_distribution<std::size_t> dist(d.begin(), d.end());
-      return dist(psi.rng());
+        recursive_lock_type l(mutex());
+        std::discrete_distribution<std::size_t> dist(d.begin(), d.end());
+        return dist(psi.rng());
     }
-    
+
     std::size_t random(std::size_t n, double* d)
     {
-      std::discrete_distribution<std::size_t> dist(d, d+n);
-      recursive_lock_type l(mutex());
-      return dist(psi.rng());
+        std::discrete_distribution<std::size_t> dist(d, d + n);
+        recursive_lock_type l(mutex());
+        return dist(psi.rng());
     }
-    
+
     double JointEnsembleProbability(std::vector<Gates::Basis> bs, std::vector<unsigned> qs)
     {
-      removeIdentities(bs,qs);
-      if ( bs.empty() )
-      {
-        return 0.0;
-      }
-      
-      recursive_lock_type l(mutex());
-      changebasis(bs, qs,true);
-      double p = psi.jointprobability(qs);
-      changebasis(bs, qs,false);
-      return p;
+        removeIdentities(bs, qs);
+        if (bs.empty())
+        {
+            return 0.0;
+        }
+
+        recursive_lock_type l(mutex());
+        changebasis(bs, qs, true);
+        double p = psi.jointprobability(qs);
+        changebasis(bs, qs, false);
+        return p;
     }
-      
+
     bool isclassical(unsigned q)
     {
-      recursive_lock_type l(mutex());
-      return psi.isclassical(q);
+        recursive_lock_type l(mutex());
+        return psi.isclassical(q);
     }
-    
+
     // allocate and release
     unsigned allocate()
     {
-      recursive_lock_type l(mutex());
-      return psi.allocate();
+        recursive_lock_type l(mutex());
+        return psi.allocate_qubit();
     }
-    
+
     std::vector<unsigned> allocate(unsigned n)
     {
-      std::vector<unsigned> qubits;
-      recursive_lock_type l(mutex());
+        std::vector<unsigned> qubits;
+        recursive_lock_type l(mutex());
 
-      for (unsigned i = 0; i < n; ++i)
-        qubits.push_back(psi.allocate());
-      return qubits;
+        for (unsigned i = 0; i < n; ++i)
+            qubits.push_back(psi.allocate_qubit());
+        return qubits;
     }
-    
+
     void allocateQubit(unsigned q)
     {
-      recursive_lock_type l(mutex());
-      psi.allocateQubit(q);
+        recursive_lock_type l(mutex());
+        psi.allocate_qubit(q);
     }
-    
+
     void allocateQubit(std::vector<unsigned> const& qubits)
     {
-      recursive_lock_type l(mutex());
-      for (auto q: qubits)
-        psi.allocateQubit(q);
+        recursive_lock_type l(mutex());
+        for (auto q : qubits)
+            psi.allocate_qubit(q);
     }
-    
+
     bool release(unsigned q)
     {
-      recursive_lock_type l(mutex());
-      flush();
-      bool allok = isclassical(q);
-      if (allok)
-      allok = (psi.getvalue(q)==false);
-      else
-      M(q);
-      psi.release(q);
-      return allok;
+        recursive_lock_type l(mutex());
+        flush();
+        bool allok = isclassical(q);
+        if (allok)
+            allok = (psi.getvalue(q) == false);
+        else
+            M(q);
+        psi.release(q);
+        return allok;
     }
-    
+
     bool release(std::vector<unsigned> const& qs)
     {
-      recursive_lock_type l(mutex());
-      bool allok=true;
-      for (auto q : qs)
-      allok = release(q) && allok;
-      return allok;
+        recursive_lock_type l(mutex());
+        bool allok = true;
+        for (auto q : qs)
+            allok = release(q) && allok;
+        return allok;
     }
-    
+
     // single-qubit gates
-    
-#define GATE1IMPL(OP) void OP(unsigned q) { recursive_lock_type l(mutex()); psi.apply(Gates::OP(q));}
-#define GATE1CIMPL(OP) void C##OP(unsigned c, unsigned q) { recursive_lock_type l(mutex()); psi.apply_controlled(c,Gates::OP(q));}
-#define GATE1MCIMPL(OP) void C##OP(std::vector<unsigned> const& c, unsigned q) { recursive_lock_type l(mutex()); psi.apply_controlled(c,Gates::OP(q));}
+
+#define GATE1IMPL(OP)                                                                                                  \
+    void OP(unsigned q)                                                                                                \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply(Gates::OP(q));                                                                                       \
+    }
+#define GATE1CIMPL(OP)                                                                                                 \
+    void C##OP(unsigned c, unsigned q)                                                                                 \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply_controlled(c, Gates::OP(q));                                                                         \
+    }
+#define GATE1MCIMPL(OP)                                                                                                \
+    void C##OP(std::vector<unsigned> const& c, unsigned q)                                                             \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply_controlled(c, Gates::OP(q));                                                                         \
+    }
 #define GATE1(OP) GATE1IMPL(OP) GATE1CIMPL(OP) GATE1MCIMPL(OP)
-    
+
     GATE1(X)
     GATE1(Y)
     GATE1(Z)
@@ -135,17 +149,32 @@ namespace SIMULATOR
     GATE1(AdjHY)
     GATE1(AdjT)
     GATE1(AdjS)
-    
+
 #undef GATE1
 #undef GATE1IMPL
 #undef GATE1CIMPL
 #undef GATE1MCIMPL
-    
-#define GATE1IMPL(OP) void OP(double phi, unsigned q) { recursive_lock_type l(mutex()); psi.apply(Gates::OP(phi,q));}
-#define GATE1CIMPL(OP) void C##OP(double phi, unsigned c, unsigned q) { recursive_lock_type l(mutex()); psi.apply_controlled(c,Gates::OP(phi,q));}
-#define GATE1MCIMPL(OP) void C##OP(double phi, std::vector<unsigned> const& c, unsigned q) { recursive_lock_type l(mutex()); psi.apply_controlled(c,Gates::OP(phi,q));}
+
+#define GATE1IMPL(OP)                                                                                                  \
+    void OP(double phi, unsigned q)                                                                                    \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply(Gates::OP(phi, q));                                                                                  \
+    }
+#define GATE1CIMPL(OP)                                                                                                 \
+    void C##OP(double phi, unsigned c, unsigned q)                                                                     \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply_controlled(c, Gates::OP(phi, q));                                                                    \
+    }
+#define GATE1MCIMPL(OP)                                                                                                \
+    void C##OP(double phi, std::vector<unsigned> const& c, unsigned q)                                                 \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply_controlled(c, Gates::OP(phi, q));                                                                    \
+    }
 #define GATE1(OP) GATE1IMPL(OP) GATE1CIMPL(OP) GATE1MCIMPL(OP)
-    
+
     GATE1(Rx)
     GATE1(Ry)
     GATE1(Rz)
@@ -154,123 +183,157 @@ namespace SIMULATOR
 #undef GATE1IMPL
 #undef GATE1CIMPL
 #undef GATE1MCIMPL
-    
+
     // rotations
     void R(Gates::Basis b, double phi, unsigned q)
     {
-      recursive_lock_type l(mutex());
-      psi.apply(Gates::R(b, phi, q));
+        recursive_lock_type l(mutex());
+        psi.apply(Gates::R(b, phi, q));
     }
-    
+
     // multi-controlled rotations
     void CR(Gates::Basis b, double phi, std::vector<unsigned> const& c, unsigned q)
     {
-      recursive_lock_type l(mutex());
-      psi.apply_controlled(c, Gates::R(b, phi, q));
+        recursive_lock_type l(mutex());
+        psi.apply_controlled(c, Gates::R(b, phi, q));
     }
-    
+
     // Exponential of Pauli operators
     void CExp(std::vector<Gates::Basis> bs, double phi, std::vector<unsigned> const& cs, std::vector<unsigned> qs)
     {
-      if (bs.size()==0)
-      return;
-      
-      unsigned somequbit =qs.front();
-      removeIdentities(bs,qs);
-      
-      recursive_lock_type l(mutex());
-      if (bs.size()==0)
-      CR(Gates::PauliI,-2.*phi,cs,somequbit);
-      else if (bs.size()==1)
-      CR(bs.front(),-2.*phi,cs,qs.front());
-      else
-      psi.apply_controlled_exp(bs,phi,cs,qs);
+        if (bs.size() == 0) return;
+
+        unsigned somequbit = qs.front();
+        removeIdentities(bs, qs);
+
+        recursive_lock_type l(mutex());
+        if (bs.size() == 0)
+            CR(Gates::PauliI, -2. * phi, cs, somequbit);
+        else if (bs.size() == 1)
+            CR(bs.front(), -2. * phi, cs, qs.front());
+        else
+            psi.apply_controlled_exp(bs, phi, cs, qs);
     }
-    
+
     void Exp(std::vector<Gates::Basis> const& bs, double phi, std::vector<unsigned> const& qs)
     {
-      recursive_lock_type l(mutex());
-      CExp(bs,phi,std::vector<unsigned>(), qs);
+        recursive_lock_type l(mutex());
+        CExp(bs, phi, std::vector<unsigned>(), qs);
     }
-    
+
     // measurements
-    
+
     bool M(unsigned q)
     {
-      recursive_lock_type l(mutex());
-     return psi.measure(q);
+        recursive_lock_type l(mutex());
+        return psi.measure(q);
     }
-    
+
     std::vector<bool> MultiM(std::vector<unsigned> const& qs)
     {
-      // ***TODO*** optimized implementation
-      recursive_lock_type l(mutex());
-      std::vector<bool> res;
-      for (auto q: qs)
-      res.push_back(psi.measure(q));
-      return res;
+        // ***TODO*** optimized implementation
+        recursive_lock_type l(mutex());
+        std::vector<bool> res;
+        for (auto q : qs)
+            res.push_back(psi.measure(q));
+        return res;
     }
-    
+
     bool Measure(std::vector<Gates::Basis> bs, std::vector<unsigned> qs)
     {
-      recursive_lock_type l(mutex());
-      removeIdentities(bs,qs);
-      // ***TODO*** optimized kernels
-      changebasis(bs, qs,true);
-      bool res = psi.jointmeasure(qs);
-      changebasis(bs, qs,false);
-      return res;
+        recursive_lock_type l(mutex());
+        removeIdentities(bs, qs);
+        // ***TODO*** optimized kernels
+        changebasis(bs, qs, true);
+        bool res = psi.jointmeasure(qs);
+        changebasis(bs, qs, false);
+        return res;
     }
 
-    void seed(unsigned s) { recursive_lock_type l(mutex()); psi.seed(s);}
-    void reset() { recursive_lock_type l(mutex()); psi.reset();}
-    unsigned qubit(unsigned id) const { recursive_lock_type l(mutex()); return psi.qubit(id);}
-    unsigned num_qubits() const { recursive_lock_type l(mutex()); return psi.num_qubits();}
-    void flush() { recursive_lock_type l(mutex()); psi.flush();}
-    ComplexType const* data() const { recursive_lock_type l(mutex()); return psi.data().data();}
-
-    void dump(bool(*callback)(size_t, double, double))
+    void seed(unsigned s)
     {
-       recursive_lock_type l(mutex());
-       flush();
-
-       auto wfn = psi.data();
-       for (std::size_t i = 0; i < wfn.size(); i++) {
-           if (!callback(i, wfn[i].real(), wfn[i].imag())) return;
-       }
+        recursive_lock_type l(mutex());
+        psi.seed(s);
+    }
+    void reset()
+    {
+        recursive_lock_type l(mutex());
+        psi.reset();
     }
 
-    void dumpIds(void(*callback)(unsigned))
+    // Do we really need to expose positional information of a qubit?
+    positional_qubit_id qubit(logical_qubit_id id) const
+    {
+        recursive_lock_type l(mutex());
+        return psi.get_qubit_position(id);
+    }
+
+    unsigned num_qubits() const
+    {
+        recursive_lock_type l(mutex());
+        return psi.num_qubits();
+    }
+    void flush()
+    {
+        recursive_lock_type l(mutex());
+        psi.flush();
+    }
+    ComplexType const* data() const
+    {
+        recursive_lock_type l(mutex());
+        return psi.data().data();
+    }
+
+    void dump(bool (*callback)(size_t, double, double))
     {
         recursive_lock_type l(mutex());
         flush();
 
-        auto qubits = psi.logicalQubits();
-        for (auto it = qubits.begin(); it != qubits.end(); ++it) {
+        auto wfn = psi.data();
+        for (std::size_t i = 0; i < wfn.size(); i++)
+        {
+            if (!callback(i, wfn[i].real(), wfn[i].imag())) return;
+        }
+    }
+
+    void dumpIds(void (*callback)(unsigned))
+    {
+        recursive_lock_type l(mutex());
+        flush();
+
+        auto qubits = psi.get_qubit_ids();
+        for (auto it = qubits.begin(); it != qubits.end(); ++it)
+        {
             callback(*it);
         }
     }
 
-    bool dumpQubits(std::vector<unsigned> const& qs, bool(*callback)(size_t, double, double))
+    bool dumpQubits(std::vector<unsigned> const& qs, bool (*callback)(size_t, double, double))
     {
         assert(qs.size() <= num_qubits());
 
         WavefunctionStorage wfn(1ull << qs.size());
 
-        if (subsytemwavefunction(qs, wfn, 1e-10)) {
-            for (std::size_t i = 0; i < wfn.size(); i++) {
+        if (subsytemwavefunction(qs, wfn, 1e-10))
+        {
+            for (std::size_t i = 0; i < wfn.size(); i++)
+            {
                 if (!callback(i, wfn[i].real(), wfn[i].imag())) break;
             }
             return true;
         }
-        else {
+        else
+        {
             return false;
         }
     }
 
     // apply permutation of basis states to the wave function
-    void permuteBasis(std::vector<unsigned> const& qs, std::size_t table_size,
-        std::size_t const* permutation_table, bool adjoint = false)
+    void permuteBasis(
+        std::vector<unsigned> const& qs,
+        std::size_t table_size,
+        std::size_t const* permutation_table,
+        bool adjoint = false)
 
     {
 #ifndef NDEBUG
@@ -285,58 +348,57 @@ namespace SIMULATOR
         psi.permute_basis(qs, table_size, permutation_table, adjoint);
     }
 
-    bool
-    subsytemwavefunction(std::vector<unsigned> const& qs, WavefunctionStorage& qubitswfn, double tolerance)
+    bool subsytemwavefunction(std::vector<unsigned> const& qs, WavefunctionStorage& qubitswfn, double tolerance)
     {
         recursive_lock_type l(mutex());
         flush();
         return psi.subsytemwavefunction(qs, qubitswfn, tolerance);
     }
-    
+
   private:
     void changebasis(Gates::Basis b, unsigned q, bool back)
     {
-      if (b == Gates::PauliX)
-      H(q);
-      else if (b == Gates::PauliY)
-      {
-        if (back)
-        AdjHY(q);
-        else
-        HY(q);
-      }
+        if (b == Gates::PauliX)
+            H(q);
+        else if (b == Gates::PauliY)
+        {
+            if (back)
+                AdjHY(q);
+            else
+                HY(q);
+        }
     }
-    
+
     void changebasis(std::vector<Gates::Basis> const& bs, std::vector<unsigned> const& qs, bool back)
     {
-      assert(bs.size() == qs.size());
-      for (unsigned i = 0; i < bs.size(); ++i)
-      changebasis(bs[i], qs[i],back);
+        assert(bs.size() == qs.size());
+        for (unsigned i = 0; i < bs.size(); ++i)
+            changebasis(bs[i], qs[i], back);
     }
-    
-    inline static void removeIdentities(std::vector<Gates::Basis>& b, std::vector<unsigned> & qs)
+
+    inline static void removeIdentities(std::vector<Gates::Basis>& b, std::vector<unsigned>& qs)
     {
-      unsigned i=0;
-      while (i != b.size())
-      {
-        if (b[i] == Gates::PauliI)
+        unsigned i = 0;
+        while (i != b.size())
         {
-          b.erase(b.begin() + i);
-          qs.erase(qs.begin() + i);
+            if (b[i] == Gates::PauliI)
+            {
+                b.erase(b.begin() + i);
+                qs.erase(qs.begin() + i);
+            }
+            else
+                ++i;
         }
-        else
-        ++i;
-      }
     }
-    
+
     WaveFunctionType psi;
-  };
-  
+};
+
 using WavefunctionType = Wavefunction<ComplexType>;
 using SimulatorType = Simulator<WavefunctionType>;
 
-MICROSOFT_QUANTUM_DECL Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned=0u);
+MICROSOFT_QUANTUM_DECL Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned = 0u);
 
-}
-}
-}
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/types.hpp
+++ b/src/Simulation/Native/src/simulator/types.hpp
@@ -5,26 +5,35 @@
 #include "util/alignedalloc.hpp"
 #include <vector>
 
-
 namespace Microsoft
 {
-  namespace Quantum
-  {
-    namespace SIMULATOR
-    {
-      
+namespace Quantum
+{
+namespace SIMULATOR
+{
+
 #ifndef USE_SINGLE_PRECISION
-      using RealType = double;
+using RealType = double;
 #else
-      using RealType = float;
+using RealType = float;
 #endif
-      
-      using ComplexType = std::complex<RealType>;
-      
-      using WavefunctionStorage = std::vector<ComplexType, AlignedAlloc<ComplexType,64>>;
 
-    }
-  }
-}
+using ComplexType = std::complex<RealType>;
 
+using WavefunctionStorage = std::vector<ComplexType, AlignedAlloc<ComplexType, 64>>;
 
+// The positional id is an implementation details of the wave function store and shouldn't be used outside of it.
+// The `using` declarations document the intent of the code but provide no compile-time safety. Consider replacing those
+// with single member structs with implicit conversion to unsigned, but no direct conversion between logical and
+// positional qubit ids.
+
+/// Logical qubit id is visible to the clients and is immutable during the lifetime of the qubit.
+using logical_qubit_id = unsigned;
+
+/// Positional qubit id describes the order of the qubit in the standard computational basis used by the wave function.
+/// It might change as the qubits are allocated/released or reodered.
+using positional_qubit_id = unsigned;
+
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/wavefunction.hpp
+++ b/src/Simulation/Native/src/simulator/wavefunction.hpp
@@ -10,138 +10,305 @@
 #include <iostream>
 #include <iterator>
 #include <limits>
+#include <list>
 #include <random>
-#include <vector>
-#include <unordered_set>
-#include <unordered_map>
 #include <string.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
-#include "types.hpp"
 #include "gates.hpp"
+#include "types.hpp"
 
 #include "external/fused.hpp"
 
 namespace Microsoft
 {
-    namespace Quantum
+namespace Quantum
+{
+namespace SIMULATOR
+{
+namespace detail
+{
+inline std::size_t get_register(const std::vector<positional_qubit_id>& qs, std::size_t basis_state)
+{
+    std::size_t result = 0;
+    for (unsigned i = 0; i < qs.size(); ++i)
+        result |= ((basis_state >> qs[i]) & 1) << i;
+    return result;
+}
+
+inline std::size_t set_register(
+    const std::vector<positional_qubit_id>& qs,
+    std::size_t qmask,
+    std::size_t basis_state,
+    std::size_t original = 0ull)
+{
+    std::size_t result = original & ~qmask;
+    for (unsigned i = 0; i < qs.size(); ++i)
+        result |= ((basis_state >> i) & 1) << qs[i];
+    return result;
+}
+} // namespace detail
+
+///
+/// When a gate is invoked, we might not apply it immediately but save all its pertinent information into an immutable
+/// cache so we can apply the gate later.
+///
+struct DeferredGate
+{
+    const std::vector<logical_qubit_id> controls_;
+    const logical_qubit_id target_;
+    const TinyMatrix<ComplexType, 2> mat_;
+
+  public:
+    DeferredGate(
+        const std::vector<logical_qubit_id>& controls,
+        logical_qubit_id target,
+        const TinyMatrix<ComplexType, 2>& mat)
+        : controls_(controls)
+        , target_(target)
+        , mat_(mat)
     {
-        namespace SIMULATOR
+    }
+    DeferredGate(DeferredGate&& other)
+        : controls_(std::move(other.controls_))
+        , target_(other.target_)
+        , mat_(std::move(other.mat_))
+    {
+    }
+    DeferredGate(const DeferredGate& other)
+        : controls_(other.controls_)
+        , target_(other.target_)
+        , mat_(other.mat_)
+    {
+    }
+};
+
+///
+/// Logic for discovering clusters of gates that can be scheduled to be flushed together.
+///
+class Cluster
+{
+    std::vector<logical_qubit_id> qids_;
+    std::vector<DeferredGate> gates_;
+
+  public:
+    Cluster(std::vector<logical_qubit_id>&& qids, std::vector<DeferredGate>&& gates)
+        : qids_(std::move(qids))
+        , gates_(std::move(gates))
+    {
+    }
+    Cluster(Cluster&& other)
+        : qids_(std::move(other.qids_))
+        , gates_(std::move(other.gates_))
+    {
+    }
+
+    // Clusters can potentially be quite big, so we don't want to copy them around gratuitously. (We probably don't want
+    // to copy them around at all, but fixing that would require more understanding of the clustering algorithm than I
+    // have right now.) Thus, we'll keep the copy operator but at least prohibit copy assignment.
+    Cluster(const Cluster& other)
+        : qids_(other.qids_)
+        , gates_(other.gates_)
+    {
+    }
+    Cluster& operator=(const Cluster&) = delete;
+
+    const std::vector<logical_qubit_id>& get_qids() const
+    {
+        return qids_;
+    }
+    const std::vector<DeferredGate>& get_gates() const
+    {
+        return gates_;
+    }
+
+    void set_qids(const std::vector<logical_qubit_id>& qids)
+    {
+        qids_ = qids;
+    }
+
+    void append_gates(const std::vector<DeferredGate>& gates)
+    {
+        for (const DeferredGate& gate : gates)
         {
-            namespace detail
-            {
-                inline std::size_t get_register(const std::vector<unsigned>& qs, std::size_t basis_state)
-                {
-                    std::size_t result = 0;
-                    for (unsigned i = 0; i < qs.size(); ++i)
-                        result |= ((basis_state >> qs[i]) & 1) << i;
-                    return result;
+            gates_.emplace_back(gate);
+        }
+    }
 
-                }
+    void set_from_other(const Cluster& other)
+    {
+        gates_.clear();
+        set_qids(other.get_qids());
+        append_gates(other.get_gates());
+    }
 
-                inline std::size_t set_register(const std::vector<unsigned>& qs, std::size_t qmask, std::size_t basis_state, std::size_t original = 0ull)
-                {
-                    std::size_t result = original & ~qmask;
-                    for (unsigned i = 0; i < qs.size(); ++i)
-                        result |= ((basis_state >> i) & 1) << qs[i];
-                    return result;
+    size_t size()
+    {
+        return gates_.size();
+    }
+
+    // Greedy method that finds next appropriate cluster
+    // TODO: it would be nice to provide a comment, outlining the algorithm...
+    std::pair<Cluster, std::vector<logical_qubit_id>> next_cluster(std::list<Cluster>& nextClusters, unsigned maxWidth)
+    {
+        std::vector<logical_qubit_id> myUnion;                            // My qubits touched + Next qubits touched
+        std::vector<logical_qubit_id> myDiff;                             // New qubits touched by Next
+        std::vector<logical_qubit_id> myInter;                            // Old qubits touched by Next
+        std::vector<logical_qubit_id> allInter;                           // My qubits + All touched qubits
+        std::set<logical_qubit_id> myTouched(qids_.begin(), qids_.end()); // My qubits touched
+        std::set<logical_qubit_id> allTouched = myTouched;                // All the qubits touched so far
+
+        for (auto it = nextClusters.rbegin(); it != nextClusters.rend(); ++it)
+        {                                            // Look at the clusters that follow us
+            auto nextQs = it->get_qids();            // Pull off one future cluster
+            std::sort(nextQs.begin(), nextQs.end()); // Has to be sorted for set operations
+            myUnion.clear();
+            std::set_union(
+                nextQs.begin(), nextQs.end(), // See what qubits we and the future cluster touch
+                myTouched.begin(), myTouched.end(), std::back_inserter(myUnion));
+            if (myUnion.size() <= maxWidth)
+            { // It's a candiate if it's not beyond our allowed width
+                myDiff.clear();
+                std::set_difference(
+                    nextQs.begin(), nextQs.end(), // Figure out if any of the future qubits aren't already seen by us
+                    myTouched.begin(), myTouched.end(), std::back_inserter(myDiff));
+                allInter.clear();
+                std::set_intersection(
+                    myDiff.begin(), myDiff.end(), // These are any new qubits that might have already been touched
+                    allTouched.begin(), allTouched.end(), std::back_inserter(allInter));
+                if (allInter.size() == 0)
+                { // If the new qubits are untouched... then this is allowed
+                    auto ret = std::make_pair(std::move(*it), myUnion);
+                    nextClusters.erase(--(it.base())); // base of reverse iterator points at the next item
+                    return ret;
                 }
             }
+            myInter.clear();
+            std::set_intersection(
+                nextQs.begin(), nextQs.end(), // If a future cluster touches any of our qubits... we've hit a hard wall
+                myTouched.begin(), myTouched.end(), std::back_inserter(myInter));
+            if (myInter.size() != 0) break;
 
-            // Creating a gate wrapper datatype to represent a gate in a cluster
-            class GateWrapper {
-            public:
-                GateWrapper(std::vector<unsigned> controls, unsigned target, TinyMatrix<ComplexType, 2> mat) : controls_(controls), target_(target), mat_(mat) {}
-                std::vector<unsigned> get_controls() { return controls_; }
-                unsigned get_target() { return target_; }
-                TinyMatrix<ComplexType, 2> get_mat() { return mat_; }
-            private:
-                std::vector<unsigned> controls_;
-                unsigned target_;
-                TinyMatrix<ComplexType, 2> mat_;
-            };
+            allTouched.insert(nextQs.begin(), nextQs.end()); // Add in all qubits touched, and try the next cluster
+        }
 
-            // Creating a cluster datatype for new scheduling logic
-            class Cluster {
-            public:
-                Cluster(std::vector<unsigned> qids, std::vector<GateWrapper> gates) : qids_(qids), gates_(gates) {}
-                std::vector<unsigned> get_qids() { return qids_; }
-                std::vector<GateWrapper> get_gates() { return gates_; }
+        // Couldn't find any more clusters to add
+        return std::make_pair(Cluster({}, {}), std::vector<logical_qubit_id>{});
+    }
 
-                void setQids(std::vector<unsigned> qids) {
-                    qids_ = qids;
+    /// Method that identifies clusters that can be flushed together.
+    // TODO: it would be nice to provide description of the clustering algorithm here...
+    static std::list<Cluster> make_clusters(unsigned fuseSpan, int maxFuseDepth, const std::vector<DeferredGate>& gates)
+    {
+        std::list<Cluster> curClusters;
+
+        if (gates.size() > 0)
+        {
+            // creating initial cluster containing one gate each
+            for (const DeferredGate& gate : gates)
+            {
+                std::vector<logical_qubit_id> qids = gate.controls_;
+                qids.push_back(gate.target_);
+                curClusters.emplace_back(std::move(qids), std::vector<DeferredGate>{gate});
+            }
+            // creating clusters using greedy algorithm
+            for (int i = 1; i < (int)fuseSpan + 1; i++)
+            {
+                // Build clusters of width 1,2,...
+                // Reverse the current clusters for processing
+                std::list<Cluster> prevClusters;
+                for (auto it = curClusters.rbegin(); it != curClusters.rend(); ++it)
+                {
+                    prevClusters.emplace_back(std::move(*it));
                 }
+                curClusters.clear();
 
-                void append_gates(std::vector<GateWrapper> gates) {
-                    gates_.insert(gates_.end(), gates.begin(), gates.end());
-                }
+                Cluster prevCluster = std::move(prevClusters.back());
+                prevClusters.pop_back();
 
-                size_t size() {
-                    return gates_.size();
-                }
+                while (prevClusters.size() > 0)
+                { // While there are more clusters...
+                    // See if we can accumlate anyone who follows
+                    auto foundCompat = prevCluster.next_cluster(prevClusters, i);
+                    const Cluster& clusterFound = foundCompat.first;
 
-                // Greedy method that finds next appropriate cluster
-                std::pair<Cluster, std::vector<unsigned>> next_cluster(std::vector<Cluster>& nextClusters, unsigned maxWidth) {
-                    std::vector<unsigned>   myUnion;                                // My qubits touched + Next qubits touched
-                    std::vector<unsigned>   myDiff;                                 // New qubits touched by Next
-                    std::vector<unsigned>   myInter;                                // Old qubits touched by Next
-                    std::vector<unsigned>   allInter;                               // My qubits + All touched qubits
-                    std::set<unsigned>      myTouched(qids_.begin(), qids_.end());  // My qubits touched
-                    std::set<unsigned>      allTouched = myTouched;                 // All the qubits touched so far
-
-                    int lastNexts = (int)nextClusters.size() - 1;                   // nexts are in reverse order (from above)
-                    for (int i = 0; i <= lastNexts; i++) {                          // Look at the clusters that follow us
-                        auto   nextQs = nextClusters[lastNexts-i].get_qids();       // Pull off one future cluster
-                        std::sort(nextQs.begin(), nextQs.end());                    // Has to be sorted for set operations
-                        myUnion.clear();
-                        std::set_union(nextQs.begin(), nextQs.end(),                // See what qubits we and the future cluster touch
-                            myTouched.begin(), myTouched.end(),
-                            std::back_inserter(myUnion));
-                        if (myUnion.size() <= maxWidth) {                           // It's a candiate if it's not beyond our allowed width
-                            myDiff.clear();
-                            std::set_difference(nextQs.begin(), nextQs.end(),       // Figure out if any of the future qubits aren't already seen by us
-                                myTouched.begin(), myTouched.end(),
-                                std::back_inserter(myDiff));
-                            allInter.clear();
-                            std::set_intersection(myDiff.begin(), myDiff.end(),     // These are any new qubits that might have already been touched
-                                allTouched.begin(), allTouched.end(),
-                                std::back_inserter(allInter));
-                            if (allInter.size() == 0) {                             // If the new qubits are untouched... then this is allowed
-                                auto cl = nextClusters[lastNexts-i];
-                                nextClusters.erase(nextClusters.begin() + (lastNexts-i));       // Remove the future cluster
-                                return std::make_pair(cl, myUnion);                 // ... and add it to our cluster (done above)
-                            }
+                    if (clusterFound.get_gates().size() == 0 || // Can't append any more clusters to this one
+                        (int)prevCluster.size() >= maxFuseDepth)
+                    {                                       // ... or we're beyond max depth
+                        curClusters.push_back(prevCluster); // Save this cluster
+                        if (prevCluster.size() > 0)
+                        {
+                            prevCluster.set_from_other(prevClusters.back());
+                            prevClusters.pop_back();
                         }
-                        myInter.clear();
-                        std::set_intersection(nextQs.begin(), nextQs.end(),         // If a future cluster touches any of our qubits... we've hit a hard wall
-                            myTouched.begin(), myTouched.end(),
-                            std::back_inserter(myInter));
-                        if (myInter.size() != 0) break;
-
-                        allTouched.insert(nextQs.begin(), nextQs.end());            // Add in all qubits touched, and try the next cluster
                     }
-                    Cluster defCl = Cluster({}, {});                                // Couldn't find any more clusters to add
-                    std::vector<unsigned> defVec = {};
-                    return std::make_pair(defCl, defVec);
-                }
-        private:
-            std::vector<unsigned> qids_;
-            std::vector<GateWrapper> gates_;
-            };
+                    else
+                    {
+                        prevCluster.set_qids(foundCompat.second); // New version of our cluster (appended)
+                        prevCluster.append_gates(clusterFound.get_gates());
+                    }
+                }                                   // Keep looking for clusters to add
+                curClusters.push_back(prevCluster); // Save the final cluster
+            }                                       // Start all over with the next larger span
+        }
 
-/// A wave function class to store and manipulate the state of qubits
+        return curClusters;
+    }
+};
 
+///
+/// Wave function represents the state of a n-qubit system.
+///
 template <class T = ComplexType>
 class Wavefunction
 {
-public:
-    using value_type = T;
-    using qubit_t = unsigned;
+#ifndef NDEBUG
+    /// There are two distinct usage patterns to how qubits are allocated and they shouldn't be mixed after allocations
+    /// have begun. However, we only check the pattern consistency in debug asserts.
+    enum class QubitAllocationPattern : int
+    {
+        any = 0,           // no qubits allocated yet, so either pattern will be OK
+        implicitLogicalId, // the wavefunction will assign logical qubit id as it sees fit
+        explicitLogicalId, // the caller specifies the logical qubit id
+    };
+#endif
+
+    /// Number of currently allocated qubits.
+    unsigned num_qubits_;
+
+    /// Represents the state of the system with num_qubits_ qubits. Might not reflect the current state if there are
+    /// pending fused gates.
+    mutable WavefunctionStorage wfn_;
+
+    /// Each qubit has a client-facing id, which we call "logical qubit id" or just "logical qubit". However, the order
+    /// of qubits in the internal representation of the state, that is, the positions of the qubits in the standard
+    /// computational basis of the wave function, might not match their logical ids or even the order of the logical
+    /// ids. `qubitmap_` stores the positional ids for all currently allocated qubits, the index into the vector is the
+    /// logical id of the qubit (which means this map might grow rather large if logical qubit ids aren't reused).
+    mutable std::vector<positional_qubit_id> qubitmap_;
+
+    /// Cache of the pending gates that haven't been applied (i.e. flushed) to the wave function storage yet.
+    static constexpr int MAX_PENDING_GATES = 999;
+    mutable std::vector<DeferredGate> pending_gates_;
+
+    Fused fused_;
+
     using RngEngine = std::mt19937;
+    RngEngine rng_;
 
-    constexpr qubit_t invalid_qubit() const { return std::numeric_limits<qubit_t>::max(); }
+#ifndef NDEBUG
+    QubitAllocationPattern usage_ = QubitAllocationPattern::any;
+#endif
 
-    /// allocate a wave function for zero qubits
-    Wavefunction(unsigned /*ignore*/) : num_qubits_(0), wfn_(1, 1.), usage_(0)
+  public:
+    using value_type = T;
+
+    /// Allocate a wave function for a 0-qubit system.
+    Wavefunction()
+        : num_qubits_(0)
+        , wfn_(1, 1.)
     {
         rng_.seed(std::clock());
     }
@@ -154,148 +321,198 @@ public:
         wfn_.resize(1);
         wfn_[0] = 1.;
         qubitmap_.resize(0);
+
+        // What about pending_gates_?
     }
 
     ~Wavefunction()
     {
+        // Why is it necessary to flush in the destructor? Who will be able to observe the effect?
         flush();
     }
 
-    unsigned qubit(unsigned q) const
+    constexpr positional_qubit_id invalid_qubit_position() const
     {
-        assert(qubitmap_[q] != invalid_qubit());
+        return std::numeric_limits<unsigned>::max();
+    }
+
+    positional_qubit_id get_qubit_position(logical_qubit_id q) const
+    {
+        assert(qubitmap_[q] != invalid_qubit_position());
         return qubitmap_[q];
     }
 
-    unsigned qubit(Gates::OneQubitGate const& g) const
+    positional_qubit_id get_qubit_position(Gates::OneQubitGate const& g) const
     {
-        return qubit(g.qubit());
+        return get_qubit_position(g.qubit());
+    }
+
+    std::vector<positional_qubit_id> get_qubit_positions(std::vector<logical_qubit_id> const& qs) const
+    {
+        std::vector<positional_qubit_id> ps;
+        for (logical_qubit_id q : qs)
+            ps.push_back(get_qubit_position(q));
+        return ps;
+    }
+
+    /// Returns the list of logical ids of all currently allocated qubits.
+    std::vector<logical_qubit_id> get_qubit_ids() const
+    {
+        std::vector<logical_qubit_id> qs;
+        for (unsigned i = 0; i < qubitmap_.size(); i++)
+        {
+            if (qubitmap_[i] != invalid_qubit_position())
+            {
+                qs.push_back(i);
+            }
+        }
+
+        return qs;
     }
 
     void flush() const
     {
-        int maxSpan = fused_.maxSpan();
-        auto clusters = make_clusters(maxSpan, gatelist_); //making clusters with gates in the queue
+        std::list<Cluster> clusters = Cluster::make_clusters(fused_.maxSpan(), fused_.maxDepth(), pending_gates_);
 
-        if (clusters.size() == 0) {
+        if (clusters.size() == 0)
+        {
             fused_.flush(wfn_);
         }
-        else {
-            // logic to flush gates in each cluster
-            for (int i = 0; i < clusters.size(); i++) {
-                Cluster cl = clusters.at(i);
-
-                for (GateWrapper gate : cl.get_gates()) {
-                    std::vector<unsigned> cs = gate.get_controls();
-                    if (cs.size() == 0) {
-                        fused_.apply(wfn_, gate.get_mat(), qubit(gate.get_target()));
+        else
+        {
+            // flush gates in each cluster
+            for (const Cluster& cl : clusters)
+            {
+                for (const DeferredGate& gate : cl.get_gates())
+                {
+                    if (gate.controls_.size() == 0)
+                    {
+                        fused_.apply(wfn_, gate.mat_, get_qubit_position(gate.target_));
                     }
-                    else {
-                        fused_.apply_controlled(wfn_, gate.get_mat(), qubits(cs), qubit(gate.get_target()));
+                    else
+                    {
+                        fused_.apply_controlled(
+                            wfn_, gate.mat_, get_qubit_positions(gate.controls_), get_qubit_position(gate.target_));
                     }
                 }
 
                 fused_.flush(wfn_);
             }
         }
-        gatelist_.clear();
+        pending_gates_.clear();
     }
 
-    /// allocate a qubit and grow the wave function
-    unsigned allocate()
+    /// Allocate a qubit with implicitly assigned logical qubit id.
+    logical_qubit_id allocate_qubit()
     {
-        assert(usage_ != 2);
-        usage_ = 1;
+#ifndef NDEBUG
+        assert(usage_ != QubitAllocationPattern::explicitLogicalId);
+        usage_ = QubitAllocationPattern::implicitLogicalId;
+#endif
+
         flush();
         wfn_.resize(2 * wfn_.size());
-        auto it = std::find(qubitmap_.begin(), qubitmap_.end(), invalid_qubit());
+
+        // Reuse a logical qubit id, if any is available.
+        auto it = std::find(qubitmap_.begin(), qubitmap_.end(), invalid_qubit_position());
         if (it != qubitmap_.end())
         {
-            unsigned num = static_cast<unsigned>(it - qubitmap_.begin());
+            positional_qubit_id num = static_cast<unsigned>(it - qubitmap_.begin());
             qubitmap_[num] = num_qubits_++;
             return num;
         }
-        else {
+        else
+        {
             qubitmap_.push_back(num_qubits_++);
             return static_cast<unsigned>(qubitmap_.size() - 1);
         }
     }
 
-    /// allocate a qubit and grow the wave function
-    void allocateQubit(unsigned id)
+    /// Allocate a qubit with explicitly provided logical qubit id. The caller is responsible for ensuring the id
+    /// doesn't collide with other allocated qubits.
+    void allocate_qubit(logical_qubit_id id)
     {
-        assert(usage_ != 1);
-        usage_ = 2;
+#ifndef NDEBUG
+        assert(usage_ != QubitAllocationPattern::implicitLogicalId);
+        usage_ = QubitAllocationPattern::explicitLogicalId;
+#endif
+
         flush();
         wfn_.resize(2 * wfn_.size());
-        if (id < qubitmap_.size()) {
+
+        if (id < qubitmap_.size())
+        {
+            assert(qubitmap_[id] == invalid_qubit_position());
             qubitmap_[id] = num_qubits_++;
         }
-        else {
-            assert(id == qubitmap_.size());
+        else
+        {
+            assert(id == qubitmap_.size()); // we want qubitmap_ to be as small as possible
             qubitmap_.push_back(num_qubits_++);
         }
         assert((wfn_.size() >> num_qubits_) == 1);
     }
 
-    /// release the specified qubit
-    /// \pre the qubit has to be in a classical state in the computational basis
-    void release(qubit_t q)
+    /// Release the specified qubit.
+    /// \pre The qubit has to be in a classical state in the computational basis.
+    void release(logical_qubit_id q)
     {
-        unsigned p = qubit(q); //returns qubitmap_[q]
+        positional_qubit_id p = qubitmap_[q];
         flush();
         kernels::collapse(wfn_, p, getvalue(q), true);
+
+        qubitmap_[q] = invalid_qubit_position();
         for (int i = 0; i < qubitmap_.size(); ++i)
-            if (qubitmap_[i] > p && qubitmap_[i] != invalid_qubit())
-                qubitmap_[i]--;
-        qubitmap_[q] = invalid_qubit();
+        {
+            if (qubitmap_[i] > p && qubitmap_[i] != invalid_qubit_position()) qubitmap_[i]--;
+        }
         --num_qubits_;
     }
 
-    /// the number of used qubits
-    qubit_t num_qubits() const
+    /// The number of currently allocated qubits.
+    unsigned num_qubits() const
     {
         return num_qubits_;
     }
 
     /// probability of measuring a 1
-    double probability(qubit_t q) const
+    double probability(logical_qubit_id q) const
     {
         flush();
-        return kernels::probability(wfn_, qubit(q));
+        return kernels::probability(wfn_, get_qubit_position(q));
     }
 
     /// probability of jointly measuring a 1
-    double jointprobability(std::vector<qubit_t> const& qs) const
+    double jointprobability(std::vector<logical_qubit_id> const& qs) const
     {
         flush();
-        std::vector<qubit_t> ps = qubits(qs);
+        std::vector<positional_qubit_id> ps = get_qubit_positions(qs);
         return kernels::jointprobability(wfn_, ps);
     }
 
     /// probability of jointly measuring a 1
-    double jointprobability(std::vector<Gates::Basis> const& bs, std::vector<qubit_t> const& qs) const
+    double jointprobability(std::vector<Gates::Basis> const& bs, std::vector<logical_qubit_id> const& qs) const
     {
         flush();
-        std::vector<qubit_t> ps = qubits(qs);
+        std::vector<positional_qubit_id> ps = get_qubit_positions(qs);
         return kernels::jointprobability(wfn_, bs, ps);
     }
 
     /// measure a qubit
-    bool measure(qubit_t q)
+    bool measure(logical_qubit_id q)
     {
         flush();
         std::uniform_real_distribution<double> uniform(0., 1.);
         bool result = (uniform(rng_) < probability(q));
-        kernels::collapse(wfn_, qubit(q), result);
+        kernels::collapse(wfn_, get_qubit_position(q), result);
         kernels::normalize(wfn_);
         return result;
     }
 
-    bool jointmeasure(std::vector<qubit_t> const& qs)
+    bool jointmeasure(std::vector<logical_qubit_id> const& qs)
     {
         flush();
-        std::vector<qubit_t> ps = qubits(qs);
+        std::vector<positional_qubit_id> ps = get_qubit_positions(qs);
         std::uniform_real_distribution<double> uniform(0., 1.);
         bool result = (uniform(rng_) < jointprobability(qs));
         kernels::jointcollapse(wfn_, ps, result);
@@ -303,31 +520,31 @@ public:
         return result;
     }
 
-    void apply_controlled_exp(std::vector<Gates::Basis> const& bs,
+    void apply_controlled_exp(
+        std::vector<Gates::Basis> const& bs,
         double phi,
-        std::vector<unsigned> const& cs,
-        std::vector<unsigned> const& qs)
+        std::vector<logical_qubit_id> const& cs,
+        std::vector<logical_qubit_id> const& qs)
     {
         flush();
-        kernels::apply_controlled_exp(wfn_, bs, phi, qubits(cs), qubits(qs));
+        kernels::apply_controlled_exp(wfn_, bs, phi, get_qubit_positions(cs), get_qubit_positions(qs));
     }
 
-    /// checks if the qubit is in classical state
-    bool isclassical(qubit_t q) const
+    /// Checks whether the qubit is in classical state.
+    bool isclassical(logical_qubit_id q) const
     {
         flush();
-        return kernels::isclassical(wfn_, qubit(q));
+        return kernels::isclassical(wfn_, get_qubit_position(q));
     }
 
     /// returns the classical value of a qubit (if classical)
     /// \pre the qubit has to be in a classical state in the computational basis
-    bool getvalue(qubit_t q) const
+    bool getvalue(logical_qubit_id q) const
     {
         flush();
         assert(isclassical(q));
-        int res = kernels::getvalue(wfn_, qubit(q));
-        if (res == 2)
-            std::cout << *this;
+        int res = kernels::getvalue(wfn_, get_qubit_position(q));
+        if (res == 2) std::cout << *this;
 
         assert(res < 2);
         return res == 1;
@@ -346,117 +563,67 @@ public:
         rng_.seed(s);
     }
 
-    //method that makes clusters to be flushed
-    std::vector<Cluster> make_clusters(unsigned fuseSpan, std::vector<GateWrapper> gates) const {
-        std::vector<Cluster> curClusters;
-
-        if (gates.size() > 0) {
-            //creating initial cluster containing one gate each
-            for (int i = 0; i < gates.size(); i++) {
-                std::vector<unsigned> qids;
-                std::vector<unsigned> controlQids = gates[i].get_controls();
-                if (controlQids.size() > 0) {
-                    qids = controlQids;
-                }
-                qids.push_back(gates[i].get_target());
-                Cluster newCl = Cluster(qids, { gates[i] });
-                curClusters.push_back(newCl);
-            }
-            //creating clusters using greedy algorithm
-            for (int i = 1; i < (int)fuseSpan + 1; i++) {                                   // Build clusters of width 1,2,...
-                std::reverse(curClusters.begin(), curClusters.end());                       // Keep everything in reverse order
-                auto prevClusters = curClusters;                                            // Save away the last set of clusters built
-                curClusters.clear();
-                auto prevCluster = prevClusters.back();                                     // Pop the first cluster
-                prevClusters.pop_back();
-                while (prevClusters.size() > 0)  {                                          // While there are more clusters...
-                    auto foundCompat = prevCluster.next_cluster(prevClusters, i);           // See if we can accumlate anyone who follows
-                    Cluster clusterFound = foundCompat.first;
-                    std::vector<unsigned> foundTotQids = foundCompat.second;
-                    if (clusterFound.get_gates().size() == 0 ||                             // Can't append any more clusters to this one
-                        (int)prevCluster.size() >= fused_.maxDepth()) {                     // ... or we're beyond max depth
-                        curClusters.push_back(prevCluster);                                 // Save this cluster
-                        if (prevCluster.size() > 0)
-                        {
-                            prevCluster = prevClusters.back();
-                            prevClusters.pop_back();
-                        }
-                    }
-                    else {
-                        prevCluster.setQids(foundTotQids);                                  // New version of our cluster (appended)
-                        prevCluster.append_gates(clusterFound.get_gates());
-                    }
-                }                                                                           // Keep looking for clusters to add
-                curClusters.push_back(prevCluster);                                         // Save the final cluster
-            }                                                                               // Start all over with the next larger span
-        }
-        
-        return curClusters;
-    }
-
-    /// generic application of a gate
+    /// Generic application of an uncontrolled gate.
     template <class Gate>
     void apply(Gate const& g)
     {
-        std::vector<qubit_t> cs;
-        GateWrapper gateApplied = GateWrapper(cs, g.qubit(), g.matrix());
-        gatelist_.push_back(gateApplied);
-        if (gatelist_.size() > 999) {
+        pending_gates_.emplace_back(std::vector<logical_qubit_id>{}, g.qubit(), g.matrix());
+        if (pending_gates_.size() > MAX_PENDING_GATES)
+        {
             flush();
         }
 
-        int doFlush = fused_.shouldFlush(wfn_, cs, g.qubit());
+        fused_.shouldFlush(wfn_, std::vector<logical_qubit_id>{}, g.qubit());
     }
 
-    /// generic application of a multiply controlled gate
+    /// Generic application of a multiply-controlled gate.
     template <class Gate>
-    void apply_controlled(std::vector<qubit_t> cs, Gate const& g)
+    void apply_controlled(const std::vector<logical_qubit_id>& cs, Gate const& g)
     {
-        std::vector<qubit_t> pcs = qubits(cs);
-        GateWrapper gateApplied = GateWrapper(cs, g.qubit(), g.matrix());
-        gatelist_.push_back(gateApplied);
-        if (gatelist_.size() > 999) {
+        pending_gates_.emplace_back(cs, g.qubit(), g.matrix());
+        if (pending_gates_.size() > MAX_PENDING_GATES)
+        {
             flush();
         }
-        
-        int doFlush = fused_.shouldFlush(wfn_, cs, g.qubit());
+
+        fused_.shouldFlush(wfn_, cs, g.qubit());
     }
 
-    /// generic application of a controlled gate
+    /// Generic application of a gate with a single control.
     template <class Gate>
-    void apply_controlled(qubit_t c, Gate const& g)
+    void apply_controlled(logical_qubit_id c, Gate const& g)
     {
-        std::vector<qubit_t> cs(1, c);
-        apply_controlled(cs, g);
+        apply_controlled(std::vector<logical_qubit_id>{c}, g);
     }
 
-    /// unoptimized application of a doubly controlled gate
+    /// Unoptimized application of a doubly-controlled gate.
     template <class Gate>
-    void apply_controlled(qubit_t c1, qubit_t c2, Gate const& g)
+    void apply_controlled(logical_qubit_id c1, logical_qubit_id c2, Gate const& g)
     {
-        std::vector<qubit_t> cs;
-        cs.push_back(c1);
-        cs.push_back(c2);
-        apply_controlled(cs, g);
+        apply_controlled({c1, c2}, g);
     }
 
     template <class A>
-    bool subsytemwavefunction(std::vector<unsigned> const& qs, std::vector<T, A>& qubitswfn, double tolerance)
+    bool subsytemwavefunction(std::vector<logical_qubit_id> const& qs, std::vector<T, A>& qubitswfn, double tolerance)
     {
         flush(); // we have to flush before we can extract the state
-        return kernels::subsytemwavefunction(wfn_, qubits(qs), qubitswfn, tolerance);
+        return kernels::subsytemwavefunction(wfn_, get_qubit_positions(qs), qubitswfn, tolerance);
     }
 
-
     // apply permutation of basis states to the wave function
-    void permute_basis(std::vector<unsigned> const& qs, std::size_t table_size,
-        std::size_t const* permutation_table, bool adjoint = false)
+    void permute_basis(
+        std::vector<logical_qubit_id> const& qs,
+        std::size_t table_size,
+        std::size_t const* permutation_table,
+        bool adjoint = false)
     {
         assert(table_size == 1ull << qs.size());
         flush();
-        auto real_qs = qubits(qs);
+
         auto num_states = wfn_.size();
         auto psi_new = WavefunctionStorage(num_states);
+
+        auto real_qs = get_qubit_positions(qs);
         auto qmask = kernels::make_mask(real_qs);
 
         auto permute = [&real_qs, qmask, table_size, permutation_table](std::size_t state) {
@@ -483,40 +650,7 @@ public:
     {
         return rng_;
     }
-
-
-    std::vector<qubit_t> qubits(std::vector<qubit_t> const& qs) const
-    {
-        std::vector<qubit_t> ps;
-        for (auto q : qs)
-            ps.push_back(qubit(q));
-        return ps;
-    }
-
-    // Returns the list of logical ids currently allocated.
-    std::vector<qubit_t> logicalQubits() const
-    {
-        std::vector<qubit_t> qs;
-        for (qubit_t i = 0; i < qubitmap_.size(); i++)
-        {
-            if (qubitmap_[i] != invalid_qubit()) qs.push_back(i);
-        }
-    
-        return qs;
-    }
-
-  private:
-    unsigned num_qubits_;             // for convenience
-    mutable WavefunctionStorage wfn_; // storing the wave function
-    mutable std::vector<qubit_t> qubitmap_;   // mapping of logical to physical qubits
-	int usage_;
-    mutable std::vector<GateWrapper> gatelist_;
-
-    // randomness support
-    RngEngine rng_;
-    Fused fused_;
 };
-
 
 /// print information about the wave function
 template <class T>
@@ -525,10 +659,9 @@ std::ostream& operator<<(std::ostream& out, Wavefunction<T> const& wfn)
     wfn.flush();
     out << "Wave function for " << wfn.num_qubits() << " with " << wfn.data().size() << " elements "
         << " using " << sizeof(T) * wfn.data().size() << " bytes" << std::endl;
-    if (wfn.num_qubits() <= 6)
-        std::copy(wfn.data().begin(), wfn.data().end(), std::ostream_iterator<T>(out, "\n"));
+    if (wfn.num_qubits() <= 6) std::copy(wfn.data().begin(), wfn.data().end(), std::ostream_iterator<T>(out, "\n"));
     return out;
 }
-}
-}
-}
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft


### PR DESCRIPTION
Format, unify naming, comment, document logical vs positional ids, remove some of the unnecessary copying -- but it has grown to be unreviewable, so creating the PR for reference only and will submit individual smaller refactors as separate PRs.