### PR TITLE
Standardize formatting across native simulator files

### DIFF
--- a/src/Simulation/Native/src/.clang-format
+++ b/src/Simulation/Native/src/.clang-format
@@ -1,0 +1,37 @@
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+---
+Language: Cpp
+BasedOnStyle: Microsoft
+
+# page width
+ColumnLimit: 120
+ReflowComments: true
+
+# tabs and indents
+UseTab: Never
+IndentWidth: 4
+TabWidth: 4
+NamespaceIndentation: None
+
+# line and statements layout
+BreakBeforeBraces: Allman
+BinPackParameters: false
+AlignAfterOpenBracket: AlwaysBreak
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortFunctionsOnASingleLine: Empty
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+AlwaysBreakTemplateDeclarations: Yes
+
+# misc
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+SpaceBeforeInheritanceColon : true
+SpaceBeforeParens: ControlStatements
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/src/Simulation/Native/src/config.hpp
+++ b/src/Simulation/Native/src/config.hpp
@@ -19,8 +19,7 @@
 
 #define BUILD_SHARED_LIBS
 
-
-#if defined (_MSC_VER) && defined (BUILD_SHARED_LIBS)
+#if defined(_MSC_VER) && defined(BUILD_SHARED_LIBS)
 
 #ifdef BUILD_DLL
 #define MICROSOFT_QUANTUM_DECL __declspec(dllexport)
@@ -46,5 +45,3 @@
 #else
 #define SIMULATOR SimulatorGeneric
 #endif
-
-

--- a/src/Simulation/Native/src/simulator/capi.cpp
+++ b/src/Simulation/Native/src/simulator/capi.cpp
@@ -2,167 +2,203 @@
 // Licensed under the MIT License.
 
 #include "simulator/capi.hpp"
-#include "simulator/simulator.hpp"
 #include "simulator/factory.hpp"
+#include "simulator/simulator.hpp"
 using namespace Microsoft::Quantum::Simulator;
 
-extern "C" {
-
-// init and cleanup
-MICROSOFT_QUANTUM_DECL unsigned init()
+extern "C"
 {
-  return Microsoft::Quantum::Simulator::create();
-}
 
-MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned id)
-  {
-    Microsoft::Quantum::Simulator::destroy(id);
-  }
+    // init and cleanup
+    MICROSOFT_QUANTUM_DECL unsigned init()
+    {
+        return Microsoft::Quantum::Simulator::create();
+    }
 
-MICROSOFT_QUANTUM_DECL void seed(_In_ unsigned id, _In_ unsigned s)
-{
-  Microsoft::Quantum::Simulator::get(id)->seed(s);
-}
+    MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned id)
+    {
+        Microsoft::Quantum::Simulator::destroy(id);
+    }
 
-// non-quantum
-MICROSOFT_QUANTUM_DECL std::size_t random_choice(_In_ unsigned id, _In_ std::size_t n, _In_reads_(n) double* p)
-{
-    return Microsoft::Quantum::Simulator::get(id)->random(n, p);
-}
+    MICROSOFT_QUANTUM_DECL void seed(_In_ unsigned id, _In_ unsigned s)
+    {
+        Microsoft::Quantum::Simulator::get(id)->seed(s);
+    }
 
-MICROSOFT_QUANTUM_DECL double JointEnsembleProbability(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) int* b, _In_reads_(n) unsigned* q)
-{
-    std::vector<Gates::Basis> bv;
-    for (unsigned i = 0; i < n; ++i)
-        bv.push_back(static_cast<Gates::Basis>(*(b + i)));
-    std::vector<unsigned> qv(q, q + n);
-    return Microsoft::Quantum::Simulator::get(id)->JointEnsembleProbability( bv, qv);
-}
+    // non-quantum
+    MICROSOFT_QUANTUM_DECL std::size_t random_choice(_In_ unsigned id, _In_ std::size_t n, _In_reads_(n) double* p)
+    {
+        return Microsoft::Quantum::Simulator::get(id)->random(n, p);
+    }
 
+    MICROSOFT_QUANTUM_DECL double JointEnsembleProbability(
+        _In_ unsigned id,
+        _In_ unsigned n,
+        _In_reads_(n) int* b,
+        _In_reads_(n) unsigned* q)
+    {
+        std::vector<Gates::Basis> bv;
+        for (unsigned i = 0; i < n; ++i)
+            bv.push_back(static_cast<Gates::Basis>(*(b + i)));
+        std::vector<unsigned> qv(q, q + n);
+        return Microsoft::Quantum::Simulator::get(id)->JointEnsembleProbability(bv, qv);
+    }
 
-MICROSOFT_QUANTUM_DECL void allocateQubit(_In_ unsigned id, _In_ unsigned q)
-{
-    Microsoft::Quantum::Simulator::get(id)->allocateQubit(q);
-}
+    MICROSOFT_QUANTUM_DECL void allocateQubit(_In_ unsigned id, _In_ unsigned q)
+    {
+        Microsoft::Quantum::Simulator::get(id)->allocateQubit(q);
+    }
 
-MICROSOFT_QUANTUM_DECL void release(_In_ unsigned id, _In_ unsigned q)
-{
-    Microsoft::Quantum::Simulator::get(id)->release(q);
-}
+    MICROSOFT_QUANTUM_DECL void release(_In_ unsigned id, _In_ unsigned q)
+    {
+        Microsoft::Quantum::Simulator::get(id)->release(q);
+    }
 
-MICROSOFT_QUANTUM_DECL unsigned num_qubits(_In_ unsigned id)
-{
-  return Microsoft::Quantum::Simulator::get(id)->num_qubits();
-}
+    MICROSOFT_QUANTUM_DECL unsigned num_qubits(_In_ unsigned id)
+    {
+        return Microsoft::Quantum::Simulator::get(id)->num_qubits();
+    }
 
 #define FWDGATE1(G)                                                                                                    \
-MICROSOFT_QUANTUM_DECL void G(_In_ unsigned id, _In_ unsigned q)                                                                          \
+    MICROSOFT_QUANTUM_DECL void G(_In_ unsigned id, _In_ unsigned q)                                                   \
     {                                                                                                                  \
-        Microsoft::Quantum::Simulator::get(id)->G(q);                                                                           \
+        Microsoft::Quantum::Simulator::get(id)->G(q);                                                                  \
     }
 #define FWDCSGATE1(G)                                                                                                  \
-    MICROSOFT_QUANTUM_DECL void MC##G(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)                                             \
+    MICROSOFT_QUANTUM_DECL void MC##G(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)   \
     {                                                                                                                  \
         std::vector<unsigned> vc(c, c + n);                                                                            \
-        Microsoft::Quantum::Simulator::get(id)->C##G(vc, q);                                                                    \
+        Microsoft::Quantum::Simulator::get(id)->C##G(vc, q);                                                           \
     }
 #define FWD(G) FWDGATE1(G) FWDCSGATE1(G)
 
-// single-qubit gates
-FWD(X)
-FWD(Y)
-FWD(Z)
-FWD(H)
-FWD(S)
-FWD(T)
-FWD(AdjS)
-FWD(AdjT)
+    // single-qubit gates
+    FWD(X)
+    FWD(Y)
+    FWD(Z)
+    FWD(H)
+    FWD(S)
+    FWD(T)
+    FWD(AdjS)
+    FWD(AdjT)
 
 #undef FWDGATE1
 #undef FWDGATE2
 #undef FWDGATE3
 #undef FWDCSGATE1
 #undef FWD
-  
-// rotations
-    
-MICROSOFT_QUANTUM_DECL void R(_In_ unsigned id, _In_ unsigned b, _In_ double phi, _In_ unsigned q)
-{
-    Microsoft::Quantum::Simulator::get(id)->R(static_cast<Gates::Basis>(b), phi, q);
-}
-  
-// multi-controlled rotations
-MICROSOFT_QUANTUM_DECL void MCR(_In_ unsigned id, _In_ unsigned b, _In_ double phi, _In_ unsigned nc, _In_reads_(nc) unsigned* c, _In_ unsigned q)
-{
-    std::vector<unsigned> cv(c, c + nc);
-    Microsoft::Quantum::Simulator::get(id)->CR(static_cast<Gates::Basis>(b), phi, cv, q);
-}
 
-// Exponential of Pauli operators
-MICROSOFT_QUANTUM_DECL void Exp(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) unsigned* b, _In_ double phi, _In_reads_(n) unsigned* q)
-{
-    std::vector<Gates::Basis> bv;
-    for (unsigned i = 0; i < n; ++i)
-        bv.push_back(static_cast<Gates::Basis>(*(b + i)));
-    std::vector<unsigned> qv(q, q + n);
-    Microsoft::Quantum::Simulator::get(id)->Exp(bv, phi, qv);
-}
-MICROSOFT_QUANTUM_DECL void MCExp(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) unsigned* b, _In_ double phi, _In_ unsigned nc, _In_reads_(nc) unsigned* c, _In_reads_(n) unsigned* q)
-{
-    std::vector<Gates::Basis> bv;
-    for (unsigned i = 0; i < n; ++i)
-        bv.push_back(static_cast<Gates::Basis>(*(b + i)));
-    std::vector<unsigned> qv(q, q + n);
-    std::vector<unsigned> cv(c, c + nc);
-    Microsoft::Quantum::Simulator::get(id)->CExp(bv, phi, cv, qv);
-}
-    
-// measurements
-MICROSOFT_QUANTUM_DECL unsigned M(_In_ unsigned id, _In_ unsigned q)
-{
-    return (unsigned)Microsoft::Quantum::Simulator::get(id)->M(q);
-}
-MICROSOFT_QUANTUM_DECL unsigned Measure(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) unsigned* b, _In_reads_(n) unsigned* q)
-{
-    std::vector<Gates::Basis> bv;
-    for (unsigned i = 0; i < n; ++i)
-        bv.push_back(static_cast<Gates::Basis>(*(b + i)));
-    std::vector<unsigned> qv(q, q + n);
-    return (unsigned)Microsoft::Quantum::Simulator::get(id)->Measure(bv, qv);
-}
-    
-// apply permutation of basis states to the wave function
-MICROSOFT_QUANTUM_DECL void PermuteBasis(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ std::size_t table_size,
-    _In_reads_(table_size) std::size_t *permutation_table)
-{
-    const std::vector<unsigned> qs(q, q + n);
-    Microsoft::Quantum::Simulator::get(id)->permuteBasis(qs, table_size, permutation_table, false);
-}
-MICROSOFT_QUANTUM_DECL void AdjPermuteBasis(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ std::size_t table_size,
-    _In_reads_(table_size) std::size_t *permutation_table)
-{
-    const std::vector<unsigned> qs(q, q + n);
-    Microsoft::Quantum::Simulator::get(id)->permuteBasis(qs, table_size, permutation_table, true);
-}
+    // rotations
 
+    MICROSOFT_QUANTUM_DECL void R(_In_ unsigned id, _In_ unsigned b, _In_ double phi, _In_ unsigned q)
+    {
+        Microsoft::Quantum::Simulator::get(id)->R(static_cast<Gates::Basis>(b), phi, q);
+    }
 
-// dump wavefunction to given callback until callback returns false
-MICROSOFT_QUANTUM_DECL void Dump(_In_ unsigned id, _In_ bool (*callback)(size_t, double, double))
-{
-    Microsoft::Quantum::Simulator::get(id)->dump(callback);
-}
+    // multi-controlled rotations
+    MICROSOFT_QUANTUM_DECL void MCR(
+        _In_ unsigned id,
+        _In_ unsigned b,
+        _In_ double phi,
+        _In_ unsigned nc,
+        _In_reads_(nc) unsigned* c,
+        _In_ unsigned q)
+    {
+        std::vector<unsigned> cv(c, c + nc);
+        Microsoft::Quantum::Simulator::get(id)->CR(static_cast<Gates::Basis>(b), phi, cv, q);
+    }
 
-// dump the wavefunction of the subset of qubits to the given callback returns false
-MICROSOFT_QUANTUM_DECL bool DumpQubits(_In_ unsigned id, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ bool(*callback)(size_t, double, double))
-{
-    std::vector<unsigned> qs(q, q + n);
-    return Microsoft::Quantum::Simulator::get(id)->dumpQubits(qs, callback);
-}
+    // Exponential of Pauli operators
+    MICROSOFT_QUANTUM_DECL void Exp(
+        _In_ unsigned id,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* b,
+        _In_ double phi,
+        _In_reads_(n) unsigned* q)
+    {
+        std::vector<Gates::Basis> bv;
+        for (unsigned i = 0; i < n; ++i)
+            bv.push_back(static_cast<Gates::Basis>(*(b + i)));
+        std::vector<unsigned> qv(q, q + n);
+        Microsoft::Quantum::Simulator::get(id)->Exp(bv, phi, qv);
+    }
+    MICROSOFT_QUANTUM_DECL void MCExp(
+        _In_ unsigned id,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* b,
+        _In_ double phi,
+        _In_ unsigned nc,
+        _In_reads_(nc) unsigned* c,
+        _In_reads_(n) unsigned* q)
+    {
+        std::vector<Gates::Basis> bv;
+        for (unsigned i = 0; i < n; ++i)
+            bv.push_back(static_cast<Gates::Basis>(*(b + i)));
+        std::vector<unsigned> qv(q, q + n);
+        std::vector<unsigned> cv(c, c + nc);
+        Microsoft::Quantum::Simulator::get(id)->CExp(bv, phi, cv, qv);
+    }
 
-// dump the list of logical qubit ids to given callback
-MICROSOFT_QUANTUM_DECL void DumpIds(_In_ unsigned id, _In_ void(*callback)(unsigned))
-{
-    Microsoft::Quantum::Simulator::get(id)->dumpIds(callback);
-}
+    // measurements
+    MICROSOFT_QUANTUM_DECL unsigned M(_In_ unsigned id, _In_ unsigned q)
+    {
+        return (unsigned)Microsoft::Quantum::Simulator::get(id)->M(q);
+    }
+    MICROSOFT_QUANTUM_DECL unsigned Measure(
+        _In_ unsigned id,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* b,
+        _In_reads_(n) unsigned* q)
+    {
+        std::vector<Gates::Basis> bv;
+        for (unsigned i = 0; i < n; ++i)
+            bv.push_back(static_cast<Gates::Basis>(*(b + i)));
+        std::vector<unsigned> qv(q, q + n);
+        return (unsigned)Microsoft::Quantum::Simulator::get(id)->Measure(bv, qv);
+    }
 
+    // apply permutation of basis states to the wave function
+    MICROSOFT_QUANTUM_DECL void PermuteBasis(
+        _In_ unsigned id,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* q,
+        _In_ std::size_t table_size,
+        _In_reads_(table_size) std::size_t* permutation_table)
+    {
+        const std::vector<unsigned> qs(q, q + n);
+        Microsoft::Quantum::Simulator::get(id)->permuteBasis(qs, table_size, permutation_table, false);
+    }
+    MICROSOFT_QUANTUM_DECL void AdjPermuteBasis(
+        _In_ unsigned id,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* q,
+        _In_ std::size_t table_size,
+        _In_reads_(table_size) std::size_t* permutation_table)
+    {
+        const std::vector<unsigned> qs(q, q + n);
+        Microsoft::Quantum::Simulator::get(id)->permuteBasis(qs, table_size, permutation_table, true);
+    }
+
+    // dump wavefunction to given callback until callback returns false
+    MICROSOFT_QUANTUM_DECL void Dump(_In_ unsigned id, _In_ bool (*callback)(size_t, double, double))
+    {
+        Microsoft::Quantum::Simulator::get(id)->dump(callback);
+    }
+
+    // dump the wavefunction of the subset of qubits to the given callback returns false
+    MICROSOFT_QUANTUM_DECL bool DumpQubits(
+        _In_ unsigned id,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* q,
+        _In_ bool (*callback)(size_t, double, double))
+    {
+        std::vector<unsigned> qs(q, q + n);
+        return Microsoft::Quantum::Simulator::get(id)->dumpQubits(qs, callback);
+    }
+
+    // dump the list of logical qubit ids to given callback
+    MICROSOFT_QUANTUM_DECL void DumpIds(_In_ unsigned id, _In_ void (*callback)(unsigned))
+    {
+        Microsoft::Quantum::Simulator::get(id)->dumpIds(callback);
+    }
 }

--- a/src/Simulation/Native/src/simulator/capi.hpp
+++ b/src/Simulation/Native/src/simulator/capi.hpp
@@ -12,63 +12,102 @@
 #define _In_reads_(n)
 #endif
 
-extern "C" {
-// non-quantum
+extern "C"
+{
+    // non-quantum
 
-MICROSOFT_QUANTUM_DECL unsigned init();
-MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned sid);
-MICROSOFT_QUANTUM_DECL void seed(_In_ unsigned sid, _In_ unsigned s);
-MICROSOFT_QUANTUM_DECL void Dump(_In_ unsigned sid, _In_ bool(*callback)(size_t, double, double));
-MICROSOFT_QUANTUM_DECL bool DumpQubits(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ bool(*callback)(size_t, double, double));
-MICROSOFT_QUANTUM_DECL void DumpIds(_In_ unsigned sid, _In_ void(*callback)(unsigned));
+    MICROSOFT_QUANTUM_DECL unsigned init();
+    MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned sid);
+    MICROSOFT_QUANTUM_DECL void seed(_In_ unsigned sid, _In_ unsigned s);
+    MICROSOFT_QUANTUM_DECL void Dump(_In_ unsigned sid, _In_ bool (*callback)(size_t, double, double));
+    MICROSOFT_QUANTUM_DECL bool DumpQubits(
+        _In_ unsigned sid,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* q,
+        _In_ bool (*callback)(size_t, double, double));
+    MICROSOFT_QUANTUM_DECL void DumpIds(_In_ unsigned sid, _In_ void (*callback)(unsigned));
 
-MICROSOFT_QUANTUM_DECL std::size_t random_choice(_In_ unsigned sid, _In_ std::size_t n, _In_reads_(n) double* p);
+    MICROSOFT_QUANTUM_DECL std::size_t random_choice(_In_ unsigned sid, _In_ std::size_t n, _In_reads_(n) double* p);
 
-MICROSOFT_QUANTUM_DECL double JointEnsembleProbability(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) int* b, _In_reads_(n) unsigned* q);
+    MICROSOFT_QUANTUM_DECL double JointEnsembleProbability(
+        _In_ unsigned sid,
+        _In_ unsigned n,
+        _In_reads_(n) int* b,
+        _In_reads_(n) unsigned* q);
 
-// allocate and release
-MICROSOFT_QUANTUM_DECL void allocateQubit(_In_ unsigned sid, _In_ unsigned qid);
-MICROSOFT_QUANTUM_DECL void release(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL unsigned num_qubits(_In_ unsigned sid);
+    // allocate and release
+    MICROSOFT_QUANTUM_DECL void allocateQubit(_In_ unsigned sid, _In_ unsigned qid);
+    MICROSOFT_QUANTUM_DECL void release(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL unsigned num_qubits(_In_ unsigned sid);
 
-// single-qubit gates
-MICROSOFT_QUANTUM_DECL void X(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void Y(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void Z(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void H(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void S(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void T(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void AdjS(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void AdjT(_In_ unsigned sid, _In_ unsigned q);
+    // single-qubit gates
+    MICROSOFT_QUANTUM_DECL void X(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void Y(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void Z(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void H(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void S(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void T(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void AdjS(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void AdjT(_In_ unsigned sid, _In_ unsigned q);
 
+    // multi-controlled single-qubit gates
 
-// multi-controlled single-qubit gates
+    MICROSOFT_QUANTUM_DECL void MCX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void MCY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void MCZ(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void MCH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void MCS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void MCT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL void MCAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
 
-MICROSOFT_QUANTUM_DECL void MCX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void MCY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void MCZ(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void MCH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void MCS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void MCT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL void MCAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    // rotations
+    MICROSOFT_QUANTUM_DECL void R(_In_ unsigned sid, _In_ unsigned b, _In_ double phi, _In_ unsigned q);
 
-// rotations
-MICROSOFT_QUANTUM_DECL void R(_In_ unsigned sid, _In_ unsigned b, _In_ double phi, _In_ unsigned q);
+    // multi-controlled rotations
+    MICROSOFT_QUANTUM_DECL void MCR(
+        _In_ unsigned sid,
+        _In_ unsigned b,
+        _In_ double phi,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* c,
+        _In_ unsigned q);
 
-// multi-controlled rotations
-MICROSOFT_QUANTUM_DECL void MCR(_In_ unsigned sid, _In_ unsigned b, _In_ double phi, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
+    // Exponential of Pauli operators
+    MICROSOFT_QUANTUM_DECL void Exp(
+        _In_ unsigned sid,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* b,
+        _In_ double phi,
+        _In_reads_(n) unsigned* q);
+    MICROSOFT_QUANTUM_DECL void MCExp(
+        _In_ unsigned sid,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* b,
+        _In_ double phi,
+        _In_ unsigned nc,
+        _In_reads_(nc) unsigned* cs,
+        _In_reads_(n) unsigned* q);
 
-// Exponential of Pauli operators
-MICROSOFT_QUANTUM_DECL void Exp(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* b, _In_ double phi, _In_reads_(n) unsigned* q);
-MICROSOFT_QUANTUM_DECL void MCExp(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* b, _In_ double phi, _In_ unsigned nc, _In_reads_(nc) unsigned* cs, _In_reads_(n) unsigned* q);
+    // measurements
+    MICROSOFT_QUANTUM_DECL unsigned M(_In_ unsigned sid, _In_ unsigned q);
+    MICROSOFT_QUANTUM_DECL unsigned Measure(
+        _In_ unsigned sid,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* b,
+        _In_reads_(n) unsigned* q);
 
-// measurements
-MICROSOFT_QUANTUM_DECL unsigned M(_In_ unsigned sid, _In_ unsigned q);
-MICROSOFT_QUANTUM_DECL unsigned Measure(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* b, _In_reads_(n) unsigned* q);
-
-// permutation oracle emulation
-MICROSOFT_QUANTUM_DECL void PermuteBasis(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ std::size_t table_size, _In_reads_(table_size) std::size_t *permutation_table);
-MICROSOFT_QUANTUM_DECL void AdjPermuteBasis(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ std::size_t table_size, _In_reads_(table_size) std::size_t *permutation_table);
-
+    // permutation oracle emulation
+    MICROSOFT_QUANTUM_DECL void PermuteBasis(
+        _In_ unsigned sid,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* q,
+        _In_ std::size_t table_size,
+        _In_reads_(table_size) std::size_t* permutation_table);
+    MICROSOFT_QUANTUM_DECL void AdjPermuteBasis(
+        _In_ unsigned sid,
+        _In_ unsigned n,
+        _In_reads_(n) unsigned* q,
+        _In_ std::size_t table_size,
+        _In_reads_(table_size) std::size_t* permutation_table);
 }

--- a/src/Simulation/Native/src/simulator/capi_test.cpp
+++ b/src/Simulation/Native/src/simulator/capi_test.cpp
@@ -2,40 +2,39 @@
 // Licensed under the MIT License.
 
 #include "simulator/capi.hpp"
+#include <array>
 #include <cassert>
 #include <cmath>
+#include <complex>
 #include <iostream>
 #include <vector>
-#include <complex>
-#include <array>
 
 // some convenience functions
 
 void CX(unsigned sim_id, unsigned c, unsigned q)
 {
-    MCX(sim_id,1,&c,q);
+    MCX(sim_id, 1, &c, q);
 }
 
 void CZ(unsigned sim_id, unsigned c, unsigned q)
 {
-    MCZ(sim_id,1,&c,q);
+    MCZ(sim_id, 1, &c, q);
 }
 
 void Ry(unsigned sim_id, double phi, unsigned q)
 {
-    R(sim_id,3,phi,q);
+    R(sim_id, 3, phi, q);
 }
 
 void CRz(unsigned sim_id, double phi, unsigned c, unsigned q)
 {
-    MCR(sim_id,2,phi,1,&c,q);
+    MCR(sim_id, 2, phi, 1, &c, q);
 }
 
 void CRx(unsigned sim_id, double phi, unsigned c, unsigned q)
 {
-    MCR(sim_id,1,phi,1,&c,q);
+    MCR(sim_id, 1, phi, 1, &c, q);
 }
-
 
 void dump(unsigned sim_id, const char* label)
 {
@@ -45,18 +44,18 @@ void dump(unsigned sim_id, const char* label)
     };
     auto sim_ids_callback = [](unsigned idx) { std::cout << idx << " "; };
 
-    std::cout << label << "\n" << "wave function for ids (least to most significant): ["; 
+    std::cout << label << "\n"
+              << "wave function for ids (least to most significant): [";
     DumpIds(sim_id, sim_ids_callback);
     std::cout << "]\n";
     Dump(sim_id, dump_callback);
 }
 
-
 void test_teleport()
 {
     auto sim_id = init();
 
-    unsigned qs[] = { 0, 1, 2 };
+    unsigned qs[] = {0, 1, 2};
 
     dump(sim_id, "teleport-pre.txt");
 
@@ -87,7 +86,7 @@ void test_teleport()
     // check teleportation success
     R(sim_id, 3, (-1.1), 0);
     H(sim_id, 0);
-    assert(M(sim_id, 0)==false);
+    assert(M(sim_id, 0) == false);
 
     dump(sim_id, "teleport-end.txt");
 
@@ -136,21 +135,20 @@ void test_allocate()
 {
     auto sim_id = init();
 
-    allocateQubit(sim_id,0);
-    allocateQubit(sim_id,1);
-    allocateQubit(sim_id,2);
-    release(sim_id,1);
-    allocateQubit(sim_id,1);
+    allocateQubit(sim_id, 0);
+    allocateQubit(sim_id, 1);
+    allocateQubit(sim_id, 2);
+    release(sim_id, 1);
+    allocateQubit(sim_id, 1);
 
     assert(num_qubits(sim_id) == 3);
 
-    release(sim_id,0);
-    release(sim_id,1);
-    release(sim_id,2);
+    release(sim_id, 0);
+    release(sim_id, 1);
+    release(sim_id, 2);
 
     assert(num_qubits(sim_id) == 0);
     destroy(sim_id);
-
 }
 /*
 // We can't use a lambda with captures to pass to a callback with __stdcall signature,
@@ -216,7 +214,7 @@ void test_dump()
   qs[1] = 1;
   assert(sim_DumpQubits(sim_id, 2, qs, check_state));
 
-  // check that when we ask for a different order of all the qubits, 
+  // check that when we ask for a different order of all the qubits,
   // the corresponding basis state is correct
   _state = wavefunction_type{ 0., 0., 0., 0., 0., 0., 1., 0. };
   qs[0] = 2;
@@ -318,7 +316,8 @@ void test_permute_basis()
     constexpr auto nqubits = 4u;
     constexpr auto nstates = 1ul << nqubits;
     std::size_t table[nstates];
-    for (std::size_t i = 0; i < nstates; ++i) {
+    for (std::size_t i = 0; i < nstates; ++i)
+    {
         table[i] = permutation(i);
     }
 
@@ -353,7 +352,7 @@ void test_permute_basis()
     assert(M(sim_id, 2) == false);
     assert(M(sim_id, 3) == false);
     assert(M(sim_id, 4) == false);
- 
+
     for (unsigned i = 0; i < nqubits + 1; ++i)
         release(sim_id, i);
     destroy(sim_id);
@@ -372,7 +371,8 @@ void test_permute_basis_adjoint()
     constexpr auto nqubits = 4u;
     constexpr auto nstates = 1ul << nqubits;
     std::size_t table[nstates];
-    for (std::size_t i = 0; i < nstates; ++i) {
+    for (std::size_t i = 0; i < nstates; ++i)
+    {
         table[i] = permutation(i);
     }
 

--- a/src/Simulation/Native/src/simulator/factory.cpp
+++ b/src/Simulation/Native/src/simulator/factory.cpp
@@ -9,99 +9,97 @@
 
 namespace Microsoft
 {
-  namespace Quantum
-  {
-    namespace SimulatorGeneric
-    {
-      Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned);
-    }
-    namespace SimulatorAVX
-    {
-      Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned);
-    }
-    namespace SimulatorAVX2
-    {
-      Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned);
-    }
-    namespace SimulatorAVX512
-    {
-      Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned);
-    }
-  }
+namespace Quantum
+{
+namespace SimulatorGeneric
+{
+Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned);
 }
+namespace SimulatorAVX
+{
+Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned);
+}
+namespace SimulatorAVX2
+{
+Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned);
+}
+namespace SimulatorAVX512
+{
+Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned);
+}
+} // namespace Quantum
+} // namespace Microsoft
 
 namespace Microsoft
 {
-  namespace Quantum
-  {
-    namespace Simulator
+namespace Quantum
+{
+namespace Simulator
+{
+std::shared_mutex _mutex;
+std::vector<std::shared_ptr<SimulatorInterface>> _psis;
+
+SimulatorInterface* createSimulator(unsigned maxlocal)
+{
+    if (haveAVX512())
     {
-      std::shared_mutex _mutex;
-      std::vector<std::shared_ptr<SimulatorInterface>> _psis;
-
-     SimulatorInterface* createSimulator(unsigned maxlocal)
-     {
-       if (haveAVX512())
-        {
-            return SimulatorAVX512::createSimulator(maxlocal);
-        }
-        else if (haveFMA() && haveAVX2())
-        {
-           return SimulatorAVX2::createSimulator(maxlocal);
-        }
-        else if(haveAVX())
-        {
-           return SimulatorAVX::createSimulator(maxlocal);
-        }
-        else
-        {
-           return SimulatorGeneric::createSimulator(maxlocal);
-        }
-
-      }
-
-      MICROSOFT_QUANTUM_DECL unsigned create(unsigned maxlocal)
-      {
-        std::lock_guard<std::shared_mutex> lock(_mutex);
-
-        size_t emptySlot = -1;
-        for (auto const& s : _psis) 
-        {
-            if (s == NULL) 
-            {
-                emptySlot = &s - &_psis[0];
-                break;
-            }
-        }
-
-        if (emptySlot == -1) 
-        {
-            _psis.push_back(std::shared_ptr<SimulatorInterface>(createSimulator(maxlocal)));
-            emptySlot = _psis.size() - 1;
-        }
-        else 
-        {
-            _psis[emptySlot] = std::shared_ptr<SimulatorInterface>(createSimulator(maxlocal));
-        }
-
-        return static_cast<unsigned>(emptySlot);
-      }
-
-      MICROSOFT_QUANTUM_DECL void destroy(unsigned id)
-      {
-        std::lock_guard<std::shared_mutex> lock(_mutex);
-
-        _psis[id].reset();
-      }
-
-      MICROSOFT_QUANTUM_DECL std::shared_ptr<SimulatorInterface>& get(unsigned id)
-      {
-        std::shared_lock<std::shared_mutex> shared_lock(_mutex);
-
-        return _psis[id];
-      }
-
+        return SimulatorAVX512::createSimulator(maxlocal);
     }
-  }
+    else if (haveFMA() && haveAVX2())
+    {
+        return SimulatorAVX2::createSimulator(maxlocal);
+    }
+    else if (haveAVX())
+    {
+        return SimulatorAVX::createSimulator(maxlocal);
+    }
+    else
+    {
+        return SimulatorGeneric::createSimulator(maxlocal);
+    }
 }
 
+MICROSOFT_QUANTUM_DECL unsigned create(unsigned maxlocal)
+{
+    std::lock_guard<std::shared_mutex> lock(_mutex);
+
+    size_t emptySlot = -1;
+    for (auto const& s : _psis)
+    {
+        if (s == NULL)
+        {
+            emptySlot = &s - &_psis[0];
+            break;
+        }
+    }
+
+    if (emptySlot == -1)
+    {
+        _psis.push_back(std::shared_ptr<SimulatorInterface>(createSimulator(maxlocal)));
+        emptySlot = _psis.size() - 1;
+    }
+    else
+    {
+        _psis[emptySlot] = std::shared_ptr<SimulatorInterface>(createSimulator(maxlocal));
+    }
+
+    return static_cast<unsigned>(emptySlot);
+}
+
+MICROSOFT_QUANTUM_DECL void destroy(unsigned id)
+{
+    std::lock_guard<std::shared_mutex> lock(_mutex);
+
+    _psis[id].reset();
+}
+
+MICROSOFT_QUANTUM_DECL std::shared_ptr<SimulatorInterface>& get(unsigned id)
+{
+    std::shared_lock<std::shared_mutex> shared_lock(_mutex);
+
+    return _psis[id];
+}
+
+} // namespace Simulator
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/factory.hpp
+++ b/src/Simulation/Native/src/simulator/factory.hpp
@@ -6,13 +6,13 @@
 
 namespace Microsoft
 {
-  namespace Quantum
-  {
-    namespace Simulator
-    {
-      MICROSOFT_QUANTUM_DECL unsigned create(unsigned =0u);
-      MICROSOFT_QUANTUM_DECL void destroy(unsigned);
-      MICROSOFT_QUANTUM_DECL std::shared_ptr<SimulatorInterface>& get(unsigned);
-    }
-  }
-}
+namespace Quantum
+{
+namespace Simulator
+{
+MICROSOFT_QUANTUM_DECL unsigned create(unsigned = 0u);
+MICROSOFT_QUANTUM_DECL void destroy(unsigned);
+MICROSOFT_QUANTUM_DECL std::shared_ptr<SimulatorInterface>& get(unsigned);
+} // namespace Simulator
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/factory_test.cpp
+++ b/src/Simulation/Native/src/simulator/factory_test.cpp
@@ -8,10 +8,10 @@ using namespace Microsoft::Quantum::Simulator;
 
 int main(int argc, char** argv)
 {
-  auto sim = get(create());
+    auto sim = get(create());
 
-  unsigned q=0; // qubit number
-  sim->allocateQubit(q);
+    unsigned q = 0; // qubit number
+    sim->allocateQubit(q);
 
     // produce random bits using H gates
     for (int i = 0; i < 100; i++)
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
         sim->H(q);
         int result = sim->M(q);
 
-            std::cout << result << std::endl;
+        std::cout << result << std::endl;
     }
 
     sim->release(q);

--- a/src/Simulation/Native/src/simulator/gates.hpp
+++ b/src/Simulation/Native/src/simulator/gates.hpp
@@ -16,453 +16,475 @@
 
 namespace Microsoft
 {
-    namespace Quantum
+namespace Quantum
+{
+namespace SIMULATOR
+{
+namespace Gates
+{
+
+/// a type for runtime basis specification
+enum Basis
+{
+    PauliI = 0,
+    PauliX = 1,
+    PauliY = 3,
+    PauliZ = 2
+};
+
+/// a general one qubit gate, storing the qubit number
+class OneQubitGate
+{
+  public:
+    OneQubitGate(unsigned q)
+        : qubit_(q)
     {
-        namespace SIMULATOR
-        {
-            namespace Gates
-            {
-
-                /// a type for runtime basis specification
-                enum Basis
-                {
-                    PauliI = 0,
-                    PauliX = 1,
-                    PauliY = 3,
-                    PauliZ = 2
-                };
-
-                /// a general one qubit gate, storing the qubit number
-                class OneQubitGate
-                {
-                public:
-                    OneQubitGate(unsigned q) : qubit_(q)
-                    {
-                    }
-                    unsigned qubit() const
-                    {
-                        return qubit_;
-                    }
-
-                    virtual TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        throw "Calling overriden function";
-                    }
-
-                private:
-                    unsigned qubit_;
-                };
-
-                /// a general one qubit roitation gate, storing the qubit number and angle
-                class RotationGate : public OneQubitGate
-                {
-                public:
-                    RotationGate(double phi, unsigned q) : OneQubitGate(q), angle_(phi)
-                    {
-                    }
-                    double angle() const
-                    {
-                        return angle_;
-                    }
-
-                private:
-                    double angle_;
-                };
-
-                /// The Pauli X gate
-                class X : public OneQubitGate
-                {
-                public:
-                    X(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "X";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        RealType mat[2][2] = { {0., 1.}, {1., 0.} };
-                        return TinyMatrix<RealType, 2>(mat);
-                    }
-                };
-
-                /// The Pauli Y gate
-                class Y : public OneQubitGate
-                {
-                public:
-                    Y(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Y";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        val_t mat[2][2] = { {val_t(0.), val_t(0.)}, {val_t(0.), val_t(0.)} };
-                        mat[0][1] = val_t(0., -1.);
-                        mat[1][0] = val_t(0., 1.);
-                        return TinyMatrix<val_t, 2>(mat);
-                    }
-                };
-
-                /// The Pauli Z gate
-                class Z : public OneQubitGate
-                {
-                public:
-                    Z(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Z";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        RealType diag[2] = { 1., -1. };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<RealType, 2>(diag));
-                    }
-                };
-
-                /// The Hadamard gate
-                class H : public OneQubitGate
-                {
-                public:
-                    H(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "H";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        RealType r = std::sqrt(0.5);
-                        RealType mat[2][2] = { {r, r}, {r, -r} };
-                        return TinyMatrix<ComplexType, 2>(TinyMatrix<RealType, 2, 2>(mat));
-                    }
-                };
-
-                /// The Y-version of a Hadamard gate
-                class HY : public OneQubitGate
-                {
-                public:
-                    HY(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "HY";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        ComplexType r(std::sqrt(0.5), 0.);
-                        ComplexType i(0., std::sqrt(0.5));
-                        ComplexType mat[2][2] = { {r, r}, {i, -i} };
-                        return TinyMatrix<ComplexType, 2>(mat);
-                    }
-                };
-
-                /// The adjoint Y-version of a Hadamard gate
-                class AdjHY : public OneQubitGate
-                {
-                public:
-                    AdjHY(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "AdjHY";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        ComplexType r(std::sqrt(0.5), 0.);
-                        ComplexType i(0., std::sqrt(0.5));
-                        ComplexType mat[2][2] = { {r, -i}, {r, i} };
-                        return TinyMatrix<ComplexType, 2>(mat);
-                    }
-                };
-
-                /// The S (phase) gate
-                class S : public OneQubitGate
-                {
-                public:
-                    S(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "S";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        val_t diag[2] = { val_t(1.), val_t(0., 1.) };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
-                    }
-                };
-
-                /// The adjoint of the S (phase) gate
-                class AdjS : public OneQubitGate
-                {
-                public:
-                    AdjS(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "AdjS";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        val_t diag[2] = { val_t(1.), val_t(0., -1.) };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
-                    }
-                };
-
-                /// The T (pi/8) gate
-                class T : public OneQubitGate
-                {
-                public:
-                    T(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "T";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        RealType r = std::sqrt(0.5);
-                        val_t diag[2] = { val_t(1.), val_t(r, r) };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
-                    }
-                };
-
-                /// The T (pi/8) gate
-                class AdjT : public OneQubitGate
-                {
-                public:
-                    AdjT(unsigned q) : OneQubitGate(q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "AdjT";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        RealType r = std::sqrt(0.5);
-                        val_t diag[2] = { val_t(1.), val_t(r, -r) };
-                        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
-                    }
-                };
-
-                /// The G gate
-                class G : public RotationGate
-                {
-                public:
-                    G(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "G";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        DiagMatrix<ComplexType, 2> d;
-                        ComplexType arg(0., 0.5 * angle());
-                        d(0, 0) = d(1, 1) = std::exp(-arg);
-                        return TinyMatrix<ComplexType, 2>(d);
-                    }
-                };
-
-                /// The Rx gate
-                class Rx : public RotationGate
-                {
-                public:
-                    Rx(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Rx";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        using val_t = ComplexType;
-                        val_t s(0., -std::sin(0.5 * angle()));
-                        val_t c = std::cos(0.5 * angle());
-                        val_t mat[2][2] = { {c, s}, {s, c} };
-                        return TinyMatrix<val_t, 2>(mat);
-                    }
-                };
-
-                /// The Ry gate
-                class Ry : public RotationGate
-                {
-                public:
-                    Ry(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Ry";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        RealType s = std::sin(0.5 * angle());
-                        RealType c = std::cos(0.5 * angle());
-                        RealType mat[2][2] = { {c, -s}, {s, c} };
-                        ;
-                        return TinyMatrix<ComplexType, 2>(TinyMatrix<RealType, 2>(mat));
-                    }
-                };
-
-                /// The Rz gate
-                class Rz : public RotationGate
-                {
-                public:
-                    Rz(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "Rz";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        DiagMatrix<ComplexType, 2> d;
-                        ComplexType arg(0., 0.5 * angle());
-                        d(0, 0) = std::exp(-arg);
-                        d(1, 1) = std::exp(arg);
-                        return TinyMatrix<ComplexType, 2>(d);
-                    }
-                };
-
-                /// The R1 gate
-                class R1 : public RotationGate
-                {
-                public:
-                    R1(RealType phi, unsigned q) : RotationGate(phi, q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "R1";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        DiagMatrix<ComplexType, 2> d;
-                        ComplexType arg(0., angle());
-                        d(0, 0) = 1.;
-                        d(1, 1) = std::exp(-arg);
-                        return TinyMatrix<ComplexType, 2>(d);
-                    }
-                };
-
-                /// The R1 gate
-                class R1Frac : public R1
-                {
-                public:
-                    R1Frac(int k, int n, unsigned q) : R1(M_PI* static_cast<RealType>(k) / static_cast<RealType>(1ll << n), q)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "R1Frac";
-                    }
-                };
-
-                /// The R gate for rotation around an arbitrary basis
-                class R : public RotationGate
-                {
-                public:
-                    R(Basis b, RealType phi, unsigned q) : RotationGate(phi, q), b_(b)
-                    {
-                    }
-
-                    std::string name() const
-                    {
-                        return "R";
-                    }
-
-                    TinyMatrix<ComplexType, 2> matrix() const
-                    {
-                        switch (b_)
-                        {
-                        case PauliI:
-                            return G(angle(), qubit()).matrix();
-                            break;
-                        case PauliX:
-                            return Rx(angle(), qubit()).matrix();
-                            break;
-                        case PauliY:
-                            return Ry(angle(), qubit()).matrix();
-                            break;
-                        case PauliZ:
-                            return Rz(angle(), qubit()).matrix();
-                            break;
-                        default:
-                            assert(false);
-                        }
-                        // dummy return
-                        return TinyMatrix<ComplexType, 2>();
-                    }
-
-                private:
-                    Basis b_;
-                };
-
-                class RFrac : public R
-                {
-                public:
-                    RFrac(Basis b, int k, int n, unsigned q) : R(b, -2. * M_PI * static_cast<RealType>(k) / static_cast<RealType>(1ll << n), q)
-                    {
-                    }
-                    std::string name() const
-                    {
-                        return "RFrac";
-                    }
-                };
-            }
-        }
     }
-}
+    unsigned qubit() const
+    {
+        return qubit_;
+    }
+
+    virtual TinyMatrix<ComplexType, 2> matrix() const
+    {
+        throw "Calling overriden function";
+    }
+
+  private:
+    unsigned qubit_;
+};
+
+/// a general one qubit roitation gate, storing the qubit number and angle
+class RotationGate : public OneQubitGate
+{
+  public:
+    RotationGate(double phi, unsigned q)
+        : OneQubitGate(q)
+        , angle_(phi)
+    {
+    }
+    double angle() const
+    {
+        return angle_;
+    }
+
+  private:
+    double angle_;
+};
+
+/// The Pauli X gate
+class X : public OneQubitGate
+{
+  public:
+    X(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "X";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        RealType mat[2][2] = {{0., 1.}, {1., 0.}};
+        return TinyMatrix<RealType, 2>(mat);
+    }
+};
+
+/// The Pauli Y gate
+class Y : public OneQubitGate
+{
+  public:
+    Y(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Y";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        val_t mat[2][2] = {{val_t(0.), val_t(0.)}, {val_t(0.), val_t(0.)}};
+        mat[0][1] = val_t(0., -1.);
+        mat[1][0] = val_t(0., 1.);
+        return TinyMatrix<val_t, 2>(mat);
+    }
+};
+
+/// The Pauli Z gate
+class Z : public OneQubitGate
+{
+  public:
+    Z(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Z";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        RealType diag[2] = {1., -1.};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<RealType, 2>(diag));
+    }
+};
+
+/// The Hadamard gate
+class H : public OneQubitGate
+{
+  public:
+    H(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "H";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        RealType r = std::sqrt(0.5);
+        RealType mat[2][2] = {{r, r}, {r, -r}};
+        return TinyMatrix<ComplexType, 2>(TinyMatrix<RealType, 2, 2>(mat));
+    }
+};
+
+/// The Y-version of a Hadamard gate
+class HY : public OneQubitGate
+{
+  public:
+    HY(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "HY";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        ComplexType r(std::sqrt(0.5), 0.);
+        ComplexType i(0., std::sqrt(0.5));
+        ComplexType mat[2][2] = {{r, r}, {i, -i}};
+        return TinyMatrix<ComplexType, 2>(mat);
+    }
+};
+
+/// The adjoint Y-version of a Hadamard gate
+class AdjHY : public OneQubitGate
+{
+  public:
+    AdjHY(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "AdjHY";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        ComplexType r(std::sqrt(0.5), 0.);
+        ComplexType i(0., std::sqrt(0.5));
+        ComplexType mat[2][2] = {{r, -i}, {r, i}};
+        return TinyMatrix<ComplexType, 2>(mat);
+    }
+};
+
+/// The S (phase) gate
+class S : public OneQubitGate
+{
+  public:
+    S(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "S";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        val_t diag[2] = {val_t(1.), val_t(0., 1.)};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
+    }
+};
+
+/// The adjoint of the S (phase) gate
+class AdjS : public OneQubitGate
+{
+  public:
+    AdjS(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "AdjS";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        val_t diag[2] = {val_t(1.), val_t(0., -1.)};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
+    }
+};
+
+/// The T (pi/8) gate
+class T : public OneQubitGate
+{
+  public:
+    T(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "T";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        RealType r = std::sqrt(0.5);
+        val_t diag[2] = {val_t(1.), val_t(r, r)};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
+    }
+};
+
+/// The T (pi/8) gate
+class AdjT : public OneQubitGate
+{
+  public:
+    AdjT(unsigned q)
+        : OneQubitGate(q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "AdjT";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        RealType r = std::sqrt(0.5);
+        val_t diag[2] = {val_t(1.), val_t(r, -r)};
+        return TinyMatrix<ComplexType, 2>(DiagMatrix<val_t, 2>(diag));
+    }
+};
+
+/// The G gate
+class G : public RotationGate
+{
+  public:
+    G(RealType phi, unsigned q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "G";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        DiagMatrix<ComplexType, 2> d;
+        ComplexType arg(0., 0.5 * angle());
+        d(0, 0) = d(1, 1) = std::exp(-arg);
+        return TinyMatrix<ComplexType, 2>(d);
+    }
+};
+
+/// The Rx gate
+class Rx : public RotationGate
+{
+  public:
+    Rx(RealType phi, unsigned q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Rx";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        using val_t = ComplexType;
+        val_t s(0., -std::sin(0.5 * angle()));
+        val_t c = std::cos(0.5 * angle());
+        val_t mat[2][2] = {{c, s}, {s, c}};
+        return TinyMatrix<val_t, 2>(mat);
+    }
+};
+
+/// The Ry gate
+class Ry : public RotationGate
+{
+  public:
+    Ry(RealType phi, unsigned q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Ry";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        RealType s = std::sin(0.5 * angle());
+        RealType c = std::cos(0.5 * angle());
+        RealType mat[2][2] = {{c, -s}, {s, c}};
+        ;
+        return TinyMatrix<ComplexType, 2>(TinyMatrix<RealType, 2>(mat));
+    }
+};
+
+/// The Rz gate
+class Rz : public RotationGate
+{
+  public:
+    Rz(RealType phi, unsigned q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "Rz";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        DiagMatrix<ComplexType, 2> d;
+        ComplexType arg(0., 0.5 * angle());
+        d(0, 0) = std::exp(-arg);
+        d(1, 1) = std::exp(arg);
+        return TinyMatrix<ComplexType, 2>(d);
+    }
+};
+
+/// The R1 gate
+class R1 : public RotationGate
+{
+  public:
+    R1(RealType phi, unsigned q)
+        : RotationGate(phi, q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "R1";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        DiagMatrix<ComplexType, 2> d;
+        ComplexType arg(0., angle());
+        d(0, 0) = 1.;
+        d(1, 1) = std::exp(-arg);
+        return TinyMatrix<ComplexType, 2>(d);
+    }
+};
+
+/// The R1 gate
+class R1Frac : public R1
+{
+  public:
+    R1Frac(int k, int n, unsigned q)
+        : R1(M_PI * static_cast<RealType>(k) / static_cast<RealType>(1ll << n), q)
+    {
+    }
+
+    std::string name() const
+    {
+        return "R1Frac";
+    }
+};
+
+/// The R gate for rotation around an arbitrary basis
+class R : public RotationGate
+{
+  public:
+    R(Basis b, RealType phi, unsigned q)
+        : RotationGate(phi, q)
+        , b_(b)
+    {
+    }
+
+    std::string name() const
+    {
+        return "R";
+    }
+
+    TinyMatrix<ComplexType, 2> matrix() const
+    {
+        switch (b_)
+        {
+        case PauliI:
+            return G(angle(), qubit()).matrix();
+            break;
+        case PauliX:
+            return Rx(angle(), qubit()).matrix();
+            break;
+        case PauliY:
+            return Ry(angle(), qubit()).matrix();
+            break;
+        case PauliZ:
+            return Rz(angle(), qubit()).matrix();
+            break;
+        default:
+            assert(false);
+        }
+        // dummy return
+        return TinyMatrix<ComplexType, 2>();
+    }
+
+  private:
+    Basis b_;
+};
+
+class RFrac : public R
+{
+  public:
+    RFrac(Basis b, int k, int n, unsigned q)
+        : R(b, -2. * M_PI * static_cast<RealType>(k) / static_cast<RealType>(1ll << n), q)
+    {
+    }
+    std::string name() const
+    {
+        return "RFrac";
+    }
+};
+} // namespace Gates
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/kernels.hpp
+++ b/src/Simulation/Native/src/simulator/kernels.hpp
@@ -29,20 +29,17 @@ inline std::size_t make_mask(std::vector<unsigned> const& qs)
     return mask;
 }
 
-    
 template <class T, class A>
 void swap(std::vector<T, A>& wfn, unsigned q1, unsigned q2)
 {
-    if (q1 == q2)
-        return;
-    if (q1 > q2)
-        std::swap(q1, q2);
+    if (q1 == q2) return;
+    if (q1 > q2) std::swap(q1, q2);
     std::size_t offset1 = 1ull << q1;
     std::size_t offset2 = 1ull << q2;
 
-    std::size_t maskk = offset1 - 1;  // bits [0...q1-1]
-    std::size_t maskj = ((offset2 >> 1) - 1) ^ maskk;  // bits [q1...q2-2]
-    std::size_t maski = ~((offset2 >> 1) - 1);  // bits [q2-1...]
+    std::size_t maskk = offset1 - 1;                  // bits [0...q1-1]
+    std::size_t maskj = ((offset2 >> 1) - 1) ^ maskk; // bits [q1...q2-2]
+    std::size_t maski = ~((offset2 >> 1) - 1);        // bits [q2-1...]
 
 #ifndef _MSC_VER
 #pragma omp parallel for schedule(static)
@@ -70,18 +67,18 @@ void jointcollapse(std::vector<T, A>& wfn, std::vector<unsigned> const& qs, bool
 // sum up probabilities for all configuratiions where an odd number of selected bits is set
 #pragma omp parallel for schedule(static)
     for (std::intptr_t i = 0; i < static_cast<std::intptr_t>(wfn.size()); i++)
-        if (poppar(i & mask) != val)
-            wfn[i] = 0.;
+        if (poppar(i & mask) != val) wfn[i] = 0.;
 }
 
 template <class T, class A>
-unsigned
-getvalue(std::vector<std::complex<T>, A> const& wfn, unsigned q, double eps = 100. * std::numeric_limits<T>::epsilon())
+unsigned getvalue(
+    std::vector<std::complex<T>, A> const& wfn,
+    unsigned q,
+    double eps = 100. * std::numeric_limits<T>::epsilon())
 {
     std::size_t mask = 1ull << q;
     for (std::size_t i = 0; i < wfn.size(); ++i)
-        if (std::abs(wfn[i]) > eps)
-            return (i & mask ? 1 : 0);
+        if (std::abs(wfn[i]) > eps) return (i & mask ? 1 : 0);
     // dummy return
     return 2;
 }
@@ -109,15 +106,15 @@ void collapse(std::vector<T, A>& wfn, unsigned q, bool val, bool compact = false
         std::size_t state = (val ? mask : 0ul);
 #pragma omp parallel for schedule(static)
         for (std::intptr_t i = 0; i < static_cast<std::intptr_t>(wfn.size()); ++i)
-            if ((i & mask) != state)
-                wfn[i] = 0.;
+            if ((i & mask) != state) wfn[i] = 0.;
     }
 }
 
 template <class T, class A>
-bool isclassical(std::vector<std::complex<T>, A> const& wfn,
-                 std::size_t q,
-                 T eps = 100. * std::numeric_limits<T>::epsilon())
+bool isclassical(
+    std::vector<std::complex<T>, A> const& wfn,
+    std::size_t q,
+    T eps = 100. * std::numeric_limits<T>::epsilon())
 {
     std::size_t offset = 1ull << q;
     bool have0 = false;
@@ -143,8 +140,7 @@ bool isclassical(std::vector<std::complex<T>, A> const& wfn,
     }
 #endif
 
-    if (have0 && have1)
-        return false;
+    if (have0 && have1) return false;
     return true;
 }
 
@@ -158,8 +154,7 @@ double jointprobability(std::vector<T, A> const& wfn, std::vector<unsigned> cons
 // sum up probabilities for all configuratiions where an odd number of selected bits is set
 #pragma omp parallel for schedule(static) reduction(+ : prob)
     for (std::intptr_t i = 0; i < static_cast<std::intptr_t>(wfn.size()); i++)
-        if (poppar(i & mask) == val)
-            prob += std::norm(wfn[i]);
+        if (poppar(i & mask) == val) prob += std::norm(wfn[i]);
     return prob;
 }
 
@@ -190,8 +185,7 @@ double probability(std::vector<std::complex<T>, A> const& wfn, unsigned q)
 inline bool isDiagonal(std::vector<Gates::Basis> const& b)
 {
     for (auto x : b)
-        if (x == Gates::PauliX || x == Gates::PauliY)
-            return false;
+        if (x == Gates::PauliX || x == Gates::PauliY) return false;
     return true;
 }
 
@@ -202,26 +196,27 @@ inline ComplexType iExp(int power)
     int p = ((power % 4) + 8) % 4;
     switch (p)
     {
-        case 0:
-            return 1;
-        case 1:
-            return 1i;
-        case 2:
-            return -1;
-        case 3:
-            return -1i;
-        default:
-            assert(false);
+    case 0:
+        return 1;
+    case 1:
+        return 1i;
+    case 2:
+        return -1;
+    case 3:
+        return -1i;
+    default:
+        assert(false);
     }
     return 0;
 }
 
 template <class T, class A>
-void apply_controlled_exp(std::vector<std::complex<T>, A>& wfn,
-                          std::vector<Gates::Basis> const& b,
-                          double phi,
-                          std::vector<unsigned> const& cs,
-                          std::vector<unsigned> const& qs)
+void apply_controlled_exp(
+    std::vector<std::complex<T>, A>& wfn,
+    std::vector<Gates::Basis> const& b,
+    double phi,
+    std::vector<unsigned> const& cs,
+    std::vector<unsigned> const& qs)
 {
     assert(qs.size() > 1);
     unsigned lowest = *std::min_element(qs.begin(), qs.end());
@@ -233,15 +228,14 @@ void apply_controlled_exp(std::vector<std::complex<T>, A>& wfn,
     if (isDiagonal(b))
     {
         std::size_t mask = make_mask(qs);
-        ComplexType phase = std::exp(ComplexType(0.,-phi));
+        ComplexType phase = std::exp(ComplexType(0., -phi));
 
 #pragma omp parallel for schedule(static)
         for (std::intptr_t x = 0; x < static_cast<std::intptr_t>(wfn.size()); x++)
-            if ((x & cmask) == cmask)
-                wfn[x] *= (poppar(x & mask) ? phase : std::conj(phase));
+            if ((x & cmask) == cmask) wfn[x] *= (poppar(x & mask) ? phase : std::conj(phase));
     }
     else
-    {   // see Exp-implementation-details.txt for the explanation of the algorithm below
+    { // see Exp-implementation-details.txt for the explanation of the algorithm below
         std::size_t xy_bits = 0;
         std::size_t yz_bits = 0;
         int y_count = 0;
@@ -249,27 +243,27 @@ void apply_controlled_exp(std::vector<std::complex<T>, A>& wfn,
         {
             switch (b[i])
             {
-                case Gates::PauliX:
-                    xy_bits |= (1ull << qs[i]);
-                    break;
-                case Gates::PauliY:
-                    xy_bits |= (1ull << qs[i]);
-                    yz_bits |= (1ull << qs[i]);
-                    ++y_count;
-                    break;
-                case Gates::PauliZ:
-                    yz_bits |= (1ull << qs[i]);
-                    break;
-                case Gates::PauliI:
-                    break;
-                default:
-                    assert(false);
+            case Gates::PauliX:
+                xy_bits |= (1ull << qs[i]);
+                break;
+            case Gates::PauliY:
+                xy_bits |= (1ull << qs[i]);
+                yz_bits |= (1ull << qs[i]);
+                ++y_count;
+                break;
+            case Gates::PauliZ:
+                yz_bits |= (1ull << qs[i]);
+                break;
+            case Gates::PauliI:
+                break;
+            default:
+                assert(false);
             }
         }
 
         T alpha = std::cos(phi);
-        ComplexType beta  = std::sin(phi)*iExp(3*y_count + 1);
-        ComplexType gamma = std::sin(phi)*iExp(y_count + 1);
+        ComplexType beta = std::sin(phi) * iExp(3 * y_count + 1);
+        ComplexType gamma = std::sin(phi) * iExp(y_count + 1);
 
 #pragma omp parallel for schedule(static)
         for (std::intptr_t x = 0; x < static_cast<std::intptr_t>(wfn.size()); x++)
@@ -288,10 +282,11 @@ void apply_controlled_exp(std::vector<std::complex<T>, A>& wfn,
 }
 
 template <class T, class A>
-double jointprobability(std::vector<T, A> const& wfn,
-                        std::vector<Gates::Basis> const& b,
-                        std::vector<unsigned> const& qs,
-                        bool val = true)
+double jointprobability(
+    std::vector<T, A> const& wfn,
+    std::vector<Gates::Basis> const& b,
+    std::vector<unsigned> const& qs,
+    bool val = true)
 {
     assert(qs.size() > 1);
 
@@ -305,8 +300,7 @@ double jointprobability(std::vector<T, A> const& wfn,
         std::size_t mask = make_mask(qs);
 #pragma omp parallel for schedule(static) reduction(+ : prob)
         for (std::intptr_t i = 0; i < static_cast<std::intptr_t>(wfn.size()); i++)
-            if (poppar(i & mask) == val)
-                prob += std::norm(wfn[i]);
+            if (poppar(i & mask) == val) prob += std::norm(wfn[i]);
     }
     else
     {
@@ -317,19 +311,19 @@ double jointprobability(std::vector<T, A> const& wfn,
         {
             switch (b[i])
             {
-                case Gates::PauliX:
-                    xy_bits |= (1ull << qs[i]);
-                    break;
-                case Gates::PauliY:
-                    xy_bits |= (1ull << qs[i]);
-                    yz_bits |= (1ull << qs[i]);
-                    ++ipow;
-                    break;
-                case Gates::PauliZ:
-                    yz_bits |= (1ull << qs[i]);
-                    break;
-                default:
-                    assert(false);
+            case Gates::PauliX:
+                xy_bits |= (1ull << qs[i]);
+                break;
+            case Gates::PauliY:
+                xy_bits |= (1ull << qs[i]);
+                yz_bits |= (1ull << qs[i]);
+                ++ipow;
+                break;
+            case Gates::PauliZ:
+                yz_bits |= (1ull << qs[i]);
+                break;
+            default:
+                assert(false);
             }
         }
 
@@ -364,27 +358,25 @@ double nrm2(std::vector<std::complex<T>, A> const& x)
     double sum = 0.;
 #pragma omp parallel for schedule(static) reduction(+ : sum)
     for (std::intptr_t i = 0; i < (std::intptr_t)x.size(); ++i)
-      sum += x[i].real() * x[i].real() + x[i].imag() * x[i].imag();
+        sum += x[i].real() * x[i].real() + x[i].imag() * x[i].imag();
     return std::sqrt(sum);
 }
-    
-    
+
 template <class T, class A>
 void normalize(std::vector<T, A>& wfn)
 {
     double scale = 1. / nrm2(wfn);
 #pragma omp parallel for schedule(static)
     for (std::intptr_t i = 0; i < static_cast<std::intptr_t>(wfn.size()); ++i)
-      wfn[i] *= scale;
+        wfn[i] *= scale;
 }
 
-
-
 template <class T, class A1, class A2>
-void subsytemwavefunction_by_pivot(std::vector<T, A1> const& wfn,
-                                   std::vector<unsigned> const& qs,
-                                   std::vector<T, A2>& qubitswfn,
-                                   std::size_t pivot_position)
+void subsytemwavefunction_by_pivot(
+    std::vector<T, A1> const& wfn,
+    std::vector<unsigned> const& qs,
+    std::vector<T, A2>& qubitswfn,
+    std::size_t pivot_position)
 {
 
     const unsigned bit_size = sizeof(std::size_t) * 8;
@@ -397,7 +389,7 @@ void subsytemwavefunction_by_pivot(std::vector<T, A1> const& wfn,
     std::size_t max = 1ull << qs.size();
 
     std::vector<size_t> chunks;
-    
+
     {
 #pragma omp single
         chunks = split_interval_in_chunks(max, omp_get_num_threads());
@@ -415,13 +407,14 @@ void subsytemwavefunction_by_pivot(std::vector<T, A1> const& wfn,
 }
 
 template <class T, class A1, class A2, class A3>
-bool istensorproduct(std::vector<T, A1> const& wfn,
-                     std::vector<unsigned> const& qs1,
-                     std::vector<T, A2> const& wfn1,
-                     std::vector<unsigned> const& qs2,
-                     std::vector<T, A3> const& wfn2,
-                     T phase,
-                     double tolerance)
+bool istensorproduct(
+    std::vector<T, A1> const& wfn,
+    std::vector<unsigned> const& qs1,
+    std::vector<T, A2> const& wfn1,
+    std::vector<unsigned> const& qs2,
+    std::vector<T, A3> const& wfn2,
+    T phase,
+    double tolerance)
 {
 
     const unsigned bit_size = sizeof(std::size_t) * 8;
@@ -475,16 +468,16 @@ bool istensorproduct(std::vector<T, A1> const& wfn,
 // Extracts wave function for a given subset of qubits. Returns true and writes wave-function into
 // qubitswfn if given subset of qubits and its complement are in separable state.
 template <class T, class A1, class A2>
-bool subsytemwavefunction(std::vector<T, A1> const& wfn,
-                          std::vector<unsigned> const& qs,
-                          std::vector<T, A2>& qubitswfn,
-                          double tolerance)
+bool subsytemwavefunction(
+    std::vector<T, A1> const& wfn,
+    std::vector<unsigned> const& qs,
+    std::vector<T, A2>& qubitswfn,
+    double tolerance)
 {
     const unsigned bit_size = sizeof(std::size_t) * 8;
 
     assert(qubitswfn.size() == 1ull << qs.size());
     assert(tolerance > 0.0);
-
 
     // We need a sorted list of qubits:
     std::vector<unsigned> sorted(qs);
@@ -499,7 +492,8 @@ bool subsytemwavefunction(std::vector<T, A1> const& wfn,
 
     unsigned total_qubits = ilog2(wfn.size());
 
-    if (total_qubits > sorted.size()) {
+    if (total_qubits > sorted.size())
+    {
         std::vector<unsigned> qs_rest = complement(sorted, total_qubits);
         std::vector<T, A1> qubitswfn_rest(1ull << (qs_rest.size()));
         assert(qubitswfn_rest.size() * qubitswfn.size() == wfn.size());
@@ -518,10 +512,14 @@ bool subsytemwavefunction(std::vector<T, A1> const& wfn,
     }
 
     // put back to original sorting:
-    for (unsigned i = 0; i < qs.size(); ++i) {
-        if (sorted[i] != qs[i]) {
-            for (unsigned p = i + 1; p < qs.size(); ++p) {
-                if (sorted[p] == qs[i]) {
+    for (unsigned i = 0; i < qs.size(); ++i)
+    {
+        if (sorted[i] != qs[i])
+        {
+            for (unsigned p = i + 1; p < qs.size(); ++p)
+            {
+                if (sorted[p] == qs[i])
+                {
                     swap(qubitswfn, i, p);
                     std::swap(sorted[p], sorted[i]);
                     break;
@@ -532,7 +530,7 @@ bool subsytemwavefunction(std::vector<T, A1> const& wfn,
 
     return true;
 }
-}
-}
-}
-}
+} // namespace kernels
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/local_test.cpp
+++ b/src/Simulation/Native/src/simulator/local_test.cpp
@@ -12,10 +12,10 @@ using namespace Microsoft::Quantum::SIMULATOR;
 void test_exp()
 {
     SimulatorType sim;
-  
+
     // prepare a test state
     auto qs = sim.allocate(4);
-	  for (auto q : qs)
+    for (auto q : qs)
         sim.H(q);
 
     // apply the Exp gate
@@ -40,7 +40,8 @@ void test_exp()
         sim.H(q);
 
     // measure and test
-    for (auto q : qs) {
+    for (auto q : qs)
+    {
         bool m = sim.M(q);
         assert(!m);
     }
@@ -75,8 +76,8 @@ void test_teleport()
     // check teleportation success
     sim.Rz((-1.1), q1);
     sim.H(q1);
-    
-    assert(sim.M(q1)==false);
+
+    assert(sim.M(q1) == false);
 
     sim.release(q1);
     sim.release(q2);
@@ -92,7 +93,7 @@ void test_gates()
 
     sim.CRx(1.0, q1, q2);
 
-    assert(sim.M(q2)==false);
+    assert(sim.M(q2) == false);
 
     sim.X(q1);
     sim.CRx(1.0, q1, q2);
@@ -102,18 +103,17 @@ void test_gates()
     sim.CRz(-1.0, q1, q2);
     sim.H(q2);
 
-    assert(sim.M(q2)==false);
+    assert(sim.M(q2) == false);
 
     sim.X(q2);
 
-    assert(sim.M(q2)==true);
+    assert(sim.M(q2) == true);
 
     sim.X(q2);
 
     sim.release(q1);
     sim.release(q2);
 }
-
 
 void test_allocate()
 {
@@ -143,17 +143,15 @@ void test_allocate()
     sim.release(q1);
     sim.release(q2);
     sim.release(q3);
-  
-    assert(sim.num_qubits() == 0);
 
+    assert(sim.num_qubits() == 0);
 }
 
 template <class SIM>
 void set(SIM& sim, bool val, unsigned qubit)
 {
     bool is = sim.M(qubit);
-    if (val != is)
-        sim.X(qubit);
+    if (val != is) sim.X(qubit);
 }
 
 void test_multicontrol()
@@ -172,11 +170,11 @@ void test_multicontrol()
         {
             // set control bits to match i:
             for (unsigned j = 0; j < n; j++)
-                set(sim,((i & (1 << j)) != 0), ctrls[j]);
+                set(sim, ((i & (1 << j)) != 0), ctrls[j]);
 
             // controlled is enabled only when all ctrls are 1 (e.g. last one):
             unsigned enabled = (i == ((1 << n) - 1));
-            set(sim,0, q);
+            set(sim, 0, q);
             assert(sim.M(q) == 0);
 
             sim.CX(ctrls, q);
@@ -252,9 +250,10 @@ void assert_cat_state(WavefunctionStorage const& wfn, double tol)
     assert(norm(wfn[(1ull << total_qubits) - 1] / wfn[0] - std::complex<double>(1, 0)) < tol * tol);
 }
 
-void test_extract_qubits_cat_state(unsigned qubits_number,
-                                   std::vector<unsigned> const& subset,
-                                   std::vector<unsigned> const& negative_test)
+void test_extract_qubits_cat_state(
+    unsigned qubits_number,
+    std::vector<unsigned> const& subset,
+    std::vector<unsigned> const& negative_test)
 {
     SimulatorType sim;
     double tol = 1e-5;

--- a/src/Simulation/Native/src/simulator/simulator.cpp
+++ b/src/Simulation/Native/src/simulator/simulator.cpp
@@ -3,10 +3,9 @@
 
 #include "simulator/simulator.hpp"
 
-
 namespace sim = Microsoft::Quantum::SIMULATOR;
 
 MICROSOFT_QUANTUM_DECL Microsoft::Quantum::Simulator::SimulatorInterface* sim::createSimulator(unsigned maxlocal)
 {
-  return new sim::SimulatorType(maxlocal);
+    return new sim::SimulatorType(maxlocal);
 }

--- a/src/Simulation/Native/src/simulator/simulator.hpp
+++ b/src/Simulation/Native/src/simulator/simulator.hpp
@@ -19,112 +19,126 @@ namespace Quantum
 namespace SIMULATOR
 {
 
-  
-  template <class WFN>
-  class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
-  {
+template <class WFN>
+class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
+{
   public:
-    
     using WaveFunctionType = WFN;
-    
-    Simulator(unsigned maxlocal=0u)
-    : psi(maxlocal)
-    {}
-    
+
+    Simulator(unsigned maxlocal = 0u)
+        : psi(maxlocal)
+    {
+    }
+
     std::size_t random(std::vector<double> const& d)
     {
-      recursive_lock_type l(mutex());
-      std::discrete_distribution<std::size_t> dist(d.begin(), d.end());
-      return dist(psi.rng());
+        recursive_lock_type l(mutex());
+        std::discrete_distribution<std::size_t> dist(d.begin(), d.end());
+        return dist(psi.rng());
     }
-    
+
     std::size_t random(std::size_t n, double* d)
     {
-      std::discrete_distribution<std::size_t> dist(d, d+n);
-      recursive_lock_type l(mutex());
-      return dist(psi.rng());
+        std::discrete_distribution<std::size_t> dist(d, d + n);
+        recursive_lock_type l(mutex());
+        return dist(psi.rng());
     }
-    
+
     double JointEnsembleProbability(std::vector<Gates::Basis> bs, std::vector<unsigned> qs)
     {
-      removeIdentities(bs,qs);
-      if ( bs.empty() )
-      {
-        return 0.0;
-      }
-      
-      recursive_lock_type l(mutex());
-      changebasis(bs, qs,true);
-      double p = psi.jointprobability(qs);
-      changebasis(bs, qs,false);
-      return p;
+        removeIdentities(bs, qs);
+        if (bs.empty())
+        {
+            return 0.0;
+        }
+
+        recursive_lock_type l(mutex());
+        changebasis(bs, qs, true);
+        double p = psi.jointprobability(qs);
+        changebasis(bs, qs, false);
+        return p;
     }
-      
+
     bool isclassical(unsigned q)
     {
-      recursive_lock_type l(mutex());
-      return psi.isclassical(q);
+        recursive_lock_type l(mutex());
+        return psi.isclassical(q);
     }
-    
+
     // allocate and release
     unsigned allocate()
     {
-      recursive_lock_type l(mutex());
-      return psi.allocate();
+        recursive_lock_type l(mutex());
+        return psi.allocate();
     }
-    
+
     std::vector<unsigned> allocate(unsigned n)
     {
-      std::vector<unsigned> qubits;
-      recursive_lock_type l(mutex());
+        std::vector<unsigned> qubits;
+        recursive_lock_type l(mutex());
 
-      for (unsigned i = 0; i < n; ++i)
-        qubits.push_back(psi.allocate());
-      return qubits;
+        for (unsigned i = 0; i < n; ++i)
+            qubits.push_back(psi.allocate());
+        return qubits;
     }
-    
+
     void allocateQubit(unsigned q)
     {
-      recursive_lock_type l(mutex());
-      psi.allocateQubit(q);
-    }
-    
-    void allocateQubit(std::vector<unsigned> const& qubits)
-    {
-      recursive_lock_type l(mutex());
-      for (auto q: qubits)
+        recursive_lock_type l(mutex());
         psi.allocateQubit(q);
     }
-    
+
+    void allocateQubit(std::vector<unsigned> const& qubits)
+    {
+        recursive_lock_type l(mutex());
+        for (auto q : qubits)
+            psi.allocateQubit(q);
+    }
+
     bool release(unsigned q)
     {
-      recursive_lock_type l(mutex());
-      flush();
-      bool allok = isclassical(q);
-      if (allok)
-      allok = (psi.getvalue(q)==false);
-      else
-      M(q);
-      psi.release(q);
-      return allok;
+        recursive_lock_type l(mutex());
+        flush();
+        bool allok = isclassical(q);
+        if (allok)
+            allok = (psi.getvalue(q) == false);
+        else
+            M(q);
+        psi.release(q);
+        return allok;
     }
-    
+
     bool release(std::vector<unsigned> const& qs)
     {
-      recursive_lock_type l(mutex());
-      bool allok=true;
-      for (auto q : qs)
-      allok = release(q) && allok;
-      return allok;
+        recursive_lock_type l(mutex());
+        bool allok = true;
+        for (auto q : qs)
+            allok = release(q) && allok;
+        return allok;
     }
-    
+
     // single-qubit gates
-    
-#define GATE1IMPL(OP) void OP(unsigned q) { recursive_lock_type l(mutex()); psi.apply(Gates::OP(q));}
-#define GATE1CIMPL(OP) void C##OP(unsigned c, unsigned q) { recursive_lock_type l(mutex()); psi.apply_controlled(c,Gates::OP(q));}
-#define GATE1MCIMPL(OP) void C##OP(std::vector<unsigned> const& c, unsigned q) { recursive_lock_type l(mutex()); psi.apply_controlled(c,Gates::OP(q));}
+
+#define GATE1IMPL(OP)                                                                                                  \
+    void OP(unsigned q)                                                                                                \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply(Gates::OP(q));                                                                                       \
+    }
+#define GATE1CIMPL(OP)                                                                                                 \
+    void C##OP(unsigned c, unsigned q)                                                                                 \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply_controlled(c, Gates::OP(q));                                                                         \
+    }
+#define GATE1MCIMPL(OP)                                                                                                \
+    void C##OP(std::vector<unsigned> const& c, unsigned q)                                                             \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply_controlled(c, Gates::OP(q));                                                                         \
+    }
 #define GATE1(OP) GATE1IMPL(OP) GATE1CIMPL(OP) GATE1MCIMPL(OP)
-    
+
     GATE1(X)
     GATE1(Y)
     GATE1(Z)
@@ -135,17 +149,32 @@ namespace SIMULATOR
     GATE1(AdjHY)
     GATE1(AdjT)
     GATE1(AdjS)
-    
+
 #undef GATE1
 #undef GATE1IMPL
 #undef GATE1CIMPL
 #undef GATE1MCIMPL
-    
-#define GATE1IMPL(OP) void OP(double phi, unsigned q) { recursive_lock_type l(mutex()); psi.apply(Gates::OP(phi,q));}
-#define GATE1CIMPL(OP) void C##OP(double phi, unsigned c, unsigned q) { recursive_lock_type l(mutex()); psi.apply_controlled(c,Gates::OP(phi,q));}
-#define GATE1MCIMPL(OP) void C##OP(double phi, std::vector<unsigned> const& c, unsigned q) { recursive_lock_type l(mutex()); psi.apply_controlled(c,Gates::OP(phi,q));}
+
+#define GATE1IMPL(OP)                                                                                                  \
+    void OP(double phi, unsigned q)                                                                                    \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply(Gates::OP(phi, q));                                                                                  \
+    }
+#define GATE1CIMPL(OP)                                                                                                 \
+    void C##OP(double phi, unsigned c, unsigned q)                                                                     \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply_controlled(c, Gates::OP(phi, q));                                                                    \
+    }
+#define GATE1MCIMPL(OP)                                                                                                \
+    void C##OP(double phi, std::vector<unsigned> const& c, unsigned q)                                                 \
+    {                                                                                                                  \
+        recursive_lock_type l(mutex());                                                                                \
+        psi.apply_controlled(c, Gates::OP(phi, q));                                                                    \
+    }
 #define GATE1(OP) GATE1IMPL(OP) GATE1CIMPL(OP) GATE1MCIMPL(OP)
-    
+
     GATE1(Rx)
     GATE1(Ry)
     GATE1(Rz)
@@ -154,123 +183,154 @@ namespace SIMULATOR
 #undef GATE1IMPL
 #undef GATE1CIMPL
 #undef GATE1MCIMPL
-    
+
     // rotations
     void R(Gates::Basis b, double phi, unsigned q)
     {
-      recursive_lock_type l(mutex());
-      psi.apply(Gates::R(b, phi, q));
+        recursive_lock_type l(mutex());
+        psi.apply(Gates::R(b, phi, q));
     }
-    
+
     // multi-controlled rotations
     void CR(Gates::Basis b, double phi, std::vector<unsigned> const& c, unsigned q)
     {
-      recursive_lock_type l(mutex());
-      psi.apply_controlled(c, Gates::R(b, phi, q));
+        recursive_lock_type l(mutex());
+        psi.apply_controlled(c, Gates::R(b, phi, q));
     }
-    
+
     // Exponential of Pauli operators
     void CExp(std::vector<Gates::Basis> bs, double phi, std::vector<unsigned> const& cs, std::vector<unsigned> qs)
     {
-      if (bs.size()==0)
-      return;
-      
-      unsigned somequbit =qs.front();
-      removeIdentities(bs,qs);
-      
-      recursive_lock_type l(mutex());
-      if (bs.size()==0)
-      CR(Gates::PauliI,-2.*phi,cs,somequbit);
-      else if (bs.size()==1)
-      CR(bs.front(),-2.*phi,cs,qs.front());
-      else
-      psi.apply_controlled_exp(bs,phi,cs,qs);
+        if (bs.size() == 0) return;
+
+        unsigned somequbit = qs.front();
+        removeIdentities(bs, qs);
+
+        recursive_lock_type l(mutex());
+        if (bs.size() == 0)
+            CR(Gates::PauliI, -2. * phi, cs, somequbit);
+        else if (bs.size() == 1)
+            CR(bs.front(), -2. * phi, cs, qs.front());
+        else
+            psi.apply_controlled_exp(bs, phi, cs, qs);
     }
-    
+
     void Exp(std::vector<Gates::Basis> const& bs, double phi, std::vector<unsigned> const& qs)
     {
-      recursive_lock_type l(mutex());
-      CExp(bs,phi,std::vector<unsigned>(), qs);
+        recursive_lock_type l(mutex());
+        CExp(bs, phi, std::vector<unsigned>(), qs);
     }
-    
+
     // measurements
-    
+
     bool M(unsigned q)
     {
-      recursive_lock_type l(mutex());
-     return psi.measure(q);
+        recursive_lock_type l(mutex());
+        return psi.measure(q);
     }
-    
+
     std::vector<bool> MultiM(std::vector<unsigned> const& qs)
     {
-      // ***TODO*** optimized implementation
-      recursive_lock_type l(mutex());
-      std::vector<bool> res;
-      for (auto q: qs)
-      res.push_back(psi.measure(q));
-      return res;
+        // ***TODO*** optimized implementation
+        recursive_lock_type l(mutex());
+        std::vector<bool> res;
+        for (auto q : qs)
+            res.push_back(psi.measure(q));
+        return res;
     }
-    
+
     bool Measure(std::vector<Gates::Basis> bs, std::vector<unsigned> qs)
     {
-      recursive_lock_type l(mutex());
-      removeIdentities(bs,qs);
-      // ***TODO*** optimized kernels
-      changebasis(bs, qs,true);
-      bool res = psi.jointmeasure(qs);
-      changebasis(bs, qs,false);
-      return res;
+        recursive_lock_type l(mutex());
+        removeIdentities(bs, qs);
+        // ***TODO*** optimized kernels
+        changebasis(bs, qs, true);
+        bool res = psi.jointmeasure(qs);
+        changebasis(bs, qs, false);
+        return res;
     }
 
-    void seed(unsigned s) { recursive_lock_type l(mutex()); psi.seed(s);}
-    void reset() { recursive_lock_type l(mutex()); psi.reset();}
-    unsigned qubit(unsigned id) const { recursive_lock_type l(mutex()); return psi.qubit(id);}
-    unsigned num_qubits() const { recursive_lock_type l(mutex()); return psi.num_qubits();}
-    void flush() { recursive_lock_type l(mutex()); psi.flush();}
-    ComplexType const* data() const { recursive_lock_type l(mutex()); return psi.data().data();}
-
-    void dump(bool(*callback)(size_t, double, double))
+    void seed(unsigned s)
     {
-       recursive_lock_type l(mutex());
-       flush();
-
-       auto wfn = psi.data();
-       for (std::size_t i = 0; i < wfn.size(); i++) {
-           if (!callback(i, wfn[i].real(), wfn[i].imag())) return;
-       }
+        recursive_lock_type l(mutex());
+        psi.seed(s);
+    }
+    void reset()
+    {
+        recursive_lock_type l(mutex());
+        psi.reset();
+    }
+    unsigned qubit(unsigned id) const
+    {
+        recursive_lock_type l(mutex());
+        return psi.qubit(id);
+    }
+    unsigned num_qubits() const
+    {
+        recursive_lock_type l(mutex());
+        return psi.num_qubits();
+    }
+    void flush()
+    {
+        recursive_lock_type l(mutex());
+        psi.flush();
+    }
+    ComplexType const* data() const
+    {
+        recursive_lock_type l(mutex());
+        return psi.data().data();
     }
 
-    void dumpIds(void(*callback)(unsigned))
+    void dump(bool (*callback)(size_t, double, double))
+    {
+        recursive_lock_type l(mutex());
+        flush();
+
+        auto wfn = psi.data();
+        for (std::size_t i = 0; i < wfn.size(); i++)
+        {
+            if (!callback(i, wfn[i].real(), wfn[i].imag())) return;
+        }
+    }
+
+    void dumpIds(void (*callback)(unsigned))
     {
         recursive_lock_type l(mutex());
         flush();
 
         auto qubits = psi.logicalQubits();
-        for (auto it = qubits.begin(); it != qubits.end(); ++it) {
+        for (auto it = qubits.begin(); it != qubits.end(); ++it)
+        {
             callback(*it);
         }
     }
 
-    bool dumpQubits(std::vector<unsigned> const& qs, bool(*callback)(size_t, double, double))
+    bool dumpQubits(std::vector<unsigned> const& qs, bool (*callback)(size_t, double, double))
     {
         assert(qs.size() <= num_qubits());
 
         WavefunctionStorage wfn(1ull << qs.size());
 
-        if (subsytemwavefunction(qs, wfn, 1e-10)) {
-            for (std::size_t i = 0; i < wfn.size(); i++) {
+        if (subsytemwavefunction(qs, wfn, 1e-10))
+        {
+            for (std::size_t i = 0; i < wfn.size(); i++)
+            {
                 if (!callback(i, wfn[i].real(), wfn[i].imag())) break;
             }
             return true;
         }
-        else {
+        else
+        {
             return false;
         }
     }
 
     // apply permutation of basis states to the wave function
-    void permuteBasis(std::vector<unsigned> const& qs, std::size_t table_size,
-        std::size_t const* permutation_table, bool adjoint = false)
+    void permuteBasis(
+        std::vector<unsigned> const& qs,
+        std::size_t table_size,
+        std::size_t const* permutation_table,
+        bool adjoint = false)
 
     {
 #ifndef NDEBUG
@@ -285,58 +345,57 @@ namespace SIMULATOR
         psi.permute_basis(qs, table_size, permutation_table, adjoint);
     }
 
-    bool
-    subsytemwavefunction(std::vector<unsigned> const& qs, WavefunctionStorage& qubitswfn, double tolerance)
+    bool subsytemwavefunction(std::vector<unsigned> const& qs, WavefunctionStorage& qubitswfn, double tolerance)
     {
         recursive_lock_type l(mutex());
         flush();
         return psi.subsytemwavefunction(qs, qubitswfn, tolerance);
     }
-    
+
   private:
     void changebasis(Gates::Basis b, unsigned q, bool back)
     {
-      if (b == Gates::PauliX)
-      H(q);
-      else if (b == Gates::PauliY)
-      {
-        if (back)
-        AdjHY(q);
-        else
-        HY(q);
-      }
+        if (b == Gates::PauliX)
+            H(q);
+        else if (b == Gates::PauliY)
+        {
+            if (back)
+                AdjHY(q);
+            else
+                HY(q);
+        }
     }
-    
+
     void changebasis(std::vector<Gates::Basis> const& bs, std::vector<unsigned> const& qs, bool back)
     {
-      assert(bs.size() == qs.size());
-      for (unsigned i = 0; i < bs.size(); ++i)
-      changebasis(bs[i], qs[i],back);
+        assert(bs.size() == qs.size());
+        for (unsigned i = 0; i < bs.size(); ++i)
+            changebasis(bs[i], qs[i], back);
     }
-    
-    inline static void removeIdentities(std::vector<Gates::Basis>& b, std::vector<unsigned> & qs)
+
+    inline static void removeIdentities(std::vector<Gates::Basis>& b, std::vector<unsigned>& qs)
     {
-      unsigned i=0;
-      while (i != b.size())
-      {
-        if (b[i] == Gates::PauliI)
+        unsigned i = 0;
+        while (i != b.size())
         {
-          b.erase(b.begin() + i);
-          qs.erase(qs.begin() + i);
+            if (b[i] == Gates::PauliI)
+            {
+                b.erase(b.begin() + i);
+                qs.erase(qs.begin() + i);
+            }
+            else
+                ++i;
         }
-        else
-        ++i;
-      }
     }
-    
+
     WaveFunctionType psi;
-  };
-  
+};
+
 using WavefunctionType = Wavefunction<ComplexType>;
 using SimulatorType = Simulator<WavefunctionType>;
 
-MICROSOFT_QUANTUM_DECL Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned=0u);
+MICROSOFT_QUANTUM_DECL Microsoft::Quantum::Simulator::SimulatorInterface* createSimulator(unsigned = 0u);
 
-}
-}
-}
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/simulatoravx.cpp
+++ b/src/Simulation/Native/src/simulator/simulatoravx.cpp
@@ -5,10 +5,9 @@
 
 #include "simulator/simulator.hpp"
 
-
 namespace sim = Microsoft::Quantum::SimulatorAVX;
 
 MICROSOFT_QUANTUM_DECL Microsoft::Quantum::Simulator::SimulatorInterface* sim::createSimulator(unsigned maxlocal)
 {
-  return new sim::SimulatorType(maxlocal);
+    return new sim::SimulatorType(maxlocal);
 }

--- a/src/Simulation/Native/src/simulator/simulatoravx2.cpp
+++ b/src/Simulation/Native/src/simulator/simulatoravx2.cpp
@@ -6,10 +6,9 @@
 
 #include "simulator/simulator.hpp"
 
-
 namespace sim = Microsoft::Quantum::SimulatorAVX2;
 
 MICROSOFT_QUANTUM_DECL Microsoft::Quantum::Simulator::SimulatorInterface* sim::createSimulator(unsigned maxlocal)
 {
-  return new sim::SimulatorType(maxlocal);
+    return new sim::SimulatorType(maxlocal);
 }

--- a/src/Simulation/Native/src/simulator/simulatoravx512.cpp
+++ b/src/Simulation/Native/src/simulator/simulatoravx512.cpp
@@ -7,10 +7,9 @@
 
 #include "simulator/simulator.hpp"
 
-
 namespace sim = Microsoft::Quantum::SimulatorAVX512;
 
 MICROSOFT_QUANTUM_DECL Microsoft::Quantum::Simulator::SimulatorInterface* sim::createSimulator(unsigned maxlocal)
 {
-  return new sim::SimulatorType(maxlocal);
+    return new sim::SimulatorType(maxlocal);
 }

--- a/src/Simulation/Native/src/simulator/simulatorinterface.hpp
+++ b/src/Simulation/Native/src/simulator/simulatorinterface.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "types.hpp"
 #include "gates.hpp"
+#include "types.hpp"
 #include "util/openmp.hpp"
 #include <vector>
 
@@ -15,34 +15,32 @@ namespace Quantum
 namespace Simulator
 {
 
-  using namespace Microsoft::Quantum::SIMULATOR;
-  class SimulatorInterface
-  {
+using namespace Microsoft::Quantum::SIMULATOR;
+class SimulatorInterface
+{
   public:
-    
-    
     SimulatorInterface()
-    : mutex_ptr(new recursive_mutex_type())
-    {}
-    
-    virtual ~SimulatorInterface() {}
-    
-    virtual std::size_t random(std::size_t n, double* d) =0;
-      
-    virtual double JointEnsembleProbability(std::vector<Gates::Basis> bs, std::vector<unsigned> qs) =0;
-    
-    // allocate and release
-    virtual void allocateQubit(unsigned q) =0;
-    virtual bool release(unsigned q)=0;
-    virtual unsigned num_qubits() const =0;
+        : mutex_ptr(new recursive_mutex_type())
+    {
+    }
 
-    
+    virtual ~SimulatorInterface() {}
+
+    virtual std::size_t random(std::size_t n, double* d) = 0;
+
+    virtual double JointEnsembleProbability(std::vector<Gates::Basis> bs, std::vector<unsigned> qs) = 0;
+
+    // allocate and release
+    virtual void allocateQubit(unsigned q) = 0;
+    virtual bool release(unsigned q) = 0;
+    virtual unsigned num_qubits() const = 0;
+
     // single-qubit gates
-    
-#define GATE1IMPL(OP) virtual void OP(unsigned q)=0;
-#define GATE1MCIMPL(OP) virtual void C##OP(std::vector<unsigned> const& c, unsigned q) =0;
-#define GATE1(OP) GATE1IMPL(OP)  GATE1MCIMPL(OP)
-    
+
+#define GATE1IMPL(OP) virtual void OP(unsigned q) = 0;
+#define GATE1MCIMPL(OP) virtual void C##OP(std::vector<unsigned> const& c, unsigned q) = 0;
+#define GATE1(OP) GATE1IMPL(OP) GATE1MCIMPL(OP)
+
     GATE1(X)
     GATE1(Y)
     GATE1(Z)
@@ -51,55 +49,76 @@ namespace Simulator
     GATE1(S)
     GATE1(AdjT)
     GATE1(AdjS)
-    
+
 #undef GATE1
 #undef GATE1IMPL
 #undef GATE1CIMPL
 #undef GATE1MCIMPL
-    
+
     // rotations
-    virtual void R(Gates::Basis b, double phi, unsigned q)=0;
-    virtual void CR(Gates::Basis b, double phi, std::vector<unsigned> const& c, unsigned q)=0;
+    virtual void R(Gates::Basis b, double phi, unsigned q) = 0;
+    virtual void CR(Gates::Basis b, double phi, std::vector<unsigned> const& c, unsigned q) = 0;
 
     // Exponential of Pauli operators
-    virtual void CExp(std::vector<Gates::Basis> bs, double phi, std::vector<unsigned> const& cs, std::vector<unsigned> qs)=0;
-    
+    virtual void CExp(
+        std::vector<Gates::Basis> bs,
+        double phi,
+        std::vector<unsigned> const& cs,
+        std::vector<unsigned> qs) = 0;
+
     virtual void Exp(std::vector<Gates::Basis> const& bs, double phi, std::vector<unsigned> const& qs)
     {
-      CExp(bs,phi,std::vector<unsigned>(), qs);
+        CExp(bs, phi, std::vector<unsigned>(), qs);
     }
-    
+
     // measurements
-    
-    virtual bool M(unsigned q)=0;
-    virtual bool Measure(std::vector<Gates::Basis> bs, std::vector<unsigned> qs)=0;
-    
-    virtual void seed(unsigned s)=0;
-    virtual void reset() =0;
-    virtual ComplexType const* data() const =0;
-    
 
-    virtual bool
-    subsytemwavefunction(std::vector<unsigned> const& qs, WavefunctionStorage& qubitswfn, double tolerance) { assert(false); return false;  };
+    virtual bool M(unsigned q) = 0;
+    virtual bool Measure(std::vector<Gates::Basis> bs, std::vector<unsigned> qs) = 0;
 
-    virtual void dump(bool (*callback)(size_t, double, double)) { assert(false); }
-    virtual bool dumpQubits(std::vector<unsigned> const& qs, bool (*callback)(size_t, double, double)) { assert(false); return false; }
-    virtual void dumpIds(void (*callback)(unsigned)) { assert(false); }
+    virtual void seed(unsigned s) = 0;
+    virtual void reset() = 0;
+    virtual ComplexType const* data() const = 0;
+
+    virtual bool subsytemwavefunction(std::vector<unsigned> const& qs, WavefunctionStorage& qubitswfn, double tolerance)
+    {
+        assert(false);
+        return false;
+    };
+
+    virtual void dump(bool (*callback)(size_t, double, double))
+    {
+        assert(false);
+    }
+    virtual bool dumpQubits(std::vector<unsigned> const& qs, bool (*callback)(size_t, double, double))
+    {
+        assert(false);
+        return false;
+    }
+    virtual void dumpIds(void (*callback)(unsigned))
+    {
+        assert(false);
+    }
 
     // apply permutation of basis states to the wave function
-    virtual void permuteBasis(std::vector<unsigned> const& qs, std::size_t table_size,
-        std::size_t const* permutation_table, bool adjoint = false) {
+    virtual void permuteBasis(
+        std::vector<unsigned> const& qs,
+        std::size_t table_size,
+        std::size_t const* permutation_table,
+        bool adjoint = false)
+    {
         throw std::runtime_error("this simulator does not support permutation oracle emulation");
     };
 
-
-    recursive_mutex_type& mutex() const { return *mutex_ptr;}
+    recursive_mutex_type& mutex() const
+    {
+        return *mutex_ptr;
+    }
 
   private:
     std::shared_ptr<recursive_mutex_type> mutex_ptr;
-  };
+};
 
-
-}
-}
-}
+} // namespace Simulator
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/types.hpp
+++ b/src/Simulation/Native/src/simulator/types.hpp
@@ -5,26 +5,23 @@
 #include "util/alignedalloc.hpp"
 #include <vector>
 
-
 namespace Microsoft
 {
-  namespace Quantum
-  {
-    namespace SIMULATOR
-    {
-      
+namespace Quantum
+{
+namespace SIMULATOR
+{
+
 #ifndef USE_SINGLE_PRECISION
-      using RealType = double;
+using RealType = double;
 #else
-      using RealType = float;
+using RealType = float;
 #endif
-      
-      using ComplexType = std::complex<RealType>;
-      
-      using WavefunctionStorage = std::vector<ComplexType, AlignedAlloc<ComplexType,64>>;
 
-    }
-  }
-}
+using ComplexType = std::complex<RealType>;
 
+using WavefunctionStorage = std::vector<ComplexType, AlignedAlloc<ComplexType, 64>>;
 
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/simulator/wavefunction.hpp
+++ b/src/Simulation/Native/src/simulator/wavefunction.hpp
@@ -11,137 +11,181 @@
 #include <iterator>
 #include <limits>
 #include <random>
-#include <vector>
-#include <unordered_set>
-#include <unordered_map>
 #include <string.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
-#include "types.hpp"
 #include "gates.hpp"
+#include "types.hpp"
 
 #include "external/fused.hpp"
 
 namespace Microsoft
 {
-    namespace Quantum
+namespace Quantum
+{
+namespace SIMULATOR
+{
+namespace detail
+{
+inline std::size_t get_register(const std::vector<unsigned>& qs, std::size_t basis_state)
+{
+    std::size_t result = 0;
+    for (unsigned i = 0; i < qs.size(); ++i)
+        result |= ((basis_state >> qs[i]) & 1) << i;
+    return result;
+}
+
+inline std::size_t set_register(
+    const std::vector<unsigned>& qs,
+    std::size_t qmask,
+    std::size_t basis_state,
+    std::size_t original = 0ull)
+{
+    std::size_t result = original & ~qmask;
+    for (unsigned i = 0; i < qs.size(); ++i)
+        result |= ((basis_state >> i) & 1) << qs[i];
+    return result;
+}
+} // namespace detail
+
+// Creating a gate wrapper datatype to represent a gate in a cluster
+class GateWrapper
+{
+  public:
+    GateWrapper(std::vector<unsigned> controls, unsigned target, TinyMatrix<ComplexType, 2> mat)
+        : controls_(controls)
+        , target_(target)
+        , mat_(mat)
     {
-        namespace SIMULATOR
-        {
-            namespace detail
-            {
-                inline std::size_t get_register(const std::vector<unsigned>& qs, std::size_t basis_state)
-                {
-                    std::size_t result = 0;
-                    for (unsigned i = 0; i < qs.size(); ++i)
-                        result |= ((basis_state >> qs[i]) & 1) << i;
-                    return result;
+    }
+    std::vector<unsigned> get_controls()
+    {
+        return controls_;
+    }
+    unsigned get_target()
+    {
+        return target_;
+    }
+    TinyMatrix<ComplexType, 2> get_mat()
+    {
+        return mat_;
+    }
 
-                }
+  private:
+    std::vector<unsigned> controls_;
+    unsigned target_;
+    TinyMatrix<ComplexType, 2> mat_;
+};
 
-                inline std::size_t set_register(const std::vector<unsigned>& qs, std::size_t qmask, std::size_t basis_state, std::size_t original = 0ull)
-                {
-                    std::size_t result = original & ~qmask;
-                    for (unsigned i = 0; i < qs.size(); ++i)
-                        result |= ((basis_state >> i) & 1) << qs[i];
-                    return result;
+// Creating a cluster datatype for new scheduling logic
+class Cluster
+{
+  public:
+    Cluster(std::vector<unsigned> qids, std::vector<GateWrapper> gates)
+        : qids_(qids)
+        , gates_(gates)
+    {
+    }
+    std::vector<unsigned> get_qids()
+    {
+        return qids_;
+    }
+    std::vector<GateWrapper> get_gates()
+    {
+        return gates_;
+    }
+
+    void setQids(std::vector<unsigned> qids)
+    {
+        qids_ = qids;
+    }
+
+    void append_gates(std::vector<GateWrapper> gates)
+    {
+        gates_.insert(gates_.end(), gates.begin(), gates.end());
+    }
+
+    size_t size()
+    {
+        return gates_.size();
+    }
+
+    // Greedy method that finds next appropriate cluster
+    std::pair<Cluster, std::vector<unsigned>> next_cluster(std::vector<Cluster>& nextClusters, unsigned maxWidth)
+    {
+        std::vector<unsigned> myUnion;                            // My qubits touched + Next qubits touched
+        std::vector<unsigned> myDiff;                             // New qubits touched by Next
+        std::vector<unsigned> myInter;                            // Old qubits touched by Next
+        std::vector<unsigned> allInter;                           // My qubits + All touched qubits
+        std::set<unsigned> myTouched(qids_.begin(), qids_.end()); // My qubits touched
+        std::set<unsigned> allTouched = myTouched;                // All the qubits touched so far
+
+        int lastNexts = (int)nextClusters.size() - 1; // nexts are in reverse order (from above)
+        for (int i = 0; i <= lastNexts; i++)
+        {                                                         // Look at the clusters that follow us
+            auto nextQs = nextClusters[lastNexts - i].get_qids(); // Pull off one future cluster
+            std::sort(nextQs.begin(), nextQs.end());              // Has to be sorted for set operations
+            myUnion.clear();
+            std::set_union(
+                nextQs.begin(), nextQs.end(), // See what qubits we and the future cluster touch
+                myTouched.begin(), myTouched.end(), std::back_inserter(myUnion));
+            if (myUnion.size() <= maxWidth)
+            { // It's a candiate if it's not beyond our allowed width
+                myDiff.clear();
+                std::set_difference(
+                    nextQs.begin(), nextQs.end(), // Figure out if any of the future qubits aren't already seen by us
+                    myTouched.begin(), myTouched.end(), std::back_inserter(myDiff));
+                allInter.clear();
+                std::set_intersection(
+                    myDiff.begin(), myDiff.end(), // These are any new qubits that might have already been touched
+                    allTouched.begin(), allTouched.end(), std::back_inserter(allInter));
+                if (allInter.size() == 0)
+                { // If the new qubits are untouched... then this is allowed
+                    auto cl = nextClusters[lastNexts - i];
+                    nextClusters.erase(nextClusters.begin() + (lastNexts - i)); // Remove the future cluster
+                    return std::make_pair(cl, myUnion); // ... and add it to our cluster (done above)
                 }
             }
+            myInter.clear();
+            std::set_intersection(
+                nextQs.begin(), nextQs.end(), // If a future cluster touches any of our qubits... we've hit a hard wall
+                myTouched.begin(), myTouched.end(), std::back_inserter(myInter));
+            if (myInter.size() != 0) break;
 
-            // Creating a gate wrapper datatype to represent a gate in a cluster
-            class GateWrapper {
-            public:
-                GateWrapper(std::vector<unsigned> controls, unsigned target, TinyMatrix<ComplexType, 2> mat) : controls_(controls), target_(target), mat_(mat) {}
-                std::vector<unsigned> get_controls() { return controls_; }
-                unsigned get_target() { return target_; }
-                TinyMatrix<ComplexType, 2> get_mat() { return mat_; }
-            private:
-                std::vector<unsigned> controls_;
-                unsigned target_;
-                TinyMatrix<ComplexType, 2> mat_;
-            };
+            allTouched.insert(nextQs.begin(), nextQs.end()); // Add in all qubits touched, and try the next cluster
+        }
+        Cluster defCl = Cluster({}, {}); // Couldn't find any more clusters to add
+        std::vector<unsigned> defVec = {};
+        return std::make_pair(defCl, defVec);
+    }
 
-            // Creating a cluster datatype for new scheduling logic
-            class Cluster {
-            public:
-                Cluster(std::vector<unsigned> qids, std::vector<GateWrapper> gates) : qids_(qids), gates_(gates) {}
-                std::vector<unsigned> get_qids() { return qids_; }
-                std::vector<GateWrapper> get_gates() { return gates_; }
-
-                void setQids(std::vector<unsigned> qids) {
-                    qids_ = qids;
-                }
-
-                void append_gates(std::vector<GateWrapper> gates) {
-                    gates_.insert(gates_.end(), gates.begin(), gates.end());
-                }
-
-                size_t size() {
-                    return gates_.size();
-                }
-
-                // Greedy method that finds next appropriate cluster
-                std::pair<Cluster, std::vector<unsigned>> next_cluster(std::vector<Cluster>& nextClusters, unsigned maxWidth) {
-                    std::vector<unsigned>   myUnion;                                // My qubits touched + Next qubits touched
-                    std::vector<unsigned>   myDiff;                                 // New qubits touched by Next
-                    std::vector<unsigned>   myInter;                                // Old qubits touched by Next
-                    std::vector<unsigned>   allInter;                               // My qubits + All touched qubits
-                    std::set<unsigned>      myTouched(qids_.begin(), qids_.end());  // My qubits touched
-                    std::set<unsigned>      allTouched = myTouched;                 // All the qubits touched so far
-
-                    int lastNexts = (int)nextClusters.size() - 1;                   // nexts are in reverse order (from above)
-                    for (int i = 0; i <= lastNexts; i++) {                          // Look at the clusters that follow us
-                        auto   nextQs = nextClusters[lastNexts-i].get_qids();       // Pull off one future cluster
-                        std::sort(nextQs.begin(), nextQs.end());                    // Has to be sorted for set operations
-                        myUnion.clear();
-                        std::set_union(nextQs.begin(), nextQs.end(),                // See what qubits we and the future cluster touch
-                            myTouched.begin(), myTouched.end(),
-                            std::back_inserter(myUnion));
-                        if (myUnion.size() <= maxWidth) {                           // It's a candiate if it's not beyond our allowed width
-                            myDiff.clear();
-                            std::set_difference(nextQs.begin(), nextQs.end(),       // Figure out if any of the future qubits aren't already seen by us
-                                myTouched.begin(), myTouched.end(),
-                                std::back_inserter(myDiff));
-                            allInter.clear();
-                            std::set_intersection(myDiff.begin(), myDiff.end(),     // These are any new qubits that might have already been touched
-                                allTouched.begin(), allTouched.end(),
-                                std::back_inserter(allInter));
-                            if (allInter.size() == 0) {                             // If the new qubits are untouched... then this is allowed
-                                auto cl = nextClusters[lastNexts-i];
-                                nextClusters.erase(nextClusters.begin() + (lastNexts-i));       // Remove the future cluster
-                                return std::make_pair(cl, myUnion);                 // ... and add it to our cluster (done above)
-                            }
-                        }
-                        myInter.clear();
-                        std::set_intersection(nextQs.begin(), nextQs.end(),         // If a future cluster touches any of our qubits... we've hit a hard wall
-                            myTouched.begin(), myTouched.end(),
-                            std::back_inserter(myInter));
-                        if (myInter.size() != 0) break;
-
-                        allTouched.insert(nextQs.begin(), nextQs.end());            // Add in all qubits touched, and try the next cluster
-                    }
-                    Cluster defCl = Cluster({}, {});                                // Couldn't find any more clusters to add
-                    std::vector<unsigned> defVec = {};
-                    return std::make_pair(defCl, defVec);
-                }
-        private:
-            std::vector<unsigned> qids_;
-            std::vector<GateWrapper> gates_;
-            };
+  private:
+    std::vector<unsigned> qids_;
+    std::vector<GateWrapper> gates_;
+};
 
 /// A wave function class to store and manipulate the state of qubits
 
 template <class T = ComplexType>
 class Wavefunction
 {
-public:
+  public:
     using value_type = T;
     using qubit_t = unsigned;
     using RngEngine = std::mt19937;
 
-    constexpr qubit_t invalid_qubit() const { return std::numeric_limits<qubit_t>::max(); }
+    constexpr qubit_t invalid_qubit() const
+    {
+        return std::numeric_limits<qubit_t>::max();
+    }
 
     /// allocate a wave function for zero qubits
-    Wavefunction(unsigned /*ignore*/) : num_qubits_(0), wfn_(1, 1.), usage_(0)
+    Wavefunction(unsigned /*ignore*/)
+        : num_qubits_(0)
+        , wfn_(1, 1.)
+        , usage_(0)
     {
         rng_.seed(std::clock());
     }
@@ -175,22 +219,28 @@ public:
     void flush() const
     {
         int maxSpan = fused_.maxSpan();
-        auto clusters = make_clusters(maxSpan, gatelist_); //making clusters with gates in the queue
+        auto clusters = make_clusters(maxSpan, gatelist_); // making clusters with gates in the queue
 
-        if (clusters.size() == 0) {
+        if (clusters.size() == 0)
+        {
             fused_.flush(wfn_);
         }
-        else {
+        else
+        {
             // logic to flush gates in each cluster
-            for (int i = 0; i < clusters.size(); i++) {
+            for (int i = 0; i < clusters.size(); i++)
+            {
                 Cluster cl = clusters.at(i);
 
-                for (GateWrapper gate : cl.get_gates()) {
+                for (GateWrapper gate : cl.get_gates())
+                {
                     std::vector<unsigned> cs = gate.get_controls();
-                    if (cs.size() == 0) {
+                    if (cs.size() == 0)
+                    {
                         fused_.apply(wfn_, gate.get_mat(), qubit(gate.get_target()));
                     }
-                    else {
+                    else
+                    {
                         fused_.apply_controlled(wfn_, gate.get_mat(), qubits(cs), qubit(gate.get_target()));
                     }
                 }
@@ -215,7 +265,8 @@ public:
             qubitmap_[num] = num_qubits_++;
             return num;
         }
-        else {
+        else
+        {
             qubitmap_.push_back(num_qubits_++);
             return static_cast<unsigned>(qubitmap_.size() - 1);
         }
@@ -228,10 +279,12 @@ public:
         usage_ = 2;
         flush();
         wfn_.resize(2 * wfn_.size());
-        if (id < qubitmap_.size()) {
+        if (id < qubitmap_.size())
+        {
             qubitmap_[id] = num_qubits_++;
         }
-        else {
+        else
+        {
             assert(id == qubitmap_.size());
             qubitmap_.push_back(num_qubits_++);
         }
@@ -242,12 +295,11 @@ public:
     /// \pre the qubit has to be in a classical state in the computational basis
     void release(qubit_t q)
     {
-        unsigned p = qubit(q); //returns qubitmap_[q]
+        unsigned p = qubit(q); // returns qubitmap_[q]
         flush();
         kernels::collapse(wfn_, p, getvalue(q), true);
         for (int i = 0; i < qubitmap_.size(); ++i)
-            if (qubitmap_[i] > p && qubitmap_[i] != invalid_qubit())
-                qubitmap_[i]--;
+            if (qubitmap_[i] > p && qubitmap_[i] != invalid_qubit()) qubitmap_[i]--;
         qubitmap_[q] = invalid_qubit();
         --num_qubits_;
     }
@@ -303,7 +355,8 @@ public:
         return result;
     }
 
-    void apply_controlled_exp(std::vector<Gates::Basis> const& bs,
+    void apply_controlled_exp(
+        std::vector<Gates::Basis> const& bs,
         double phi,
         std::vector<unsigned> const& cs,
         std::vector<unsigned> const& qs)
@@ -326,8 +379,7 @@ public:
         flush();
         assert(isclassical(q));
         int res = kernels::getvalue(wfn_, qubit(q));
-        if (res == 2)
-            std::cout << *this;
+        if (res == 2) std::cout << *this;
 
         assert(res < 2);
         return res == 1;
@@ -346,51 +398,60 @@ public:
         rng_.seed(s);
     }
 
-    //method that makes clusters to be flushed
-    std::vector<Cluster> make_clusters(unsigned fuseSpan, std::vector<GateWrapper> gates) const {
+    // method that makes clusters to be flushed
+    std::vector<Cluster> make_clusters(unsigned fuseSpan, std::vector<GateWrapper> gates) const
+    {
         std::vector<Cluster> curClusters;
 
-        if (gates.size() > 0) {
-            //creating initial cluster containing one gate each
-            for (int i = 0; i < gates.size(); i++) {
+        if (gates.size() > 0)
+        {
+            // creating initial cluster containing one gate each
+            for (int i = 0; i < gates.size(); i++)
+            {
                 std::vector<unsigned> qids;
                 std::vector<unsigned> controlQids = gates[i].get_controls();
-                if (controlQids.size() > 0) {
+                if (controlQids.size() > 0)
+                {
                     qids = controlQids;
                 }
                 qids.push_back(gates[i].get_target());
-                Cluster newCl = Cluster(qids, { gates[i] });
+                Cluster newCl = Cluster(qids, {gates[i]});
                 curClusters.push_back(newCl);
             }
-            //creating clusters using greedy algorithm
-            for (int i = 1; i < (int)fuseSpan + 1; i++) {                                   // Build clusters of width 1,2,...
-                std::reverse(curClusters.begin(), curClusters.end());                       // Keep everything in reverse order
-                auto prevClusters = curClusters;                                            // Save away the last set of clusters built
+            // creating clusters using greedy algorithm
+            for (int i = 1; i < (int)fuseSpan + 1; i++)
+            {                                                         // Build clusters of width 1,2,...
+                std::reverse(curClusters.begin(), curClusters.end()); // Keep everything in reverse order
+                auto prevClusters = curClusters;                      // Save away the last set of clusters built
                 curClusters.clear();
-                auto prevCluster = prevClusters.back();                                     // Pop the first cluster
+                auto prevCluster = prevClusters.back(); // Pop the first cluster
                 prevClusters.pop_back();
-                while (prevClusters.size() > 0)  {                                          // While there are more clusters...
-                    auto foundCompat = prevCluster.next_cluster(prevClusters, i);           // See if we can accumlate anyone who follows
+                while (prevClusters.size() > 0)
+                { // While there are more clusters...
+                    auto foundCompat =
+                        prevCluster.next_cluster(prevClusters, i); // See if we can accumlate anyone who follows
                     Cluster clusterFound = foundCompat.first;
                     std::vector<unsigned> foundTotQids = foundCompat.second;
-                    if (clusterFound.get_gates().size() == 0 ||                             // Can't append any more clusters to this one
-                        (int)prevCluster.size() >= fused_.maxDepth()) {                     // ... or we're beyond max depth
-                        curClusters.push_back(prevCluster);                                 // Save this cluster
+                    if (clusterFound.get_gates().size() == 0 || // Can't append any more clusters to this one
+                        (int)prevCluster.size() >= fused_.maxDepth())
+                    {                                       // ... or we're beyond max depth
+                        curClusters.push_back(prevCluster); // Save this cluster
                         if (prevCluster.size() > 0)
                         {
                             prevCluster = prevClusters.back();
                             prevClusters.pop_back();
                         }
                     }
-                    else {
-                        prevCluster.setQids(foundTotQids);                                  // New version of our cluster (appended)
+                    else
+                    {
+                        prevCluster.setQids(foundTotQids); // New version of our cluster (appended)
                         prevCluster.append_gates(clusterFound.get_gates());
                     }
-                }                                                                           // Keep looking for clusters to add
-                curClusters.push_back(prevCluster);                                         // Save the final cluster
-            }                                                                               // Start all over with the next larger span
+                }                                   // Keep looking for clusters to add
+                curClusters.push_back(prevCluster); // Save the final cluster
+            }                                       // Start all over with the next larger span
         }
-        
+
         return curClusters;
     }
 
@@ -401,7 +462,8 @@ public:
         std::vector<qubit_t> cs;
         GateWrapper gateApplied = GateWrapper(cs, g.qubit(), g.matrix());
         gatelist_.push_back(gateApplied);
-        if (gatelist_.size() > 999) {
+        if (gatelist_.size() > 999)
+        {
             flush();
         }
 
@@ -415,10 +477,11 @@ public:
         std::vector<qubit_t> pcs = qubits(cs);
         GateWrapper gateApplied = GateWrapper(cs, g.qubit(), g.matrix());
         gatelist_.push_back(gateApplied);
-        if (gatelist_.size() > 999) {
+        if (gatelist_.size() > 999)
+        {
             flush();
         }
-        
+
         int doFlush = fused_.shouldFlush(wfn_, cs, g.qubit());
     }
 
@@ -447,10 +510,12 @@ public:
         return kernels::subsytemwavefunction(wfn_, qubits(qs), qubitswfn, tolerance);
     }
 
-
     // apply permutation of basis states to the wave function
-    void permute_basis(std::vector<unsigned> const& qs, std::size_t table_size,
-        std::size_t const* permutation_table, bool adjoint = false)
+    void permute_basis(
+        std::vector<unsigned> const& qs,
+        std::size_t table_size,
+        std::size_t const* permutation_table,
+        bool adjoint = false)
     {
         assert(table_size == 1ull << qs.size());
         flush();
@@ -484,7 +549,6 @@ public:
         return rng_;
     }
 
-
     std::vector<qubit_t> qubits(std::vector<qubit_t> const& qs) const
     {
         std::vector<qubit_t> ps;
@@ -501,22 +565,21 @@ public:
         {
             if (qubitmap_[i] != invalid_qubit()) qs.push_back(i);
         }
-    
+
         return qs;
     }
 
   private:
-    unsigned num_qubits_;             // for convenience
-    mutable WavefunctionStorage wfn_; // storing the wave function
-    mutable std::vector<qubit_t> qubitmap_;   // mapping of logical to physical qubits
-	int usage_;
+    unsigned num_qubits_;                   // for convenience
+    mutable WavefunctionStorage wfn_;       // storing the wave function
+    mutable std::vector<qubit_t> qubitmap_; // mapping of logical to physical qubits
+    int usage_;
     mutable std::vector<GateWrapper> gatelist_;
 
     // randomness support
     RngEngine rng_;
     Fused fused_;
 };
-
 
 /// print information about the wave function
 template <class T>
@@ -525,10 +588,9 @@ std::ostream& operator<<(std::ostream& out, Wavefunction<T> const& wfn)
     wfn.flush();
     out << "Wave function for " << wfn.num_qubits() << " with " << wfn.data().size() << " elements "
         << " using " << sizeof(T) * wfn.data().size() << " bytes" << std::endl;
-    if (wfn.num_qubits() <= 6)
-        std::copy(wfn.data().begin(), wfn.data().end(), std::ostream_iterator<T>(out, "\n"));
+    if (wfn.num_qubits() <= 6) std::copy(wfn.data().begin(), wfn.data().end(), std::ostream_iterator<T>(out, "\n"));
     return out;
 }
-}
-}
-}
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/alignedalloc.hpp
+++ b/src/Simulation/Native/src/util/alignedalloc.hpp
@@ -42,13 +42,9 @@ class AlignedAlloc
         using other = AlignedAlloc<U, Align>;
     };
 
-    AlignedAlloc() noexcept
-    {
-    }
+    AlignedAlloc() noexcept {}
 
-    AlignedAlloc(AlignedAlloc const&) noexcept
-    {
-    }
+    AlignedAlloc(AlignedAlloc const&) noexcept {}
 
     template <typename U>
     AlignedAlloc(AlignedAlloc<U, Align> const&) noexcept
@@ -58,15 +54,13 @@ class AlignedAlloc
     pointer allocate(size_type n)
     {
         pointer ptr;
-        SafeInt<size_type> sz (n);
+        SafeInt<size_type> sz(n);
         sz *= sizeof(T);
 #ifdef _WIN32
         ptr = reinterpret_cast<pointer>(_aligned_malloc(sz, Align));
-        if (ptr == 0)
-            throw std::bad_alloc();
+        if (ptr == 0) throw std::bad_alloc();
 #else
-        if (posix_memalign(reinterpret_cast<void**>(&ptr), Align, sz))
-            throw std::bad_alloc();
+        if (posix_memalign(reinterpret_cast<void**>(&ptr), Align, sz)) throw std::bad_alloc();
 #endif
         return ptr;
     }
@@ -118,6 +112,6 @@ class AlignedAlloc
     }
 };
 
-}
-}
-}
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/argmaxnrm2.hpp
+++ b/src/Simulation/Native/src/util/argmaxnrm2.hpp
@@ -57,5 +57,5 @@ std::size_t argmaxnrm2(const std::vector<T, A>& values)
 
     return argmaxs[argmax - begin(argmaxvals)] - begin(values);
 }
-}
-}
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/bititerator.hpp
+++ b/src/Simulation/Native/src/util/bititerator.hpp
@@ -66,7 +66,8 @@ struct bititerator
     std::uint64_t const_bits_mask;
     std::uint64_t mask_values;
 
-    bititerator(std::uint64_t start, const std::vector<unsigned>& bits_positions_to_iterate) : b(start)
+    bititerator(std::uint64_t start, const std::vector<unsigned>& bits_positions_to_iterate)
+        : b(start)
     {
         const unsigned bitsize = sizeof(b) * 8;
         std::vector<unsigned> const_bits_positions = complement(bits_positions_to_iterate, bitsize);
@@ -89,9 +90,10 @@ struct bititerator
         mask_values = mask.to_ullong();
     }
 
-    bititerator(std::uint64_t start_for_bits_to_iterate,
-                std::uint64_t rest,
-                const std::vector<unsigned>& bits_positions_to_iterate)
+    bititerator(
+        std::uint64_t start_for_bits_to_iterate,
+        std::uint64_t rest,
+        const std::vector<unsigned>& bits_positions_to_iterate)
         : bititerator(sparse_map(bits_positions_to_iterate, start_for_bits_to_iterate, rest), bits_positions_to_iterate)
     {
     }
@@ -105,5 +107,5 @@ struct bititerator
         return *this;
     }
 };
-}
-}
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/bitops.hpp
+++ b/src/Simulation/Native/src/util/bitops.hpp
@@ -14,12 +14,10 @@
 
 #include <bitset>
 
-
 namespace Microsoft
 {
 namespace Quantum
 {
-
 
 /// the logarithm base 2 of  an integer
 
@@ -28,8 +26,7 @@ unsigned ilog2(Int n)
 {
 #ifdef _WIN32
     for (unsigned width = 0; width < 8 * sizeof(Int); ++width)
-        if ((static_cast<Int>(1) << width) == n)
-            return width;
+        if ((static_cast<Int>(1) << width) == n) return width;
     // not a power of 2
     assert(false);
     return std::numeric_limits<unsigned>::max(); // dummy return
@@ -39,8 +36,6 @@ unsigned ilog2(Int n)
     return l;
 #endif
 }
-
-
 
 // bit count
 inline unsigned popcnt(uint64_t x)
@@ -52,7 +47,7 @@ inline unsigned popcnt(uint64_t x)
     return _popcnt64(x);
 #endif
 #else
-  return static_cast<unsigned>(std::bitset<64>(x).count());
+    return static_cast<unsigned>(std::bitset<64>(x).count());
 #endif
 }
 
@@ -62,5 +57,5 @@ inline bool poppar(uint64_t x)
     return popcnt(x) & 1u;
 }
 
-}
-}
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/bitops_test.cpp
+++ b/src/Simulation/Native/src/util/bitops_test.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-
 #include <cassert>
 #include <limits>
 

--- a/src/Simulation/Native/src/util/cpuid.hpp
+++ b/src/Simulation/Native/src/util/cpuid.hpp
@@ -7,99 +7,92 @@
 #include <intrin.h>
 #endif
 
-
 namespace Microsoft
 {
-  namespace Quantum
-  {
+namespace Quantum
+{
 
-    inline bool haveAVX()
+inline bool haveAVX()
+{
+    try
     {
-      try
-      {
 #ifndef _MSC_VER
         return __builtin_cpu_supports("avx");
 #else
         int cpuInfo[4];
-        __cpuid(cpuInfo,0);
-        if (cpuInfo[0]<1)
-          return false;
+        __cpuid(cpuInfo, 0);
+        if (cpuInfo[0] < 1) return false;
         __cpuid(cpuInfo, 1);
-        return cpuInfo[2]&(1u<<28);
+        return cpuInfo[2] & (1u << 28);
 #endif
-      }
-      catch (const std::exception&)
-      {
-        return false;
-      }
     }
-  
-    inline bool haveAVX512()
+    catch (const std::exception&)
     {
-      try
-      {
-#ifndef _MSC_VER
-        //__builtin_cpu_init();
-          return (__builtin_cpu_supports("avx512f") != 0 && __builtin_cpu_supports("avx512cd") != 0);
-#else
-        int cpuInfo[4];
-        __cpuid(cpuInfo,0);
-        if (cpuInfo[0]<7)
-          return false;
-        __cpuid(cpuInfo, 7);
-        return cpuInfo[1]&(1u<<16);
-#endif
-      }
-      catch (const std::exception&)
-      {
         return false;
-      }
     }
-
-    inline bool haveAVX2()
-    {
-      try
-      {
-#ifndef _MSC_VER
-        //__builtin_cpu_init();
-        return __builtin_cpu_supports("avx2");
-#else
-        int cpuInfo[4];
-        __cpuid(cpuInfo,0);
-        if (cpuInfo[0]<7)
-          return false;
-        __cpuid(cpuInfo, 7);
-        return cpuInfo[1]&(1u<<5);
-#endif
-      }
-      catch (const std::exception&)
-      {
-        return false;
-      }
-    }
-
-    inline bool haveFMA()
-    {
-      try
-      {
-#ifndef _MSC_VER
-        //__builtin_cpu_init();
-        return __builtin_cpu_supports("avx2");
-#else
-        int cpuInfo[4];
-        __cpuid(cpuInfo,0);
-        if (cpuInfo[0]<1)
-          return false;
-        __cpuid(cpuInfo, 1);
-        return cpuInfo[2]&(1u<<12);
-#endif
-      }
-      catch (const std::exception&)
-      {
-        return false;
-      }
-    }
-  }
 }
 
+inline bool haveAVX512()
+{
+    try
+    {
+#ifndef _MSC_VER
+        //__builtin_cpu_init();
+        return (__builtin_cpu_supports("avx512f") != 0 && __builtin_cpu_supports("avx512cd") != 0);
+#else
+        int cpuInfo[4];
+        __cpuid(cpuInfo, 0);
+        if (cpuInfo[0] < 7) return false;
+        __cpuid(cpuInfo, 7);
+        return cpuInfo[1] & (1u << 16);
+#endif
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+}
 
+inline bool haveAVX2()
+{
+    try
+    {
+#ifndef _MSC_VER
+        //__builtin_cpu_init();
+        return __builtin_cpu_supports("avx2");
+#else
+        int cpuInfo[4];
+        __cpuid(cpuInfo, 0);
+        if (cpuInfo[0] < 7) return false;
+        __cpuid(cpuInfo, 7);
+        return cpuInfo[1] & (1u << 5);
+#endif
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+}
+
+inline bool haveFMA()
+{
+    try
+    {
+#ifndef _MSC_VER
+        //__builtin_cpu_init();
+        return __builtin_cpu_supports("avx2");
+#else
+        int cpuInfo[4];
+        __cpuid(cpuInfo, 0);
+        if (cpuInfo[0] < 1) return false;
+        __cpuid(cpuInfo, 1);
+        return cpuInfo[2] & (1u << 12);
+#endif
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+}
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/cpuid_test.cpp
+++ b/src/Simulation/Native/src/util/cpuid_test.cpp
@@ -6,15 +6,12 @@
 
 int main()
 {
-  if(Microsoft::Quantum::haveAVX512())
-  std::cout << "Have AVX-512\n";
-  if(Microsoft::Quantum::haveAVX2())
-  std::cout << "Have AVX2\n";
-  if(Microsoft::Quantum::haveFMA())
-  std::cout << "Have FMA\n";
-  if(Microsoft::Quantum::haveAVX())
-    std::cout << "Have AVX\n";
-  else
-    std::cout << "Don't have AVX\n";
+    if (Microsoft::Quantum::haveAVX512()) std::cout << "Have AVX-512\n";
+    if (Microsoft::Quantum::haveAVX2()) std::cout << "Have AVX2\n";
+    if (Microsoft::Quantum::haveFMA()) std::cout << "Have FMA\n";
+    if (Microsoft::Quantum::haveAVX())
+        std::cout << "Have AVX\n";
+    else
+        std::cout << "Don't have AVX\n";
     return 0;
 }

--- a/src/Simulation/Native/src/util/diagmatrix.hpp
+++ b/src/Simulation/Native/src/util/diagmatrix.hpp
@@ -26,9 +26,7 @@ class DiagMatrix
     using const_reference = value_type const&;
     using size_type = unsigned;
 
-    DiagMatrix()
-    {
-    }
+    DiagMatrix() {}
 
     DiagMatrix(DiagMatrix const&) = default;
     DiagMatrix& operator=(DiagMatrix const&) = default;
@@ -108,8 +106,7 @@ class DiagMatrix
     bool operator==(DiagMatrix<U, N> const& rhs) const
     {
         for (unsigned i = 0; i < this->rows(); ++i)
-            if (diag_[i] != rhs(i, i))
-                return false;
+            if (diag_[i] != rhs(i, i)) return false;
         return true;
     }
 
@@ -123,6 +120,6 @@ class DiagMatrix
   private:
     value_type diag_[N];
 };
-}
-}
-}
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/diagmatrix_test.cpp
+++ b/src/Simulation/Native/src/util/diagmatrix_test.cpp
@@ -36,8 +36,7 @@ void testsize()
     assert(matc == matb);
     assert(matc == matc);
 
-    if (mat.size() != 0)
-        assert(&mat(0, 0) == mat.data());
+    if (mat.size() != 0) assert(&mat(0, 0) == mat.data());
 
     // test assignments
     Microsoft::Quantum::SIMULATOR::DiagMatrix<T, N> mate;

--- a/src/Simulation/Native/src/util/openmp.cpp
+++ b/src/Simulation/Native/src/util/openmp.cpp
@@ -8,8 +8,7 @@
 void Microsoft::Quantum::openmp::init(unsigned numthreads)
 {
 #ifdef _OPENMP
-    if (numthreads)
-        omp_set_num_threads(numthreads);
+    if (numthreads) omp_set_num_threads(numthreads);
 #if defined(__ICC) || defined(__INTEL_COMPILER)
     kmp_set_defaults("KMP_AFFINITY=compact");
 #endif

--- a/src/Simulation/Native/src/util/openmp.hpp
+++ b/src/Simulation/Native/src/util/openmp.hpp
@@ -5,8 +5,8 @@
 
 #include "config.hpp"
 
-#include <thread>
 #include <mutex>
+#include <thread>
 
 #ifdef _OPENMP
 #include "omp.h"
@@ -89,20 +89,19 @@ class omp_recursive_mutex
     omp_nest_lock_t _mutex;
 };
 
-  using mutex_type = omp_mutex;
-  using recursive_mutex_type = omp_recursive_mutex;
+using mutex_type = omp_mutex;
+using recursive_mutex_type = omp_recursive_mutex;
 
 #else
-  using mutex_type = std::mutex;
-  using recursive_mutex_type = std::recursive_mutex;
+using mutex_type = std::mutex;
+using recursive_mutex_type = std::recursive_mutex;
 #endif
-  
 
-}
-  using openmp::mutex_type;
-  using openmp::recursive_mutex_type;
-  using lock_type = std::lock_guard<mutex_type>;
-  using recursive_lock_type = std::lock_guard<recursive_mutex_type>;
+} // namespace openmp
+using openmp::mutex_type;
+using openmp::recursive_mutex_type;
+using lock_type = std::lock_guard<mutex_type>;
+using recursive_lock_type = std::lock_guard<recursive_mutex_type>;
 
-}
-}
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/openmp_test.cpp
+++ b/src/Simulation/Native/src/util/openmp_test.cpp
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 #include "util/openmp.hpp"
-#include <mutex>
 #include <cassert>
+#include <mutex>
 
 int main()
 {

--- a/src/Simulation/Native/src/util/splitinterval.hpp
+++ b/src/Simulation/Native/src/util/splitinterval.hpp
@@ -32,5 +32,5 @@ static std::vector<std::size_t> split_interval_in_chunks(std::size_t max, std::s
     assert(res[res.size() - 1] == max);
     return res;
 }
-}
-}
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/tinymatrix.hpp
+++ b/src/Simulation/Native/src/util/tinymatrix.hpp
@@ -28,9 +28,7 @@ class TinyMatrix
     using const_reference = value_type const&;
     using size_type = unsigned;
 
-    TinyMatrix()
-    {
-    }
+    TinyMatrix() {}
 
     TinyMatrix(TinyMatrix const&) = default;
     TinyMatrix& operator=(TinyMatrix const&) = default;
@@ -127,8 +125,7 @@ class TinyMatrix
     {
         for (unsigned i = 0; i < this->rows(); ++i)
             for (unsigned j = 0; j < this->cols(); ++j)
-                if (mat_[i][j] != rhs(i, j))
-                    return false;
+                if (mat_[i][j] != rhs(i, j)) return false;
         return true;
     }
 
@@ -142,6 +139,6 @@ class TinyMatrix
   private:
     value_type mat_[M][N];
 };
-}
-}
-}
+} // namespace SIMULATOR
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Simulation/Native/src/util/tinymatrix_test.cpp
+++ b/src/Simulation/Native/src/util/tinymatrix_test.cpp
@@ -37,8 +37,7 @@ void testsize()
     assert(matc == matb);
     assert(matc == matc);
 
-    if (mat.size() != 0)
-        assert(&mat(0, 0) == mat.data());
+    if (mat.size() != 0) assert(&mat(0, 0) == mat.data());
 
     // test assignments
     Microsoft::Quantum::SIMULATOR::TinyMatrix<T, N, M> mate;


### PR DESCRIPTION
Added a .clang-format that is almost identical to the one we are using in QirRuntime (because of the deep hierarchy of namespaces to cut on wasted leading space had to set `NamespaceIndentation: None`). The rest of the change is a mechanical reformatting of all files in the Native Simulator folder except the external ones.

Note on .clang-format: presence of this file in the project doesn't affect the build and doesn't cause the formatting to be applied automatically, but devs with clang tools installed can manually invoke the formatter to ensure consistency across the project (and it's also handy to reflow comments, etc. during writing the code).

This is 1st installment towards https://github.com/microsoft/qsharp-runtime/pull/409. I'll appreciate a quick review, if possible, so I can move on with the more substantial refactors. Thanks!