### PR TITLE
CMake on Windows now requires CMAKE_RC_COMPILER to be set 

### DIFF
--- a/src/QirRuntime/build-qir-runtime.ps1
+++ b/src/QirRuntime/build-qir-runtime.ps1
@@ -5,6 +5,7 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
     Write-Host "##[info]Build QIR Runtime"
     $oldCC = $env:CC
     $oldCXX = $env:CXX
+    $oldRC = $env:RC
 
     if (($IsMacOS) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Darwin"))))
     {
@@ -15,12 +16,14 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
         Write-Host "On Linux build QIR Runtime using Clang"
         $env:CC = "/usr/bin/clang"
         $env:CXX = "/usr/bin/clang++"
+        $env:RC = "/usr/bin/clang++"
     }
     elseif (($IsWindows) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Win"))))
     {
         Write-Host "On Windows build QIR Runtime using Clang"
         $env:CC = "C:\Program Files\LLVM\bin\clang.exe"
         $env:CXX = "C:\Program Files\LLVM\bin\clang++.exe"
+        $env:RC = "C:\Program Files\LLVM\bin\clang++.exe"
         $llvmExtras = (Join-Path $PSScriptRoot "externals/LLVM")
         $env:PATH += ";$llvmExtras"
     } else {
@@ -41,6 +44,7 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
 
     $env:CC = $oldCC
     $env:CXX = $oldCXX
+    $env:RC = $oldRC
 
     if ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to build QIR Runtime."


### PR DESCRIPTION
@anpaz, I'm not sure what have changed since my #13353f31b8d464923d737994caeb3030508f83fb that built correctly in the PR and didn't require the variable to be set. Are the build engines now picking up a different version of CMake?