### PR TITLE
Release qubits in array in the order they were allocated in

### DIFF
--- a/src/Simulation/Common/QubitManager.cs
+++ b/src/Simulation/Common/QubitManager.cs
@@ -488,9 +488,11 @@ namespace Microsoft.Quantum.Simulation.Common
                 return;
             }
 
-            for (long i = qubitsToRelease.Length-1; i>=0; i--)
-            { // Going from the end is more efficient in case we are tracking scope.
-                this.Release(qubitsToRelease[i], wasUsedOnlyForBorrowing: false);
+            // When tracking scopes for borrowing, it's more efficient to release qubits in the same order
+            // they were allocated in (which in case of allocated arrays is from left to right).
+            foreach (var qubit in qubitsToRelease)
+            {
+                this.Release(qubit, wasUsedOnlyForBorrowing: false);
             }
         }
 
@@ -663,9 +665,11 @@ namespace Microsoft.Quantum.Simulation.Common
                 return;
             }
 
-            for (long i = qubitsToReturn.Length - 1; i >= 0; i--)
-            { // Going from the end is more efficient in case we are tracking scope.
-                this.Return(qubitsToReturn[i]);
+            // When tracking scopes for borrowing, it's more efficient to release qubits in the same order
+            // they were allocated in (which in case of borrowed arrays is from left to right if we had to allocate).
+            foreach (var qubit in qubitsToReturn)
+            {
+                this.Return(qubit);
             }
         }
     }

--- a/src/Simulation/Simulators.Tests/CoreTests.cs
+++ b/src/Simulation/Simulators.Tests/CoreTests.cs
@@ -95,8 +95,8 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 testOneBody(1, (1, q0));
                 testOneBody(1, (1, q1));
                 testOneBody(1, (1, q4));
-                testOneBody(3, (1, q5));
-                testOneBody(0, (1, q6));
+                testOneBody(1, (1, q5));
+                testOneBody(2, (1, q6));
                 testOneBody(2, (2, q2));
                 testOneBody(2, (2, q3));
                 testOneBody(1, (3, q0));
@@ -114,8 +114,8 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 testOneAdjoint(1, (1, q0));
                 testOneAdjoint(1, (1, q1));
                 testOneAdjoint(1, (1, q4));
-                testOneAdjoint(3, (1, q5));
-                testOneAdjoint(0, (1, q6));
+                testOneAdjoint(2, (1, q5));
+                testOneAdjoint(1, (1, q6));
                 testOneAdjoint(2, (2, q2));
                 testOneAdjoint(2, (2, q3));
                 testOneAdjoint(1, (3, q2));
@@ -131,8 +131,8 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 testOneCtrl(1, (1, q0));
                 testOneCtrl(1, (1, q1));
                 testOneCtrl(1, (1, q4));
-                testOneCtrl(2, (1, q5));
-                testOneCtrl(0, (1, q6));
+                testOneCtrl(1, (1, q5));
+                testOneCtrl(1, (1, q6));
                 testOneCtrl(0, (2, q0));
                 testOneCtrl(0, (2, q1));
                 testOneCtrl(2, (2, q2));

--- a/src/Simulation/Simulators.Tests/QubitManagerTests.cs
+++ b/src/Simulation/Simulators.Tests/QubitManagerTests.cs
@@ -46,13 +46,13 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             qm.Release(qa2);
 
             Qubit q3 = qm.Allocate();
-            Assert.True(q3.Id == 5);
+            Assert.True(q3.Id == 7);
 
             Qubit q4 = qm.Allocate();
             Assert.True(q4.Id == 6);
 
             Qubit q5 = qm.Allocate();
-            Assert.True(q5.Id == 7);
+            Assert.True(q5.Id == 5);
 
             // Test borrowing
             Qubit[] exclusion = new Qubit[4];
@@ -69,7 +69,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.True(qab[0].Id == 0);
             Assert.True(qab[1].Id == 2);
             Assert.True(qab[2].Id == 4);
-            Assert.True(qab[3].Id == 7);
+            Assert.True(qab[3].Id == 5);
             Assert.True(qab[4].Id == 8);
 
             Qubit q6 = qm.Allocate();
@@ -110,8 +110,8 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             qm.Return(qab2);
             
             IQArray<Qubit> qa4 = qm.Allocate(2);
-            Assert.True(qa4[0].Id == 12); // make sure 11 is not reused.
-            Assert.True(qa4[1].Id == 13); // make sure 11 is not reused.
+            Assert.True(qa4[0].Id == 23); // make sure 11 is not reused.
+            Assert.True(qa4[1].Id == 22); // make sure 11 is not reused.
             qm.Release(qa4);
 
             
@@ -194,7 +194,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                 Assert.True(q4.Id == 2);
 
                 Qubit q5 = qm.Allocate();
-                Assert.True(q5.Id == 8);
+                Assert.True(q5.Id == 6);
             }
 
             { // BLOCK testing mayExtendCapacity:true


### PR DESCRIPTION
For borrowing QubitManager tracks qubits allocated in each frame(=scope) by adding them in order of allocation into `List<Qubit>` on `StackFrame` class. `Release(Qubit)` method then removes the qubit from the list using [List.Remove](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.remove?view=net-5.0) method, which has to traverse the list to find the element to be removed. Thus, when removing in reverse to allocation order (as it happens in case of arrays), the list is fully traversed on each call, yielding O(n^2) complexity. One might have expected the remove at the tail rather than at the head of the list to be faster because it wouldn't require shifting of the remaining elements, and it is, if using `List.RemoveAt` method. However, apparently C# runtime optimizes the shift, because search time dominates even when working with `List<int>` and even more so when the type defines custom equality operation.

For the attached standalone ListRemoveExperiment (`WithCustomEquality` class mimics Qubit in qsharp-runtime) I'm seeing the following times (release builds for lists with 10000 items):

1. Remove at head on ints: 3.98 
2. Remove at tail on ints: 0.0241 (x100 faster than 1 because doesn't have to shift the elements)
3. Remove value forward on ints: 3.2857 (same as 1, because minimal search overhead, being slightly faster is a fluke)
4. Remove value backward on ints: 18.3455 (x5 slower than 3 -- search dominates the shift)

5. Remove at head on custom type: 13.0862 (slower than 1, probably because the custom type is bigger than int)
6. Remove at tail on custom type: 0.0274 (same as 2, as expected)
7. Remove value forward on custom type: 14.3319 (same as 5, because minimal search overhead)
8. Remove value backward on custom type: 546.5933 (x40 slower than 7 -- search trumps the shift)

The above dynamics from the standalone app translate into QubitManage almost exactly. It can be observed in qdk perf tests, or by running a test like the one below in qsharp-runtime directly. All simulators that enable borrowing are affected.

```
        [Fact]
        public void test_perf()
        {
            var count = 10000;
            var sim = new ToffoliSimulator();
            var allocate = sim.Get<Intrinsic.Allocate>();
            var release = sim.Get<Intrinsic.Release>();

            var qs = allocate.Apply(count);
            release.Apply(qs);
        }
```


[ListRemoveExperiment.txt](https://github.com/microsoft/qsharp-runtime/files/5533538/ListRemoveExperiment.txt)
