### PR TITLE
Make it easier to add new new entry point driver tests

### DIFF
--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -34,7 +34,7 @@ let private intrinsicFile = Path.GetFullPath "Intrinsic.qs"
 let private testFile = Path.GetFullPath "Tests.qs"
 
 /// The namespace used for the test cases.
-let private testNamespace = "Microsoft.Quantum.EntryPointDriver.Tests"
+let private testNamespace = "EntryPointTest"
 
 /// The test case for the given test number.
 let private testCase =
@@ -215,12 +215,17 @@ let ``Returns String`` () =
     let given = test 3
     given [] |> yields "Hello, World!"
 
+[<Fact>]
+let ``Namespace and callable use same name`` () =
+    let given = test 4
+    given [] |> yields ""
+
 
 // Single Option
 
 [<Fact>]
 let ``Accepts Int`` () =
-    let given = test 4
+    let given = test 5
     given ["-n"; "42"] |> yields "42"
     given ["-n"; "4.2"] |> fails
     given ["-n"; "9223372036854775807"] |> yields "9223372036854775807"
@@ -229,7 +234,7 @@ let ``Accepts Int`` () =
 
 [<Fact>]
 let ``Accepts BigInt`` () =
-    let given = test 5
+    let given = test 6
     given ["-n"; "42"] |> yields "42"
     given ["-n"; "4.2"] |> fails
     given ["-n"; "9223372036854775807"] |> yields "9223372036854775807"
@@ -238,13 +243,13 @@ let ``Accepts BigInt`` () =
 
 [<Fact>]
 let ``Accepts Double`` () =
-    let given = test 6
+    let given = test 7
     given ["-n"; "4.2"] |> yields "4.2"
     given ["-n"; "foo"] |> fails
 
 [<Fact>]
 let ``Accepts Bool`` () =
-    let given = test 7
+    let given = test 8
     given ["-b"; "false"] |> yields "False"
     given ["-b"; "true"] |> yields "True"
     given ["-b"; "one"] |> fails
@@ -252,7 +257,7 @@ let ``Accepts Bool`` () =
 
 [<Fact>]
 let ``Accepts Pauli`` () =
-    let given = test 8
+    let given = test 9
     given ["-p"; "PauliI"] |> yields "PauliI"
     given ["-p"; "PauliX"] |> yields "PauliX"
     given ["-p"; "PauliY"] |> yields "PauliY"
@@ -265,7 +270,7 @@ let ``Accepts Pauli`` () =
 
 [<Fact>]
 let ``Accepts Result`` () =
-    let given = test 9
+    let given = test 10
     given ["-r"; "Zero"] |> yields "Zero"
     given ["-r"; "zero"] |> yields "Zero"
     given ["-r"; "One"] |> yields "One"
@@ -276,7 +281,7 @@ let ``Accepts Result`` () =
 
 [<Fact>]
 let ``Accepts Range`` () =
-    let given = test 10
+    let given = test 11
     given ["-r"; "0..0"] |> yields "0..1..0"
     given ["-r"; "0..1"] |> yields "0..1..1"
     given ["-r"; "0..2..10"] |> yields "0..2..10"
@@ -299,18 +304,18 @@ let ``Accepts Range`` () =
 
 [<Fact>]
 let ``Accepts String`` () =
-    let given = test 11
+    let given = test 12
     given ["-s"; "Hello, World!"] |> yields "Hello, World!"
 
 [<Fact>]
 let ``Accepts Unit`` () =
-    let given = test 12
+    let given = test 13
     given ["-u"; "()"] |> yields ""
     given ["-u"; "42"] |> fails
 
 [<Fact>]
 let ``Accepts String array`` () =
-    let given = test 13
+    let given = test 14
     given ["--xs"; "foo"] |> yields "[foo]"
     given ["--xs"; "foo"; "bar"] |> yields "[foo,bar]"
     given ["--xs"; "foo bar"; "baz"] |> yields "[foo bar,baz]"
@@ -319,14 +324,14 @@ let ``Accepts String array`` () =
 
 [<Fact>]
 let ``Accepts BigInt array`` () =
-    let given = test 14
+    let given = test 15
     given ["--bs"; "9223372036854775808"] |> yields "[9223372036854775808]"
     given ["--bs"; "1"; "2"; "9223372036854775808"] |> yields "[1,2,9223372036854775808]"
     given ["--bs"; "1"; "2"; "4.2"] |> fails
 
 [<Fact>]
 let ``Accepts Pauli array`` () =
-    let given = test 15
+    let given = test 16
     given ["--ps"; "PauliI"] |> yields "[PauliI]"
     given ["--ps"; "PauliZ"; "PauliX"] |> yields "[PauliZ,PauliX]"
     given ["--ps"; "PauliY"; "PauliY"; "PauliY"] |> yields "[PauliY,PauliY,PauliY]"
@@ -334,7 +339,7 @@ let ``Accepts Pauli array`` () =
 
 [<Fact>]
 let ``Accepts Range array`` () =
-    let given = test 16
+    let given = test 17
     given ["--rs"; "1..10"] |> yields "[1..1..10]"
     given ["--rs"; "1..10"; "2..4..20"] |> yields "[1..1..10,2..4..20]"
     given ["--rs"; "1 ..10"; "2 ..4 ..20"] |> yields "[1..1..10,2..4..20]"
@@ -343,14 +348,14 @@ let ``Accepts Range array`` () =
 
 [<Fact>]
 let ``Accepts Result array`` () =
-    let given = test 17
+    let given = test 18
     given ["--rs"; "One"] |> yields "[One]"
     given ["--rs"; "One"; "Zero"] |> yields "[One,Zero]"
     given ["--rs"; "Zero"; "One"; "Two"] |> fails
 
 [<Fact>]
 let ``Accepts Unit array`` () =
-    let given = test 18
+    let given = test 19
     given ["--us"; "()"] |> yields "[()]"
     given ["--us"; "()"; "()"] |> yields "[(),()]"
     given ["--us"; "()"; "()"; "()"] |> yields "[(),(),()]"
@@ -358,7 +363,7 @@ let ``Accepts Unit array`` () =
 
 [<Fact>]
 let ``Supports repeat-name array syntax`` () =
-    let given = test 13
+    let given = test 14
     given ["--xs"; "Hello"; "--xs"; "World"] |> yields "[Hello,World]"
     given ["--xs"; "foo"; "bar"; "--xs"; "baz"] |> yields "[foo,bar,baz]"
     given ["--xs"; "foo"; "--xs"; "bar"; "--xs"; "baz"] |> yields "[foo,bar,baz]"
@@ -369,13 +374,13 @@ let ``Supports repeat-name array syntax`` () =
 
 [<Fact>]
 let ``Accepts two options`` () =
-    let given = test 19
+    let given = test 20
     given ["-n"; "7"; "-b"; "true"] |> yields "7 True"
     given ["-b"; "true"; "-n"; "7"] |> yields "7 True"
 
 [<Fact>]
 let ``Accepts three options`` () =
-    let given = test 20
+    let given = test 21
     given ["-n"; "7"; "-b"; "true"; "--xs"; "foo"] |> yields "7 True [foo]"
     given ["--xs"; "foo"; "-n"; "7"; "-b"; "true"] |> yields "7 True [foo]"
     given ["-n"; "7"; "--xs"; "foo"; "-b"; "true"] |> yields "7 True [foo]"
@@ -383,7 +388,7 @@ let ``Accepts three options`` () =
 
 [<Fact>]
 let ``Requires all options`` () =
-    let given = test 20
+    let given = test 21
     given ["-b"; "true"; "--xs"; "foo"] |> fails
     given ["-n"; "7"; "--xs"; "foo"] |> fails
     given ["-n"; "7"; "-b"; "true"] |> fails
@@ -397,22 +402,22 @@ let ``Requires all options`` () =
 
 [<Fact>]
 let ``Accepts redundant one-tuple`` () =
-    let given = test 21
+    let given = test 22
     given ["-x"; "7"] |> yields "7"
     
 [<Fact>]
 let ``Accepts redundant two-tuple`` () =
-    let given = test 22
+    let given = test 23
     given ["-x"; "7"; "-y"; "8"] |> yields "7 8"
     
 [<Fact>]
 let ``Accepts one-tuple`` () =
-    let given = test 23
+    let given = test 24
     given ["-x"; "7"; "-y"; "8"] |> yields "7 8"
 
 [<Fact>]    
 let ``Accepts two-tuple`` () =
-    let given = test 24
+    let given = test 25
     given ["-x"; "7"; "-y"; "8"; "-z"; "9"] |> yields "7 8 9"
 
 
@@ -420,13 +425,13 @@ let ``Accepts two-tuple`` () =
 
 [<Fact>]
 let ``Uses kebab-case`` () =
-    let given = test 25
+    let given = test 26
     given ["--camel-case-name"; "foo"] |> yields "foo"
     given ["--camelCaseName"; "foo"] |> fails
 
 [<Fact>]
 let ``Uses single-dash short names`` () =
-    let given = test 26
+    let given = test 27
     given ["-x"; "foo"] |> yields "foo"
     given ["--x"; "foo"] |> fails
 
@@ -435,7 +440,7 @@ let ``Uses single-dash short names`` () =
 
 [<Fact>]
 let ``Shadows --simulator`` () =
-    let given = test 27
+    let given = test 28
     given ["--simulator"; "foo"]
     |> yields "Warning: Option --simulator is overridden by an entry point parameter name. Using default value QuantumSimulator.
                foo"
@@ -448,26 +453,26 @@ let ``Shadows --simulator`` () =
 
 [<Fact>]
 let ``Shadows -s`` () =
-    let given = test 28
+    let given = test 29
     given ["-s"; "foo"] |> yields "foo"
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "-s"; "foo"] |> yields "foo"
     given ["--simulator"; "bar"; "-s"; "foo"] |> fails
 
 [<Fact>]
 let ``Shadows --version`` () =
-    let given = test 29
+    let given = test 30
     given ["--version"; "foo"] |> yields "foo"
 
 [<Fact>]
 let ``Shadows --target`` () =
-    let given = test 30
+    let given = test 31
     given ["--target"; "foo"] |> yields "foo"
     given submitWithNothingTarget
     |> failsWith "The required option --target conflicts with an entry point parameter name."
 
 [<Fact>]
 let ``Shadows --shots`` () =
-    let given = test 31
+    let given = test 32
     given ["--shots"; "7"] |> yields "7"
     given (submitWithNothingTarget @ ["--shots"; "7"])
     |> yields "Warning: Option --shots is overridden by an entry point parameter name. Using default value 500.
@@ -491,30 +496,30 @@ let private resourceSummary =
 
 [<Fact>]
 let ``Supports QuantumSimulator`` () =
-    let given = test 32
+    let given = test 33
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "false"] |> yields "Hello, World!"
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "true"] |> yields "Hello, World!"
 
 [<Fact>]
 let ``Supports ToffoliSimulator`` () =
-    let given = test 32
+    let given = test 33
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "--use-h"; "false"] |> yields "Hello, World!"
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "--use-h"; "true"] |> fails
 
 [<Fact>]
 let ``Supports ResourcesEstimator`` () =
-    let given = test 32
+    let given = test 33
     given ["--simulator"; AssemblyConstants.ResourcesEstimator; "--use-h"; "false"] |> yields resourceSummary
     given ["--simulator"; AssemblyConstants.ResourcesEstimator; "--use-h"; "true"] |> yields resourceSummary
 
 [<Fact>]
 let ``Rejects unknown simulator`` () =
-    let given = test 32
+    let given = test 33
     given ["--simulator"; "FooSimulator"; "--use-h"; "false"] |> fails
 
 [<Fact>]
 let ``Supports default standard simulator`` () =
-    let given = testWithSim AssemblyConstants.ResourcesEstimator 32
+    let given = testWithSim AssemblyConstants.ResourcesEstimator 33
     given ["--use-h"; "false"] |> yields resourceSummary
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "false"] |> yields "Hello, World!"
 
@@ -522,7 +527,7 @@ let ``Supports default standard simulator`` () =
 let ``Supports default custom simulator`` () =
     // This is not really a "custom" simulator, but the driver does not recognize the fully-qualified name of the
     // standard simulators, so it is treated as one.
-    let given = testWithSim typeof<ToffoliSimulator>.FullName 32
+    let given = testWithSim typeof<ToffoliSimulator>.FullName 33
     given ["--use-h"; "false"] |> yields "Hello, World!"
     given ["--use-h"; "true"] |> fails
     given ["--simulator"; typeof<ToffoliSimulator>.FullName; "--use-h"; "false"] |> yields "Hello, World!"
@@ -721,7 +726,7 @@ let ``Uses documentation`` () =
                      Commands:
                        simulate    (default) Run the program using a local simulator."
 
-    let given = test 33
+    let given = test 34
     given ["--help"] |> yields message
     given ["-h"] |> yields message
     given ["-?"] |> yields message
@@ -751,7 +756,7 @@ let ``Shows help text for submit command`` () =
                       --pauli <PauliI|PauliX|PauliY|PauliZ> (REQUIRED)    The name of a Pauli matrix.
                       --my-cool-bool (REQUIRED)                           A neat bit.
                       -?, -h, --help                                      Show help and usage information"
-    let given = test 33
+    let given = test 34
     given ["submit"; "--help"] |> yields message
 
 [<Fact>]
@@ -779,5 +784,5 @@ let ``Shows help text for submit command with default target`` () =
                       --pauli <PauliI|PauliX|PauliY|PauliZ> (REQUIRED)    The name of a Pauli matrix.
                       --my-cool-bool (REQUIRED)                           A neat bit.
                       -?, -h, --help                                      Show help and usage information"
-    let given = testWithTarget "foo.target" 33
+    let given = testWithTarget "foo.target" 34
     given ["submit"; "--help"] |> yields message

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -44,7 +44,7 @@ let private testNamespace = "EntryPointTest"
 /// </remarks>
 let private testCases =
     File.ReadAllText testFile
-    |> fun text -> text.Split "// ---"
+    |> fun text -> Environment.NewLine + "// ---" |> text.Split
     |> Seq.map (fun case ->
         let parts = case.Split (Environment.NewLine, 2)
         parts.[0].Trim (), parts.[1])

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -47,7 +47,7 @@ let private testCase =
     fun name -> cases |> Map.find name
 
 /// Compiles the Q# source code.
-let private compileQsharp source =
+let private compileQSharp source =
     let uri name = Uri ("file://" + name)
     let fileManager name content =
         CompilationUnitManager.InitializeFileManager (uri name, content)
@@ -65,7 +65,7 @@ let private compileQsharp source =
     compilation.BuiltCompilation
 
 /// Generates C# source code from the compiled Q# syntax tree using the given assembly constants.
-let private generateCsharp constants (compilation : QsCompilation) =
+let private generateCSharp constants (compilation : QsCompilation) =
     let context = CodegenContext.Create (compilation, constants)
     let entryPoint = context.allCallables.[Seq.exactlyOne compilation.EntryPoints]
     [
@@ -83,7 +83,7 @@ let private referencedAssembly name =
     path |> Option.defaultWith (fun () -> failwith (sprintf "Missing reference to assembly '%s'." name))
 
 /// Compiles the C# sources into an assembly.
-let private compileCsharp (sources : string seq) =
+let private compileCSharp (sources : string seq) =
     let references : MetadataReference list =
         [
             "netstandard"
@@ -116,9 +116,9 @@ let private compileCsharp (sources : string seq) =
 let private testAssembly testNum constants =
     testNum
     |> testCase
-    |> compileQsharp
-    |> generateCsharp constants
-    |> compileCsharp
+    |> compileQSharp
+    |> generateCSharp constants
+    |> compileCSharp
 
 /// Runs the entry point in the assembly with the given command-line arguments, and returns the output, errors, and exit
 /// code.

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -36,7 +36,7 @@ let private testFile = Path.GetFullPath "Tests.qs"
 let private testNamespace = "EntryPointTest"
 
 /// <summary>
-/// The source code for each test case, indexed by the test case name.
+/// A map where each key is a test case name, and each value is the source code of the test case.
 /// </summary>
 /// <remarks>
 /// Each test case corresponds to a section from <see cref="testFile"/>, separated by "// ---". The text immediately

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -23,7 +23,6 @@ open Microsoft.Quantum.QsCompiler.ReservedKeywords
 open Microsoft.Quantum.QsCompiler.SyntaxTree
 open Microsoft.Quantum.Simulation.Simulators
 
-
 /// The path to the Q# file that provides the Microsoft.Quantum.Core namespace.
 let private coreFile = Path.GetFullPath "Core.qs"
 
@@ -36,11 +35,16 @@ let private testFile = Path.GetFullPath "Tests.qs"
 /// The namespace used for the test cases.
 let private testNamespace = "EntryPointTest"
 
-/// The test case for the given test number.
+/// The test case for the given test name.
 let private testCase =
-    File.ReadAllText testFile
-    |> fun text -> text.Split "// ---"
-    |> fun cases num -> cases.[num - 1]
+    let cases =
+        File.ReadAllText testFile
+        |> fun text -> text.Split "// ---"
+        |> Seq.map (fun case ->
+            let parts = case.Split (Environment.NewLine, 2)
+            parts.[0].Trim (), parts.[1])
+        |> Map.ofSeq
+    fun name -> cases |> Map.find name
 
 /// Compiles the Q# source code.
 let private compileQsharp source =
@@ -197,35 +201,33 @@ let private submitWithNothingTarget = submitWithoutTarget @ ["--target"; "test.n
 /// Standard command-line arguments for the "submit" command using the "test.error" target.
 let private submitWithErrorTarget = submitWithoutTarget @ ["--target"; "test.error"]
 
-
 // No Option
 
 [<Fact>]
 let ``Returns Unit`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given [] |> yields ""
-    
+
 [<Fact>]
 let ``Returns Int`` () =
-    let given = test 2
+    let given = test "Returns Int"
     given [] |> yields "42"
 
 [<Fact>]
 let ``Returns String`` () =
-    let given = test 3
+    let given = test "Returns String"
     given [] |> yields "Hello, World!"
 
 [<Fact>]
 let ``Namespace and callable use same name`` () =
-    let given = test 4
+    let given = test "Namespace and callable use same name"
     given [] |> yields ""
-
 
 // Single Option
 
 [<Fact>]
 let ``Accepts Int`` () =
-    let given = test 5
+    let given = test "Accepts Int"
     given ["-n"; "42"] |> yields "42"
     given ["-n"; "4.2"] |> fails
     given ["-n"; "9223372036854775807"] |> yields "9223372036854775807"
@@ -234,7 +236,7 @@ let ``Accepts Int`` () =
 
 [<Fact>]
 let ``Accepts BigInt`` () =
-    let given = test 6
+    let given = test "Accepts BigInt"
     given ["-n"; "42"] |> yields "42"
     given ["-n"; "4.2"] |> fails
     given ["-n"; "9223372036854775807"] |> yields "9223372036854775807"
@@ -243,13 +245,13 @@ let ``Accepts BigInt`` () =
 
 [<Fact>]
 let ``Accepts Double`` () =
-    let given = test 7
+    let given = test "Accepts Double"
     given ["-n"; "4.2"] |> yields "4.2"
     given ["-n"; "foo"] |> fails
 
 [<Fact>]
 let ``Accepts Bool`` () =
-    let given = test 8
+    let given = test "Accepts Bool"
     given ["-b"; "false"] |> yields "False"
     given ["-b"; "true"] |> yields "True"
     given ["-b"; "one"] |> fails
@@ -257,7 +259,7 @@ let ``Accepts Bool`` () =
 
 [<Fact>]
 let ``Accepts Pauli`` () =
-    let given = test 9
+    let given = test "Accepts Pauli"
     given ["-p"; "PauliI"] |> yields "PauliI"
     given ["-p"; "PauliX"] |> yields "PauliX"
     given ["-p"; "PauliY"] |> yields "PauliY"
@@ -270,7 +272,7 @@ let ``Accepts Pauli`` () =
 
 [<Fact>]
 let ``Accepts Result`` () =
-    let given = test 10
+    let given = test "Accepts Result"
     given ["-r"; "Zero"] |> yields "Zero"
     given ["-r"; "zero"] |> yields "Zero"
     given ["-r"; "One"] |> yields "One"
@@ -281,7 +283,7 @@ let ``Accepts Result`` () =
 
 [<Fact>]
 let ``Accepts Range`` () =
-    let given = test 11
+    let given = test "Accepts Range"
     given ["-r"; "0..0"] |> yields "0..1..0"
     given ["-r"; "0..1"] |> yields "0..1..1"
     given ["-r"; "0..2..10"] |> yields "0..2..10"
@@ -304,18 +306,18 @@ let ``Accepts Range`` () =
 
 [<Fact>]
 let ``Accepts String`` () =
-    let given = test 12
+    let given = test "Accepts String"
     given ["-s"; "Hello, World!"] |> yields "Hello, World!"
 
 [<Fact>]
 let ``Accepts Unit`` () =
-    let given = test 13
+    let given = test "Accepts Unit"
     given ["-u"; "()"] |> yields ""
     given ["-u"; "42"] |> fails
 
 [<Fact>]
 let ``Accepts String array`` () =
-    let given = test 14
+    let given = test "Accepts String array"
     given ["--xs"; "foo"] |> yields "[foo]"
     given ["--xs"; "foo"; "bar"] |> yields "[foo,bar]"
     given ["--xs"; "foo bar"; "baz"] |> yields "[foo bar,baz]"
@@ -324,14 +326,14 @@ let ``Accepts String array`` () =
 
 [<Fact>]
 let ``Accepts BigInt array`` () =
-    let given = test 15
+    let given = test "Accepts BigInt array"
     given ["--bs"; "9223372036854775808"] |> yields "[9223372036854775808]"
     given ["--bs"; "1"; "2"; "9223372036854775808"] |> yields "[1,2,9223372036854775808]"
     given ["--bs"; "1"; "2"; "4.2"] |> fails
 
 [<Fact>]
 let ``Accepts Pauli array`` () =
-    let given = test 16
+    let given = test "Accepts Pauli array"
     given ["--ps"; "PauliI"] |> yields "[PauliI]"
     given ["--ps"; "PauliZ"; "PauliX"] |> yields "[PauliZ,PauliX]"
     given ["--ps"; "PauliY"; "PauliY"; "PauliY"] |> yields "[PauliY,PauliY,PauliY]"
@@ -339,7 +341,7 @@ let ``Accepts Pauli array`` () =
 
 [<Fact>]
 let ``Accepts Range array`` () =
-    let given = test 17
+    let given = test "Accepts Range array"
     given ["--rs"; "1..10"] |> yields "[1..1..10]"
     given ["--rs"; "1..10"; "2..4..20"] |> yields "[1..1..10,2..4..20]"
     given ["--rs"; "1 ..10"; "2 ..4 ..20"] |> yields "[1..1..10,2..4..20]"
@@ -348,14 +350,14 @@ let ``Accepts Range array`` () =
 
 [<Fact>]
 let ``Accepts Result array`` () =
-    let given = test 18
+    let given = test "Accepts Result array"
     given ["--rs"; "One"] |> yields "[One]"
     given ["--rs"; "One"; "Zero"] |> yields "[One,Zero]"
     given ["--rs"; "Zero"; "One"; "Two"] |> fails
 
 [<Fact>]
 let ``Accepts Unit array`` () =
-    let given = test 19
+    let given = test "Accepts Unit array"
     given ["--us"; "()"] |> yields "[()]"
     given ["--us"; "()"; "()"] |> yields "[(),()]"
     given ["--us"; "()"; "()"; "()"] |> yields "[(),(),()]"
@@ -363,24 +365,23 @@ let ``Accepts Unit array`` () =
 
 [<Fact>]
 let ``Supports repeat-name array syntax`` () =
-    let given = test 14
+    let given = test "Accepts String array"
     given ["--xs"; "Hello"; "--xs"; "World"] |> yields "[Hello,World]"
     given ["--xs"; "foo"; "bar"; "--xs"; "baz"] |> yields "[foo,bar,baz]"
     given ["--xs"; "foo"; "--xs"; "bar"; "--xs"; "baz"] |> yields "[foo,bar,baz]"
     given ["--xs"; "foo bar"; "--xs"; "baz"] |> yields "[foo bar,baz]"
 
-
 // Multiple Options
 
 [<Fact>]
 let ``Accepts two options`` () =
-    let given = test 20
+    let given = test "Accepts two options"
     given ["-n"; "7"; "-b"; "true"] |> yields "7 True"
     given ["-b"; "true"; "-n"; "7"] |> yields "7 True"
 
 [<Fact>]
 let ``Accepts three options`` () =
-    let given = test 21
+    let given = test "Accepts three options"
     given ["-n"; "7"; "-b"; "true"; "--xs"; "foo"] |> yields "7 True [foo]"
     given ["--xs"; "foo"; "-n"; "7"; "-b"; "true"] |> yields "7 True [foo]"
     given ["-n"; "7"; "--xs"; "foo"; "-b"; "true"] |> yields "7 True [foo]"
@@ -388,7 +389,7 @@ let ``Accepts three options`` () =
 
 [<Fact>]
 let ``Requires all options`` () =
-    let given = test 21
+    let given = test "Accepts three options"
     given ["-b"; "true"; "--xs"; "foo"] |> fails
     given ["-n"; "7"; "--xs"; "foo"] |> fails
     given ["-n"; "7"; "-b"; "true"] |> fails
@@ -397,50 +398,47 @@ let ``Requires all options`` () =
     given ["--xs"; "foo"] |> fails
     given [] |> fails
 
-
 // Tuples
 
 [<Fact>]
 let ``Accepts redundant one-tuple`` () =
-    let given = test 22
+    let given = test "Accepts redundant one-tuple"
     given ["-x"; "7"] |> yields "7"
-    
+
 [<Fact>]
 let ``Accepts redundant two-tuple`` () =
-    let given = test 23
+    let given = test "Accepts redundant two-tuple"
     given ["-x"; "7"; "-y"; "8"] |> yields "7 8"
-    
+
 [<Fact>]
 let ``Accepts one-tuple`` () =
-    let given = test 24
+    let given = test "Accepts one-tuple"
     given ["-x"; "7"; "-y"; "8"] |> yields "7 8"
 
 [<Fact>]    
 let ``Accepts two-tuple`` () =
-    let given = test 25
+    let given = test "Accepts two-tuple"
     given ["-x"; "7"; "-y"; "8"; "-z"; "9"] |> yields "7 8 9"
-
 
 // Name Conversion
 
 [<Fact>]
 let ``Uses kebab-case`` () =
-    let given = test 26
+    let given = test "Uses kebab-case"
     given ["--camel-case-name"; "foo"] |> yields "foo"
     given ["--camelCaseName"; "foo"] |> fails
 
 [<Fact>]
 let ``Uses single-dash short names`` () =
-    let given = test 27
+    let given = test "Uses single-dash short names"
     given ["-x"; "foo"] |> yields "foo"
     given ["--x"; "foo"] |> fails
-
 
 // Shadowing
 
 [<Fact>]
 let ``Shadows --simulator`` () =
-    let given = test 28
+    let given = test "Shadows --simulator"
     given ["--simulator"; "foo"]
     |> yields "Warning: Option --simulator is overridden by an entry point parameter name. Using default value QuantumSimulator.
                foo"
@@ -453,35 +451,34 @@ let ``Shadows --simulator`` () =
 
 [<Fact>]
 let ``Shadows -s`` () =
-    let given = test 29
+    let given = test "Shadows -s"
     given ["-s"; "foo"] |> yields "foo"
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "-s"; "foo"] |> yields "foo"
     given ["--simulator"; "bar"; "-s"; "foo"] |> fails
 
 [<Fact>]
 let ``Shadows --version`` () =
-    let given = test 30
+    let given = test "Shadows --version"
     given ["--version"; "foo"] |> yields "foo"
 
 [<Fact>]
 let ``Shadows --target`` () =
-    let given = test 31
+    let given = test "Shadows --target"
     given ["--target"; "foo"] |> yields "foo"
     given submitWithNothingTarget
     |> failsWith "The required option --target conflicts with an entry point parameter name."
 
 [<Fact>]
 let ``Shadows --shots`` () =
-    let given = test 32
+    let given = test "Shadows --shots"
     given ["--shots"; "7"] |> yields "7"
     given (submitWithNothingTarget @ ["--shots"; "7"])
     |> yields "Warning: Option --shots is overridden by an entry point parameter name. Using default value 500.
                https://www.example.com/00000000-0000-0000-0000-0000000000000"
 
-
 // Simulators
 
-// The expected output from the resources estimator.
+/// The expected output from the resources estimator.
 let private resourceSummary =
     "Metric          Sum Max
      CNOT            0   0
@@ -496,30 +493,30 @@ let private resourceSummary =
 
 [<Fact>]
 let ``Supports QuantumSimulator`` () =
-    let given = test 33
+    let given = test "X or H"
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "false"] |> yields "Hello, World!"
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "true"] |> yields "Hello, World!"
 
 [<Fact>]
 let ``Supports ToffoliSimulator`` () =
-    let given = test 33
+    let given = test "X or H"
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "--use-h"; "false"] |> yields "Hello, World!"
     given ["--simulator"; AssemblyConstants.ToffoliSimulator; "--use-h"; "true"] |> fails
 
 [<Fact>]
 let ``Supports ResourcesEstimator`` () =
-    let given = test 33
+    let given = test "X or H"
     given ["--simulator"; AssemblyConstants.ResourcesEstimator; "--use-h"; "false"] |> yields resourceSummary
     given ["--simulator"; AssemblyConstants.ResourcesEstimator; "--use-h"; "true"] |> yields resourceSummary
 
 [<Fact>]
 let ``Rejects unknown simulator`` () =
-    let given = test 33
+    let given = test "X or H"
     given ["--simulator"; "FooSimulator"; "--use-h"; "false"] |> fails
 
 [<Fact>]
 let ``Supports default standard simulator`` () =
-    let given = testWithSim AssemblyConstants.ResourcesEstimator 33
+    let given = testWithSim AssemblyConstants.ResourcesEstimator "X or H"
     given ["--use-h"; "false"] |> yields resourceSummary
     given ["--simulator"; AssemblyConstants.QuantumSimulator; "--use-h"; "false"] |> yields "Hello, World!"
 
@@ -527,7 +524,7 @@ let ``Supports default standard simulator`` () =
 let ``Supports default custom simulator`` () =
     // This is not really a "custom" simulator, but the driver does not recognize the fully-qualified name of the
     // standard simulators, so it is treated as one.
-    let given = testWithSim typeof<ToffoliSimulator>.FullName 33
+    let given = testWithSim typeof<ToffoliSimulator>.FullName "X or H"
     given ["--use-h"; "false"] |> yields "Hello, World!"
     given ["--use-h"; "true"] |> fails
     given ["--simulator"; typeof<ToffoliSimulator>.FullName; "--use-h"; "false"] |> yields "Hello, World!"
@@ -537,23 +534,22 @@ let ``Supports default custom simulator`` () =
     given ["--simulator"; AssemblyConstants.ResourcesEstimator; "--use-h"; "false"] |> yields resourceSummary
     given ["--simulator"; typeof<QuantumSimulator>.FullName; "--use-h"; "false"] |> fails
 
-
 // Azure Quantum Submission
 
 [<Fact>]
 let ``Submit can submit a job`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given submitWithNothingTarget
     |> yields "https://www.example.com/00000000-0000-0000-0000-0000000000000"
 
 [<Fact>]
 let ``Submit can show only the ID`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given (submitWithNothingTarget @ ["--output"; "id"]) |> yields "00000000-0000-0000-0000-0000000000000"
 
 [<Fact>]
 let ``Submit uses default values`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given (submitWithNothingTarget @ ["--verbose"])
     |> yields "Subscription: mySubscription
                Resource Group: myResourceGroup
@@ -572,7 +568,7 @@ let ``Submit uses default values`` () =
 
 [<Fact>]
 let ``Submit uses default values with default target`` () =
-    let given = testWithTarget "test.nothing" 1
+    let given = testWithTarget "test.nothing" "Returns Unit"
     given (submitWithoutTarget @ ["--verbose"])
     |> yields "Subscription: mySubscription
                Resource Group: myResourceGroup
@@ -591,7 +587,7 @@ let ``Submit uses default values with default target`` () =
 
 [<Fact>]
 let ``Submit allows overriding default values`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given (submitWithNothingTarget @ [
         "--verbose"
         "--storage"
@@ -622,7 +618,7 @@ let ``Submit allows overriding default values`` () =
 
 [<Fact>]
 let ``Submit allows overriding default values with default target`` () =
-    let given = testWithTarget "foo.target" 1
+    let given = testWithTarget "foo.target" "Returns Unit"
     given (submitWithNothingTarget @ [
         "--verbose"
         "--storage"
@@ -653,7 +649,7 @@ let ``Submit allows overriding default values with default target`` () =
 
 [<Fact>]
 let ``Submit requires a positive number of shots`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given (submitWithNothingTarget @ ["--shots"; "1"])
     |> yields "https://www.example.com/00000000-0000-0000-0000-0000000000000"
     given (submitWithNothingTarget @ ["--shots"; "0"]) |> fails
@@ -661,12 +657,12 @@ let ``Submit requires a positive number of shots`` () =
 
 [<Fact>]
 let ``Submit fails with unknown target`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given (submitWithoutTarget @ ["--target"; "foo"]) |> failsWith "The target 'foo' was not recognized."
 
 [<Fact>]
 let ``Submit supports dry run option`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given (submitWithNothingTarget @ ["--dry-run"]) |> yields "✔️  The program is valid!"
     given (submitWithErrorTarget @ ["--dry-run"])
     |> failsWith "❌  The program is invalid.
@@ -681,7 +677,7 @@ let ``Submit has required options`` () =
         | x :: xs ->
             let next = powerSet xs
             List.map (fun list -> x :: list) next @ next
-    let given = test 1
+    let given = test "Returns Unit"
 
     // Try every possible combination of arguments. The command should succeed only when all of the arguments are
     // included.
@@ -695,12 +691,11 @@ let ``Submit has required options`` () =
 
 [<Fact>]
 let ``Submit catches exceptions`` () =
-    let given = test 1
+    let given = test "Returns Unit"
     given submitWithErrorTarget
     |> failsWith "Something went wrong when submitting the program to the Azure Quantum service.
 
                   This quantum machine always has an error."
-
 
 // Help
 
@@ -726,7 +721,7 @@ let ``Uses documentation`` () =
                      Commands:
                        simulate    (default) Run the program using a local simulator."
 
-    let given = test 34
+    let given = test "Help"
     given ["--help"] |> yields message
     given ["-h"] |> yields message
     given ["-?"] |> yields message
@@ -756,7 +751,7 @@ let ``Shows help text for submit command`` () =
                       --pauli <PauliI|PauliX|PauliY|PauliZ> (REQUIRED)    The name of a Pauli matrix.
                       --my-cool-bool (REQUIRED)                           A neat bit.
                       -?, -h, --help                                      Show help and usage information"
-    let given = test 34
+    let given = test "Help"
     given ["submit"; "--help"] |> yields message
 
 [<Fact>]
@@ -784,5 +779,5 @@ let ``Shows help text for submit command with default target`` () =
                       --pauli <PauliI|PauliX|PauliY|PauliZ> (REQUIRED)    The name of a Pauli matrix.
                       --my-cool-bool (REQUIRED)                           A neat bit.
                       -?, -h, --help                                      Show help and usage information"
-    let given = testWithTarget "foo.target" 34
+    let given = testWithTarget "foo.target" "Help"
     given ["submit"; "--help"] |> yields message

--- a/src/Simulation/EntryPointDriver.Tests/Tests.qs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.qs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// Each test case is separated by "// ---". The text immediately after "// ---" until the end of the line is the name of
+// the test case, which usually corresponds to a test name in Tests.fs.
+
 //
 // No Options
 //

--- a/src/Simulation/EntryPointDriver.Tests/Tests.qs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.qs
@@ -5,14 +5,14 @@
 // No Options
 //
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ReturnUnit() : Unit { }
 }
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ReturnInt() : Int {
         return 42;
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ReturnString() : String {
         return "Hello, World!";
@@ -30,11 +30,18 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
+namespace EntryPointTest {
+    @EntryPoint()
+    operation EntryPointTest() : Unit { }
+}
+
+// ---
+
 //
 // Single Option
 //
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptInt(n : Int) : Int {
         return n;
@@ -43,7 +50,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptBigInt(n : BigInt) : BigInt {
         return n;
@@ -52,7 +59,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptDouble(n : Double) : Double {
         return n;
@@ -61,7 +68,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptBool(b : Bool) : Bool {
         return b;
@@ -70,7 +77,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptPauli(p : Pauli) : Pauli {
         return p;
@@ -79,7 +86,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptResult(r : Result) : Result {
         return r;
@@ -88,7 +95,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptRange(r : Range) : Range {
         return r;
@@ -97,7 +104,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptString(s : String) : String {
         return s;
@@ -106,7 +113,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptUnit(u : Unit) : Unit {
         return u;
@@ -115,7 +122,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptStringArray(xs : String[]) : String[] {
         return xs;
@@ -124,7 +131,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptBigIntArray(bs : BigInt[]) : BigInt[] {
         return bs;
@@ -133,7 +140,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptPauliArray(ps : Pauli[]) : Pauli[] {
         return ps;
@@ -142,7 +149,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptRangeArray(rs : Range[]) : Range[] {
         return rs;
@@ -151,7 +158,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptResultArray(rs : Result[]) : Result[] {
         return rs;
@@ -160,7 +167,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation AcceptUnitArray(us : Unit[]) : Unit[] {
         return us;
@@ -173,7 +180,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 // Multiple Options
 //
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation TwoOptions(n : Int, b : Bool) : String {
         return $"{n} {b}";
@@ -182,7 +189,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ThreeOptions(n : Int, b : Bool, xs : String[]) : String {
         return $"{n} {b} {xs}";
@@ -195,7 +202,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 // Tuples
 //
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation RedundantOneTuple((x : Int)) : String {
         return $"{x}";
@@ -204,7 +211,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation RedundantTwoTuple((x : Int, y : Int)) : String {
         return $"{x} {y}";
@@ -213,7 +220,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation OneTuple(x : Int, (y : Int)) : String {
         return $"{x} {y}";
@@ -222,7 +229,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation TwoTuple(x : Int, (y : Int, z : Int)) : String {
         return $"{x} {y} {z}";
@@ -235,7 +242,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 // Name Conversion
 //
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation CamelCase(camelCaseName : String) : String {
         return camelCaseName;
@@ -244,7 +251,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation SingleLetter(x : String) : String {
         return x;
@@ -257,7 +264,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 // Shadowing
 //
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ShadowSimulator(simulator : String) : String {
         return simulator;
@@ -266,7 +273,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ShadowS(s : String) : String {
         return s;
@@ -275,7 +282,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ShadowVersion(version : String) : String {
         return version;
@@ -284,7 +291,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ShadowTarget(target : String) : String {
         return target;
@@ -293,7 +300,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 
 // ---
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     @EntryPoint()
     operation ShadowShots(shots : Int) : Int {
         return shots;
@@ -306,7 +313,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 // Simulators
 //
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     open Microsoft.Quantum.Intrinsic;
 
     @EntryPoint()
@@ -332,7 +339,7 @@ namespace Microsoft.Quantum.EntryPointDriver.Tests {
 // Help
 //
 
-namespace Microsoft.Quantum.EntryPointDriver.Tests {
+namespace EntryPointTest {
     /// # Summary
     /// This test checks that the entry point documentation appears correctly in the command line help message.
     ///

--- a/src/Simulation/EntryPointDriver.Tests/Tests.qs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.qs
@@ -5,12 +5,14 @@
 // No Options
 //
 
+// --- Returns Unit
+
 namespace EntryPointTest {
     @EntryPoint()
     operation ReturnUnit() : Unit { }
 }
 
-// ---
+// --- Returns Int
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -19,7 +21,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Returns String
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -28,18 +30,18 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Namespace and callable use same name
 
 namespace EntryPointTest {
     @EntryPoint()
     operation EntryPointTest() : Unit { }
 }
 
-// ---
-
 //
 // Single Option
 //
+
+// --- Accepts Int
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -48,7 +50,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts BigInt
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -57,7 +59,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Double
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -66,7 +68,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Bool
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -75,7 +77,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Pauli
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -84,7 +86,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Result
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -93,7 +95,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Range
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -102,7 +104,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts String
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -111,7 +113,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Unit
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -120,7 +122,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts String array
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -129,7 +131,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts BigInt array
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -138,7 +140,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Pauli array
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -147,7 +149,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Range array
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -156,7 +158,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Result array
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -165,7 +167,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts Unit array
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -174,11 +176,11 @@ namespace EntryPointTest {
     }
 }
 
-// ---
-
 //
 // Multiple Options
 //
+
+// --- Accepts two options
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -187,7 +189,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts three options
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -196,11 +198,11 @@ namespace EntryPointTest {
     }
 }
 
-// ---
-
 //
 // Tuples
 //
+
+// --- Accepts redundant one-tuple
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -209,7 +211,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts redundant two-tuple
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -218,7 +220,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts one-tuple
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -227,7 +229,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Accepts two-tuple
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -236,11 +238,11 @@ namespace EntryPointTest {
     }
 }
 
-// ---
-
 //
 // Name Conversion
 //
+
+// --- Uses kebab-case
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -249,7 +251,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Uses single-dash short names
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -258,11 +260,11 @@ namespace EntryPointTest {
     }
 }
 
-// ---
-
 //
 // Shadowing
 //
+
+// --- Shadows --simulator
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -271,7 +273,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Shadows -s
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -280,7 +282,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Shadows --version
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -289,7 +291,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Shadows --target
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -298,7 +300,7 @@ namespace EntryPointTest {
     }
 }
 
-// ---
+// --- Shadows --shots
 
 namespace EntryPointTest {
     @EntryPoint()
@@ -307,11 +309,11 @@ namespace EntryPointTest {
     }
 }
 
-// ---
-
 //
 // Simulators
 //
+
+// --- X or H
 
 namespace EntryPointTest {
     open Microsoft.Quantum.Intrinsic;
@@ -333,11 +335,11 @@ namespace EntryPointTest {
     }
 }
 
-// ---
-
 //
 // Help
 //
+
+// --- Help
 
 namespace EntryPointTest {
     /// # Summary


### PR DESCRIPTION
This changes the entry point driver test cases from being indexed by their position in the file to being indexed by a name. This makes it easier to add new tests without needing to update the indices of all the tests that come after the newly added test.

It also adds a new test to make sure that an entry point callable with the same name as the parent namespace is supported (see microsoft/qsharp-compiler#711).