### PR TITLE
Fixing negative exponentiation in ExpFrac

### DIFF
--- a/src/Simulation/TargetDefinitions/Decompositions/ExpFrac.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ExpFrac.qs
@@ -31,6 +31,8 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Register to apply the given rotation to.
     @EnableTestingViaName("Test.TargetDefinitions.ExpFrac")
     operation ExpFrac (paulis : Pauli[], numerator : Int, power : Int, qubits : Qubit[]) : Unit is Adj + Ctl {
+        // Note that power must be converted to a double and used with 2.0 instead of 2 to allow for
+        // negative exponents that result in a fractional denominator.
         let angle = (PI() * IntAsDouble(numerator)) / (2.0 ^ IntAsDouble(power));
         Exp(paulis, angle, qubits);
     }

--- a/src/Simulation/TargetDefinitions/Decompositions/ExpFrac.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ExpFrac.qs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Register to apply the given rotation to.
     @EnableTestingViaName("Test.TargetDefinitions.ExpFrac")
     operation ExpFrac (paulis : Pauli[], numerator : Int, power : Int, qubits : Qubit[]) : Unit is Adj + Ctl {
-        let angle = (PI() * IntAsDouble(numerator)) / IntAsDouble(2 ^ power);
+        let angle = (PI() * IntAsDouble(numerator)) / (2.0 ^ IntAsDouble(power));
         Exp(paulis, angle, qubits);
     }
 }

--- a/src/Simulation/TargetDefinitions/Decompositions/RFrac.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RFrac.qs
@@ -41,6 +41,8 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```
     @EnableTestingViaName("Test.TargetDefinitions.RFrac")
     operation RFrac (pauli : Pauli, numerator : Int, power : Int, qubit : Qubit) : Unit is Adj + Ctl {
+        // Note that power must be converted to a double and used with 2.0 instead of 2 to allow for
+        // negative exponents that result in a fractional denominator.
         let angle = ((-2.0 * PI()) * IntAsDouble(numerator)) / (2.0 ^ IntAsDouble(power));
         R(pauli, angle, qubit);
     }


### PR DESCRIPTION
Turns out I forgot to fix the same bug in ExpFrac as I already fixed in RFrac (see #414).