### PR TITLE
Native Simulator: refactor clustering algorithm to copy less memory around (plus a bug fix)

### DIFF
--- a/src/Simulation/Native/src/simulator/local_test.cpp
+++ b/src/Simulation/Native/src/simulator/local_test.cpp
@@ -188,18 +188,18 @@ TEST_CASE("Clustering", "[local_test]")
     TinyMatrix<ComplexType, 2> ignore;
     const int unlimited = 99;
 
-    GateWrapper g_n_1({} /*controls*/, 1 /*target*/, ignore);
-    GateWrapper g_n_2({} /*controls*/, 2 /*target*/, ignore);
-    GateWrapper g_n_3({} /*controls*/, 3 /*target*/, ignore);
-    GateWrapper g_n_4({} /*controls*/, 4 /*target*/, ignore);
-    GateWrapper g_1_2({1} /*controls*/, 2 /*target*/, ignore);
-    GateWrapper g_1_3({1} /*controls*/, 3 /*target*/, ignore);
-    GateWrapper g_2_3({2} /*controls*/, 3 /*target*/, ignore);
-    GateWrapper g_3_4({3} /*controls*/, 4 /*target*/, ignore);
+    DeferredGate g_n_1({} /*controls*/, 1 /*target*/, ignore);
+    DeferredGate g_n_2({} /*controls*/, 2 /*target*/, ignore);
+    DeferredGate g_n_3({} /*controls*/, 3 /*target*/, ignore);
+    DeferredGate g_n_4({} /*controls*/, 4 /*target*/, ignore);
+    DeferredGate g_1_2({1} /*controls*/, 2 /*target*/, ignore);
+    DeferredGate g_1_3({1} /*controls*/, 3 /*target*/, ignore);
+    DeferredGate g_2_3({2} /*controls*/, 3 /*target*/, ignore);
+    DeferredGate g_3_4({3} /*controls*/, 4 /*target*/, ignore);
 
     SECTION("Single qubit gates only") // {X(q1), Y(q1), X(q2), Z(q1), Y(q2)}
     {
-        std::vector<GateWrapper> gates{g_n_1, g_n_1, g_n_2, g_n_1, g_n_2};
+        std::vector<DeferredGate> gates{g_n_1, g_n_1, g_n_2, g_n_1, g_n_2};
         auto cls = Cluster::make_clusters(1 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
         REQUIRE(cls.size() == 2);
 
@@ -214,7 +214,7 @@ TEST_CASE("Clustering", "[local_test]")
 
     SECTION("CNOT as barrier") // {X(q1), Y(q1), CNOT(q1, q2), Z(q1)}
     {
-        std::vector<GateWrapper> gates{g_n_1, g_n_1, g_1_2, g_n_1};
+        std::vector<DeferredGate> gates{g_n_1, g_n_1, g_1_2, g_n_1};
         auto cls = Cluster::make_clusters(1 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
         REQUIRE(cls.size() == 3);
 
@@ -233,7 +233,7 @@ TEST_CASE("Clustering", "[local_test]")
 
     SECTION("Pull gate through a CNOT (width 1)") // X(q1), X(q2), CNOT(q2, q3), Y(q1)
     {
-        std::vector<GateWrapper> gates{g_n_1, g_n_2, g_2_3, g_n_1};
+        std::vector<DeferredGate> gates{g_n_1, g_n_2, g_2_3, g_n_1};
         auto cls = Cluster::make_clusters(2 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
         REQUIRE(cls.size() == 2);
 
@@ -253,7 +253,7 @@ TEST_CASE("Clustering", "[local_test]")
     // {X(q1), Y(q1), X(q2)}, {CNOT(q2, q3), Y(q2), X(q3)}
     SECTION("Pull gate through a CNOT (width 2)")
     {
-        std::vector<GateWrapper> gates{g_n_1, g_n_2, g_2_3, g_n_2, g_n_3, g_n_1};
+        std::vector<DeferredGate> gates{g_n_1, g_n_2, g_2_3, g_n_2, g_n_3, g_n_1};
         auto cls = Cluster::make_clusters(2 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
         REQUIRE(cls.size() == 2);
 
@@ -273,7 +273,7 @@ TEST_CASE("Clustering", "[local_test]")
     // cannot be merged into the first cluster and terminates it, preventing addition of Y(q2))
     SECTION("Many CNOT gates")
     {
-        std::vector<GateWrapper> gates{g_n_1, g_n_2, g_n_3, g_1_2, g_1_3, g_n_1, g_n_2, g_n_3};
+        std::vector<DeferredGate> gates{g_n_1, g_n_2, g_n_3, g_1_2, g_1_3, g_n_1, g_n_2, g_n_3};
         auto cls = Cluster::make_clusters(2 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
         REQUIRE(cls.size() == 3);
 
@@ -292,7 +292,7 @@ TEST_CASE("Clustering", "[local_test]")
 
     SECTION("Fusion limit on single qubit")
     {
-        std::vector<GateWrapper> gates{g_n_1, g_n_1, g_n_1, g_n_1};
+        std::vector<DeferredGate> gates{g_n_1, g_n_1, g_n_1, g_n_1};
         auto cls = Cluster::make_clusters(1 /*cluster qubit width*/, 2 /*gates per cluster*/, gates);
         REQUIRE(cls.size() == 2);
 
@@ -307,7 +307,7 @@ TEST_CASE("Clustering", "[local_test]")
 
     SECTION("Fusion limit on multiple qubits")
     {
-        std::vector<GateWrapper> gates{g_n_1, g_1_2, g_3_4, g_n_3};
+        std::vector<DeferredGate> gates{g_n_1, g_1_2, g_3_4, g_n_3};
         auto cls = Cluster::make_clusters(unlimited /*cluster qubit width*/, 2 /*gates per cluster*/, gates);
         REQUIRE(cls.size() == 2);
 

--- a/src/Simulation/Native/src/simulator/local_test.cpp
+++ b/src/Simulation/Native/src/simulator/local_test.cpp
@@ -182,6 +182,144 @@ TEST_CASE("Logical vs positional qubit ids", "[local_test]")
 
     REQUIRE(psi.num_qubits() == 0);
 }
+
+TEST_CASE("Clustering", "[local_test]")
+{
+    TinyMatrix<ComplexType, 2> ignore;
+    const int unlimited = 99;
+
+    GateWrapper g_n_1({} /*controls*/, 1 /*target*/, ignore);
+    GateWrapper g_n_2({} /*controls*/, 2 /*target*/, ignore);
+    GateWrapper g_n_3({} /*controls*/, 3 /*target*/, ignore);
+    GateWrapper g_n_4({} /*controls*/, 4 /*target*/, ignore);
+    GateWrapper g_1_2({1} /*controls*/, 2 /*target*/, ignore);
+    GateWrapper g_1_3({1} /*controls*/, 3 /*target*/, ignore);
+    GateWrapper g_2_3({2} /*controls*/, 3 /*target*/, ignore);
+    GateWrapper g_3_4({3} /*controls*/, 4 /*target*/, ignore);
+
+    SECTION("Single qubit gates only") // {X(q1), Y(q1), X(q2), Z(q1), Y(q2)}
+    {
+        std::vector<GateWrapper> gates{g_n_1, g_n_1, g_n_2, g_n_1, g_n_2};
+        auto cls = Cluster::make_clusters(1 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
+        REQUIRE(cls.size() == 2);
+
+        auto it = cls.begin();
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1});
+        CHECK(it->get_gates().size() == 3);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{2});
+        CHECK(it->get_gates().size() == 2);
+    }
+
+    SECTION("CNOT as barrier") // {X(q1), Y(q1), CNOT(q1, q2), Z(q1)}
+    {
+        std::vector<GateWrapper> gates{g_n_1, g_n_1, g_1_2, g_n_1};
+        auto cls = Cluster::make_clusters(1 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
+        REQUIRE(cls.size() == 3);
+
+        auto it = cls.begin();
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1});
+        CHECK(it->get_gates().size() == 2);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1, 2});
+        CHECK(it->get_gates().size() == 1);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1});
+        CHECK(it->get_gates().size() == 1);
+    }
+
+    SECTION("Pull gate through a CNOT (width 1)") // X(q1), X(q2), CNOT(q2, q3), Y(q1)
+    {
+        std::vector<GateWrapper> gates{g_n_1, g_n_2, g_2_3, g_n_1};
+        auto cls = Cluster::make_clusters(2 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
+        REQUIRE(cls.size() == 2);
+
+        auto it = cls.begin();
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1, 2});
+        CHECK(it->get_gates().size() == 3);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{2, 3});
+        CHECK(it->get_gates().size() == 1);
+    }
+
+    // X(q1), X(q2), CNOT(q2, q3), Y(q2), X(q3), Y(q1)
+    // Our clustering algorithm starts by clustering at width 1, which allows to combine Y(q1) and X(q1):
+    // {X(q1), Y(q1)}, {X(q2)}, {CNOT(q2, q3)}, {Y(q2)}, {X(q3)}
+    // The next step would create clusters of width 2:
+    // {X(q1), Y(q1), X(q2)}, {CNOT(q2, q3), Y(q2), X(q3)}
+    SECTION("Pull gate through a CNOT (width 2)")
+    {
+        std::vector<GateWrapper> gates{g_n_1, g_n_2, g_2_3, g_n_2, g_n_3, g_n_1};
+        auto cls = Cluster::make_clusters(2 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
+        REQUIRE(cls.size() == 2);
+
+        auto it = cls.begin();
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1, 2});
+        CHECK(it->get_gates().size() == 3);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{2, 3});
+        CHECK(it->get_gates().size() == 3);
+    }
+
+    // X(q1), X(q2), X(q3), CNOT(q1, q2), CNOT(q1, q3), Y(q1), Y(q2), Y(q3)
+    // For width 2 clustering our algorithm gets:
+    // {X(q1), X(q2), CNOT(q1, q2)}, {X(q3), CNOT(q1, q3), Y(q1), Y(q3)}, {Y(q2)}
+    // !and not this one: {X(q1), X(q2), CNOT(q1, q2), Y(q2)}, {X(q3), CNOT(q1, q3), Y(q1), Y(q3)} (because CNOT(q1, q3)
+    // cannot be merged into the first cluster and terminates it, preventing addition of Y(q2))
+    SECTION("Many CNOT gates")
+    {
+        std::vector<GateWrapper> gates{g_n_1, g_n_2, g_n_3, g_1_2, g_1_3, g_n_1, g_n_2, g_n_3};
+        auto cls = Cluster::make_clusters(2 /*cluster qubit width*/, unlimited /*gates per cluster*/, gates);
+        REQUIRE(cls.size() == 3);
+
+        auto it = cls.begin();
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1, 2});
+        CHECK(it->get_gates().size() == 3);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1, 3});
+        CHECK(it->get_gates().size() == 4);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{2});
+        CHECK(it->get_gates().size() == 1);
+    }
+
+    SECTION("Fusion limit on single qubit")
+    {
+        std::vector<GateWrapper> gates{g_n_1, g_n_1, g_n_1, g_n_1};
+        auto cls = Cluster::make_clusters(1 /*cluster qubit width*/, 2 /*gates per cluster*/, gates);
+        REQUIRE(cls.size() == 2);
+
+        auto it = cls.begin();
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1});
+        CHECK(it->get_gates().size() == 2);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1});
+        CHECK(it->get_gates().size() == 2);
+    }
+
+    SECTION("Fusion limit on multiple qubits")
+    {
+        std::vector<GateWrapper> gates{g_n_1, g_1_2, g_3_4, g_n_3};
+        auto cls = Cluster::make_clusters(unlimited /*cluster qubit width*/, 2 /*gates per cluster*/, gates);
+        REQUIRE(cls.size() == 2);
+
+        auto it = cls.begin();
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{1, 2});
+        CHECK(it->get_gates().size() == 2);
+
+        ++it;
+        CHECK(it->get_qids() == std::vector<logical_qubit_id>{3, 4});
+        CHECK(it->get_gates().size() == 2);
+    }
+}
 #endif
 
 template <class SIM>

--- a/src/Simulation/Native/src/simulator/wavefunction.hpp
+++ b/src/Simulation/Native/src/simulator/wavefunction.hpp
@@ -290,11 +290,6 @@ class Cluster
 
                 if (clusterFound == prevClusters.end() || prevCluster.size() >= maxFusedDepth)
                 {
-                    // This is a bug, because the found cluster won't be incorporated if the branch was taken due to
-                    // maxFusedDepth condition. The bug existed prior to the refactor, but was hidden by the fact that
-                    // the found cluster was removed from the list inside `find_compatible_cluster`.
-                    if (clusterFound != prevClusters.end()) prevClusters.erase(clusterFound);
-
                     // Cannot extend this cluster anymore, stash it away for the next pass and try to extend the next
                     // one from the list. Doing swap/move/pop in this order allows us to avoid copying clusters.
                     prevCluster.swap(prevClusters.front());

--- a/src/Simulation/Native/src/simulator/wavefunction.hpp
+++ b/src/Simulation/Native/src/simulator/wavefunction.hpp
@@ -68,7 +68,7 @@ class DeferredGate
         , mat_(mat)
     {
     }
-    
+
     const std::vector<logical_qubit_id>& get_controls() const
     {
         return controls_;
@@ -83,18 +83,69 @@ class DeferredGate
     }
 };
 
-// Creating a cluster datatype for new scheduling logic
+///
+/// A few utility functions for Cluster class
+///
+static bool is_sorted_assending(const std::vector<logical_qubit_id>& x)
+{
+    return std::adjacent_find(x.begin(), x.end(), std::greater<logical_qubit_id>()) == x.end();
+}
+
+static bool is_intersection_empty(const std::vector<logical_qubit_id>& x, const std::vector<logical_qubit_id>& y)
+{
+    assert(is_sorted_assending(x));
+    assert(is_sorted_assending(y));
+
+    std::vector<logical_qubit_id> intersection;
+    std::set_intersection(x.begin(), x.end(), y.begin(), y.end(), std::back_inserter(intersection));
+    return intersection.empty();
+}
+
+static bool is_intersection_empty(const std::vector<logical_qubit_id>& x, const std::set<logical_qubit_id>& y)
+{
+    assert(is_sorted_assending(x));
+
+    std::vector<logical_qubit_id> intersection;
+    std::set_intersection(x.begin(), x.end(), y.begin(), y.end(), std::back_inserter(intersection));
+    return intersection.empty();
+}
+
+///
+/// Cluster represents a group of gates that should be flushed together.
+///
 class Cluster
 {
+    /// Union of logical qubit ids for controls and targets of all gates in this cluster. For performance reasons must
+    /// be sorted in assending order.
     std::vector<logical_qubit_id> qids_;
+
+    /// Gates in this cluster. When flushing the cluster, the gates will be applied in order from left to rigth.
     std::vector<DeferredGate> gates_;
 
   public:
+    Cluster() = default;
     Cluster(const std::vector<logical_qubit_id>& qids, const std::vector<DeferredGate>& gates)
         : qids_(qids)
         , gates_(gates)
     {
+        assert(is_sorted_assending(qids));
     }
+    Cluster(Cluster&& other)
+        : qids_(std::move(other.qids_))
+        , gates_(std::move(other.gates_))
+    {
+    }
+
+    // prevent gratuitous copying of clusters (which might be quite large)
+    Cluster(const Cluster&) = delete;
+    Cluster& operator=(const Cluster&) = delete;
+
+    void swap(Cluster& other)
+    {
+        qids_.swap(other.qids_);
+        gates_.swap(other.gates_);
+    }
+
     const std::vector<logical_qubit_id>& get_qids() const
     {
         return qids_;
@@ -104,14 +155,15 @@ class Cluster
         return gates_;
     }
 
-    void setQids(const std::vector<logical_qubit_id>& qids)
+    Cluster& append(const Cluster& other)
     {
-        qids_ = qids;
-    }
+        gates_.insert(gates_.end(), other.gates_.begin(), other.gates_.end());
 
-    void append_gates(const std::vector<DeferredGate>& gates)
-    {
-        gates_.insert(gates_.end(), gates.begin(), gates.end());
+        std::vector<logical_qubit_id> merged;
+        std::set_union(other.qids_.begin(), other.qids_.end(), qids_.begin(), qids_.end(), std::back_inserter(merged));
+        qids_.swap(merged);
+
+        return *this;
     }
 
     size_t size() const
@@ -119,106 +171,146 @@ class Cluster
         return gates_.size();
     }
 
-    // Greedy method that finds next appropriate cluster
-    std::pair<Cluster, std::vector<logical_qubit_id>> next_cluster(
-        std::vector<Cluster>& nextClusters,
-        unsigned maxWidth)
+    bool empty() const
     {
-        std::vector<logical_qubit_id> myUnion;                            // My qubits touched + Next qubits touched
-        std::vector<logical_qubit_id> myDiff;                             // New qubits touched by Next
-        std::vector<logical_qubit_id> myInter;                            // Old qubits touched by Next
-        std::vector<logical_qubit_id> allInter;                           // My qubits + All touched qubits
-        std::set<logical_qubit_id> myTouched(qids_.begin(), qids_.end()); // My qubits touched
-        std::set<logical_qubit_id> allTouched = myTouched;                // All the qubits touched so far
-
-        int lastNexts = (int)nextClusters.size() - 1; // nexts are in reverse order (from above)
-        for (int i = 0; i <= lastNexts; i++)
-        {                                                         // Look at the clusters that follow us
-            auto nextQs = nextClusters[lastNexts - i].get_qids(); // Pull off one future cluster
-            std::sort(nextQs.begin(), nextQs.end());              // Has to be sorted for set operations
-            myUnion.clear();
-            std::set_union(
-                nextQs.begin(), nextQs.end(), // See what qubits we and the future cluster touch
-                myTouched.begin(), myTouched.end(), std::back_inserter(myUnion));
-            if (myUnion.size() <= maxWidth)
-            { // It's a candiate if it's not beyond our allowed width
-                myDiff.clear();
-                std::set_difference(
-                    nextQs.begin(), nextQs.end(), // Figure out if any of the future qubits aren't already seen by us
-                    myTouched.begin(), myTouched.end(), std::back_inserter(myDiff));
-                allInter.clear();
-                std::set_intersection(
-                    myDiff.begin(), myDiff.end(), // These are any new qubits that might have already been touched
-                    allTouched.begin(), allTouched.end(), std::back_inserter(allInter));
-                if (allInter.size() == 0)
-                { // If the new qubits are untouched... then this is allowed
-                    auto cl = nextClusters[lastNexts - i];
-                    nextClusters.erase(nextClusters.begin() + (lastNexts - i)); // Remove the future cluster
-                    return std::make_pair(cl, myUnion); // ... and add it to our cluster (done above)
-                }
-            }
-            myInter.clear();
-            std::set_intersection(
-                nextQs.begin(), nextQs.end(), // If a future cluster touches any of our qubits... we've hit a hard wall
-                myTouched.begin(), myTouched.end(), std::back_inserter(myInter));
-            if (myInter.size() != 0) break;
-
-            allTouched.insert(nextQs.begin(), nextQs.end()); // Add in all qubits touched, and try the next cluster
-        }
-        
-        // Couldn't find any more clusters to add
-        return std::make_pair(Cluster({}, {}), std::vector<logical_qubit_id>{});
+        return gates_.empty();
     }
 
-    // method that makes clusters to be flushed
-    static std::vector<Cluster> make_clusters(
+    /// We say that two clusters "commute" if their sets of qubits don't intersect. The list of clusters given to this
+    /// method is assumed to be in temporal order, where this cluster is implicitly the earliest. Our goal is to find a
+    /// cluster that can be commuted to the front of the list and merged with this cluster without increasing its width
+    /// beyond `max_cluster_width`. The algorithm picks first such cluster from the start of the list (with the least
+    /// distance to commute).
+    std::list<Cluster>::const_iterator find_compatible_cluster(
+        const std::list<Cluster>& nextClusters,
+        unsigned max_cluster_width)
+    {
+        // Union of all qubits in clusters that we are skipping as we are searching for the compatible one.
+        std::set<logical_qubit_id> skipped_qids;
+
+        for (auto candidate = nextClusters.begin(); candidate != nextClusters.end(); ++candidate)
+        {
+            const std::vector<logical_qubit_id>& candidate_qids = candidate->get_qids();
+
+            // New qubits the candidate cluster would add into this cluster.
+            std::vector<logical_qubit_id> qids_new;
+            std::set_difference(
+                candidate_qids.begin(), candidate_qids.end(), qids_.begin(), qids_.end(), std::back_inserter(qids_new));
+
+            // If the new qubits from the candidate cluster don't touch any of the clusters we've skipped, the candidate
+            // cluster is compatible with this one. But we also need to check that the new qubits wouldn't increase the
+            // width of the cluster too much.
+            if (is_intersection_empty(qids_new, skipped_qids) && (qids_.size() + qids_new.size() <= max_cluster_width))
+            {
+                return candidate;
+            }
+
+            // If the candidate cluster isn't compatible with this one but shares qubits, we treat it as a barrier no
+            // other cluster can be pulled through (<irinayat> example #5 below shows that this might lead to more
+            // final clusters than necessary -- why this condition and not checking for intersection of candidate_qids
+            // with qids_skipped?).
+            if (!is_intersection_empty(candidate_qids, qids_)) break;
+
+            skipped_qids.insert(candidate_qids.begin(), candidate_qids.end());
+        }
+
+        // Found no compatible cluster.
+        return nextClusters.end();
+    }
+
+    ///
+    /// Group given gates into clusters that should be flushed together (in the order of the returned list). The order
+    /// of elements in `gates` list represents the temporal order in which the gates were invoked.
+    ///
+    /// Cluster of width one can contain multiple single-qubit gates that apply to the same qubit. Cluster of width two
+    /// can contain multiple single- or two-qubit gates that apply to the same two qubits, and so on. Given a list of
+    /// gates in temporal order, our goal is to group them into clusters of gates that can be efficiently fused but such
+    /// that applying these clusters in order would be equivalent to applying the original gates sequence. Therefore,
+    /// the order of gates inside the cluster is important but it's not guaranteed to be the same as in the original
+    /// gates sequence.
+    ///
+    /// The greedy algorithm we use doesn't necessarily produce an 'optimal' clustering (e.g. it might not find the
+    /// clustering with the least number of clusters, or balance clusters in terms of gate/qubit counts, or group qubits
+    /// with close positional id together). To delay creating clusters that interfere with each other, the merging is
+    /// done in multiple passes that increment the number of allowed qubits per cluster until the maximum of `fuseSpan`
+    /// is reached.
+    ///
+    /// Examples:
+    ///
+    /// 1. Sequence of gates: {H(q1), X(q2), Y(q2), Z(q1)}
+    ///    Will be organized into clusters of width 1 as: {{q1: H(q1), Z(q1)}, {q2: X(q2), Y(q2)}}.
+    /// 2. Sequence of gates: {H(q1), Z(q1), CNOT(q1, q2), X(q1)}
+    ///    X(q1) gate cannot be clustered together with H and Z because that would affect execution of CNOT (these two
+    ///    gates don't commute). Thus, clusters of width 1 are:
+    ///    {{q1: H(q1), Z(q1)}, {q1, q2: CNOT(q1, q2)}, {q1: X(q1)}}.
+    ///    Note, that single-gate clusters might excede the maximum cluster width.
+    /// 3. Sequence of gates: X(q1), X(q2), CNOT(q2, q3), Y(q2), X(q3), Y(q1)
+    ///    Because the algorithm grows the clusters gradually, it will be able to combine X(q1) and Y(q1) when creating
+    ///    clusters of width 1, and on the second step for width 2 it will create:
+    ///    {q1, q2: X(q1), Y(q1), X(q2)}, {q2, q3: CNOT(q2, q3), Y(q2), X(q3)}
+    ///    Note, that running the algorithm for width = 3 doesn't change the clusters, and for width = 4 it would
+    ///    combine all gates together into single sequence, but in different order than the original!
+    /// 4. Sequence of gates: X(q1), X(q2), X(q3), CNOT(q1, q2), CNOT(q1, q3), Y(q1), Y(q2), Y(q3)
+    ///    For width 2 clustering our algorithm gets:
+    ///    {X(q1), X(q2), CNOT(q1, q2)}, {X(q3), CNOT(q1, q3), Y(q1), Y(q3)}, {Y(q2)}
+    ///    and not this one: {X(q1), X(q2), CNOT(q1, q2), Y(q2)}, {X(q3), CNOT(q1, q3), Y(q1), Y(q3)} (see the comment
+    ///    in `find_compatible_cluster`)
+    static std::list<Cluster> make_clusters(
         unsigned fuseSpan,
         int maxFusedDepth,
         const std::vector<DeferredGate>& gates)
     {
-        std::vector<Cluster> curClusters;
+        if (gates.empty()) return std::list<Cluster>{};
 
-        if (gates.size() > 0)
+        // Create initial clusters, containing one gate each.
+        std::list<Cluster> curClusters;
+        for (const DeferredGate& gate : gates)
         {
-            // creating initial cluster containing one gate each
-            for (int i = 0; i < gates.size(); i++)
+            std::vector<logical_qubit_id> qids = gate.get_controls();
+            qids.push_back(gate.get_target());
+            std::sort(qids.begin(), qids.end());
+            curClusters.emplace_back(qids, std::vector<DeferredGate>{gate});
+        }
+
+        // Run incremental left-to-right passes over the clusters, increasing the number of allowed qubits on each pass.
+        std::list<Cluster> prevClusters;
+        for (unsigned cluster_width = 1; cluster_width < fuseSpan + 1; cluster_width++)
+        {
+            assert(prevClusters.empty());
+            prevClusters.swap(curClusters);
+
+            Cluster prevCluster;
+            prevCluster.swap(prevClusters.front());
+            prevClusters.pop_front();
+
+            while (!prevClusters.empty())
             {
-                std::vector<logical_qubit_id> qids = gates[i].get_controls();
-                qids.push_back(gates[i].get_target());
-                curClusters.emplace_back(qids, std::vector<DeferredGate>{gates[i]});
+                std::list<Cluster>::const_iterator clusterFound =
+                    prevCluster.find_compatible_cluster(prevClusters, cluster_width);
+
+                if (clusterFound == prevClusters.end() || prevCluster.size() >= maxFusedDepth)
+                {
+                    // This is a bug, because the found cluster won't be incorporated if the branch was taken due to
+                    // maxFusedDepth condition. The bug existed prior to the refactor, but was hidden by the fact that
+                    // the found cluster was removed from the list inside `find_compatible_cluster`.
+                    if (clusterFound != prevClusters.end()) prevClusters.erase(clusterFound);
+
+                    // Cannot extend this cluster anymore, stash it away for the next pass and try to extend the next
+                    // one from the list. Doing swap/move/pop in this order allows us to avoid copying clusters.
+                    prevCluster.swap(prevClusters.front());
+                    curClusters.push_back(std::move(prevClusters.front()));
+                    prevClusters.pop_front();
+                }
+                else
+                {
+                    // Extend this cluster and try again whether it can be extended even further while keeping its
+                    // width <= cluster_width.
+                    prevCluster.append(*clusterFound);
+                    prevClusters.erase(clusterFound);
+                }
             }
-            // creating clusters using greedy algorithm
-            for (int i = 1; i < (int)fuseSpan + 1; i++)
-            {                                                         // Build clusters of width 1,2,...
-                std::reverse(curClusters.begin(), curClusters.end()); // Keep everything in reverse order
-                auto prevClusters = curClusters;                      // Save away the last set of clusters built
-                curClusters.clear();
-                auto prevCluster = prevClusters.back(); // Pop the first cluster
-                prevClusters.pop_back();
-                while (prevClusters.size() > 0)
-                { // While there are more clusters...
-                    auto foundCompat =
-                        prevCluster.next_cluster(prevClusters, i); // See if we can accumlate anyone who follows
-                    const Cluster& clusterFound = foundCompat.first;
-                    if (clusterFound.get_gates().size() == 0 || // Can't append any more clusters to this one
-                        (int)prevCluster.size() >= maxFusedDepth)
-                    {                                       // ... or we're beyond max depth
-                        curClusters.push_back(prevCluster); // Save this cluster
-                        if (prevCluster.size() > 0)
-                        {
-                            prevCluster = prevClusters.back();
-                            prevClusters.pop_back();
-                        }
-                    }
-                    else
-                    {
-                        const std::vector<logical_qubit_id>& foundTotQids = foundCompat.second;
-                        prevCluster.setQids(foundTotQids); // New version of our cluster (appended)
-                        prevCluster.append_gates(clusterFound.get_gates());
-                    }
-                }                                   // Keep looking for clusters to add
-                curClusters.push_back(prevCluster); // Save the final cluster
-            }                                       // Start all over with the next larger span
+
+            curClusters.push_back(std::move(prevCluster)); // Save the final cluster
         }
 
         return curClusters;
@@ -340,9 +432,9 @@ class Wavefunction
 
     void flush() const
     {
-        std::vector<Cluster> clusters = Cluster::make_clusters(fused_.maxSpan(), fused_.maxDepth(), pending_gates_);
+        std::list<Cluster> clusters = Cluster::make_clusters(fused_.maxSpan(), fused_.maxDepth(), pending_gates_);
 
-        if (clusters.size() == 0)
+        if (clusters.empty())
         {
             fused_.flush(wfn_);
         }


### PR DESCRIPTION
The change wasn't meant to improve the clustering algorithm, only to eliminate inefficiencies related to how it accessed the pertinent data-structures. However, have discovered a bug that might cause some pending gates to be dropped if the fuse limit was hit. The bug is documented by two of the new tests and is fixed in the last commit of this PR.

Local runs of dbw_test don't show much difference in GPS. The numbers from five runs before/after the change are (for the sake of space, the last loop only):

| Loops[   9] before | Loops[   9] after | 
| :------------- | :----------: | 
| GPS = 1.09e+04 | GPS = 1.29e+04 |
| GPS = 1.28e+04 | GPS = 1.34e+04 |
| GPS = 9.92e+03 | GPS = 1.13e+04 |
| GPS = 1.36e+04 | GPS = 1.16e+04 |
| GPS = 1.22e+04 | GPS = 1.26e+04 |
