### PR TITLE
Enable test for using "Data" as a named item

### DIFF
--- a/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
+++ b/src/Simulation/CsharpGeneration/Microsoft.Quantum.CsharpGeneration.fsproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20082705-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.13.20102604" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\Simulators.Dev.props" />

--- a/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
+++ b/src/Simulation/QsharpCore/Microsoft.Quantum.QSharp.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators.Tests/Circuits/MemberNames.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/MemberNames.qs
@@ -7,8 +7,7 @@
 
     newtype Items = (Item2 : Int, Item1 : Int);
 
-    // TODO:
-    // newtype Bar = (Data : Int);
+    newtype Bar = (Data : Int);
 
     operation Body() : Unit { }
 
@@ -50,12 +49,11 @@
         AssertEqual(3, items::Item2);
         AssertEqual(4, items::Item1);
 
-        // TODO:
-        // let bar = Bar(10);
-        // AssertEqual(10, bar::Data);
+        let bar = Bar(10);
+        AssertEqual(10, bar::Data);
     }
 
-    @Test("QuantumSimulator")    
+    @Test("QuantumSimulator")
     operation AvoidsOperationPropertyShadowing1() : Unit {
         using (q = Qubit()) {
             let MicrosoftQuantumIntrinsicX = Z;

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CsharpGeneration>false</CsharpGeneration>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QsharpExe/QsharpExe.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />
@@ -54,5 +54,3 @@
   </Target>
 
 </Project>
-
-

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082705-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />


### PR DESCRIPTION
This enables a commented out test for using "Data" as a named item, which is now supported since microsoft/qsharp-compiler#643 was merged recently.