### PR TITLE
Update deprecated operation characteristics syntax

### DIFF
--- a/src/Simulation/Simulators.Tests/Circuits/CallableInterfacesTest.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/CallableInterfacesTest.qs
@@ -77,13 +77,13 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
     }
     
     
-    operation CheckAdjoint (gate : (Qubit => Unit : Adjoint), qubit : Qubit) : Unit {
+    operation CheckAdjoint (gate : (Qubit => Unit is Adj), qubit : Qubit) : Unit {
         
         Adjoint gate(qubit);
     }
     
     
-    operation CheckControlled (gate : (Qubit => Unit : Controlled), qubit : Qubit) : Unit {
+    operation CheckControlled (gate : (Qubit => Unit is Ctl), qubit : Qubit) : Unit {
         
         
         using (ctrls = Qubit[2]) {
@@ -92,7 +92,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
     }
     
     
-    operation CheckUnitary (gate : (Qubit => Unit : Adjoint, Controlled), qubit : Qubit) : Unit {
+    operation CheckUnitary (gate : (Qubit => Unit is Adj + Ctl), qubit : Qubit) : Unit {
         
         
         using (ctrls = Qubit[2]) {
@@ -102,7 +102,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
     }
     
     
-    operation OneRound (plain : (Qubit => Unit), adj : (Qubit => Unit : Adjoint), ctr : (Qubit => Unit : Controlled), uni : (Qubit => Unit : Adjoint, Controlled)) : Unit {
+    operation OneRound (plain : (Qubit => Unit), adj : (Qubit => Unit is Adj), ctr : (Qubit => Unit is Ctl), uni : (Qubit => Unit is Adj + Ctl)) : Unit {
         
         
         using (qubits = Qubit[1]) {

--- a/src/Simulation/Simulators.Tests/Circuits/ClosedType.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/ClosedType.qs
@@ -36,7 +36,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits.ClosedType {
     }
     
     
-    operation TraceGate (gate : (Qubit => Unit : Adjoint, Controlled), tag : String, qubit : Qubit) : Unit {
+    operation TraceGate (gate : (Qubit => Unit is Adj + Ctl), tag : String, qubit : Qubit) : Unit {
         
         body (...) {
             Trace(tag);
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits.ClosedType {
     }
     
     
-    operation Repeat (callback : (Qubit => Unit : Adjoint, Controlled), bodyCount : Int, adjointCount : Int, controlledCount : Int, source : Qubit) : Unit {
+    operation Repeat (callback : (Qubit => Unit is Adj + Ctl), bodyCount : Int, adjointCount : Int, controlledCount : Int, source : Qubit) : Unit {
         
         body (...) {
             

--- a/src/Simulation/Simulators.Tests/Circuits/CoreOperations.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/CoreOperations.qs
@@ -25,17 +25,17 @@ namespace Microsoft.Quantum.Tests.CoreOperations {
     
     newtype Plain1 = ((Qubit, Qubit) => Unit);
     
-    newtype Adj1 = ((Qubit, Qubit) => Unit : Adjoint);
+    newtype Adj1 = ((Qubit, Qubit) => Unit is Adj);
     
     newtype Adj2 = Adj1;
     
-    newtype Ctrl1 = ((Qubit, Qubit) => Unit : Controlled);
+    newtype Ctrl1 = ((Qubit, Qubit) => Unit is Ctl);
     
-    newtype U1 = ((Qubit, Qubit, Qubit[]) => Unit : Adjoint, Controlled);
+    newtype U1 = ((Qubit, Qubit, Qubit[]) => Unit is Adj + Ctl);
     
     newtype U2 = U1;
     
-    newtype U3 = (Qubit => Unit : Adjoint, Controlled);
+    newtype U3 = (Qubit => Unit is Adj + Ctl);
     
     
     operation BPlain1 (available : Int, q1 : Qubit, action : ((Qubit, Qubit) => Unit)) : Unit {
@@ -60,7 +60,7 @@ namespace Microsoft.Quantum.Tests.CoreOperations {
     }
     
     
-    operation BAdj1 (available : Int, (q1 : Qubit, q2 : Qubit, qs : Qubit[]), action : ((Qubit, Qubit) => Unit : Adjoint)) : Unit {
+    operation BAdj1 (available : Int, (q1 : Qubit, q2 : Qubit, qs : Qubit[]), action : ((Qubit, Qubit) => Unit is Adj)) : Unit {
         
         body (...) {
             
@@ -90,7 +90,7 @@ namespace Microsoft.Quantum.Tests.CoreOperations {
     }
     
     
-    operation BCtrl1 (available : Int, qs : Qs, action : ((Qubit, Qubit) => Unit : Controlled)) : Unit {
+    operation BCtrl1 (available : Int, qs : Qs, action : ((Qubit, Qubit) => Unit is Ctl)) : Unit {
         
         body (...) {
             
@@ -120,7 +120,7 @@ namespace Microsoft.Quantum.Tests.CoreOperations {
     }
     
     
-    operation BU1 (available : Int, qs : Qubit[], action : ((Qubit, Qubit, Qubit[]) => Unit : Adjoint, Controlled)) : Unit {
+    operation BU1 (available : Int, qs : Qubit[], action : ((Qubit, Qubit, Qubit[]) => Unit is Adj + Ctl)) : Unit {
         
         body (...) {
             
@@ -137,7 +137,7 @@ namespace Microsoft.Quantum.Tests.CoreOperations {
     }
     
     
-    operation BGen<'T> (available : Int, arg : 'T, action : ((Qubit, Qubit, 'T) => Unit : Adjoint, Controlled)) : Unit {
+    operation BGen<'T> (available : Int, arg : 'T, action : ((Qubit, Qubit, 'T) => Unit is Adj + Ctl)) : Unit {
         
         body (...) {
             
@@ -178,7 +178,7 @@ namespace Microsoft.Quantum.Tests.CoreOperations {
     }
     
     
-    operation TestAllVariants<'T> (available : Int, args : 'T, action : ((Qubit, Qubit, 'T) => Unit : Adjoint, Controlled), B : ((Int, 'T, ((Qubit, Qubit, 'T) => Unit : Adjoint, Controlled)) => Unit : Adjoint, Controlled)) : Unit {
+    operation TestAllVariants<'T> (available : Int, args : 'T, action : ((Qubit, Qubit, 'T) => Unit is Adj + Ctl), B : ((Int, 'T, ((Qubit, Qubit, 'T) => Unit is Adj + Ctl)) => Unit is Adj + Ctl)) : Unit {
         
         
         using (ctrls = Qubit[2]) {

--- a/src/Simulation/Simulators.Tests/Circuits/StartOperation.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/StartOperation.qs
@@ -9,9 +9,9 @@ namespace Microsoft.Quantum.Tests.StartOperation {
     
     newtype Qubits = Qubit[];
     
-    newtype UDT1 = ((Int, Qubit, (Qubit, Qubit), Result) => Unit : Adjoint, Controlled);
+    newtype UDT1 = ((Int, Qubit, (Qubit, Qubit), Result) => Unit is Adj + Ctl);
     
-    newtype UDT2 = (Qubit => Unit : Adjoint, Controlled);
+    newtype UDT2 = (Qubit => Unit is Adj + Ctl);
     
     newtype UDT3 = ((Int, Qubit) => Int);
     
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Tests.StartOperation {
     }
     
     
-    operation AllVariants<'T> (gate : ('T => Unit : Adjoint, Controlled), i : 'T, ctrls : Qubits) : Unit {
+    operation AllVariants<'T> (gate : ('T => Unit is Adj + Ctl), i : 'T, ctrls : Qubits) : Unit {
         
         body (...) {
             gate(i);
@@ -91,7 +91,7 @@ namespace Microsoft.Quantum.Tests.StartOperation {
     
     // This is needed to fix the bug that the parser is reporting incorrectly the type of UDTs:
     
-    function UDT1asUnitary (u : UDT1) : ((Int, Qubit, (Qubit, Qubit), Result) => Unit : Adjoint, Controlled) {
+    function UDT1asUnitary (u : UDT1) : ((Int, Qubit, (Qubit, Qubit), Result) => Unit is Adj + Ctl) {
         
         return u!;
     }

--- a/src/Simulation/Simulators.Tests/Circuits/Tuples.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/Tuples.qs
@@ -41,7 +41,7 @@ namespace Microsoft.Quantum.Tests.Tuples {
     
     newtype TupleE = (Int, Qubit[]);
     
-    newtype TupleF = ((TupleA, TupleD) => Unit : Adjoint, Controlled);
+    newtype TupleF = ((TupleA, TupleD) => Unit is Adj + Ctl);
     
     newtype TupleG = (Qubit, TupleF, TupleC, TupleD);
     

--- a/src/Simulation/Simulators.Tests/Circuits/VerifyUnitary.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/VerifyUnitary.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests.Circuits {
     ///     then it tests Controlled with different number of control qubits, also verifying that
     ///     Adjoint Controlled works.
     /// </summary>
-    operation VerifyUnitary (gate : (Qubit => Unit : Adjoint, Controlled), start : (Pauli, Result), expected : (Complex, Complex)) : Unit {
+    operation VerifyUnitary (gate : (Qubit => Unit is Adj + Ctl), start : (Pauli, Result), expected : (Complex, Complex)) : Unit {
         
         
         using (qubits = Qubit[1]) {

--- a/src/Simulation/Simulators.Tests/QuantumTestSuite/AssertEqualInPlace.qs
+++ b/src/Simulation/Simulators.Tests/QuantumTestSuite/AssertEqualInPlace.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation OnFirstQubitA (op : (Qubit => Unit : Adjoint), qubits : Qubit[]) : Unit {
+    operation OnFirstQubitA (op : (Qubit => Unit is Adj), qubits : Qubit[]) : Unit {
         
         body (...) {
             op(qubits[0]);
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation OnFirstQubitAC (op : (Qubit => Unit : Adjoint, Controlled), qubits : Qubit[]) : Unit {
+    operation OnFirstQubitAC (op : (Qubit => Unit is Adj + Ctl), qubits : Qubit[]) : Unit {
         
         body (...) {
             op(qubits[0]);
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation OnSecondQubitAC (op : (Qubit => Unit : Adjoint, Controlled), qubits : Qubit[]) : Unit {
+    operation OnSecondQubitAC (op : (Qubit => Unit is Adj + Ctl), qubits : Qubit[]) : Unit {
         
         body (...) {
             op(qubits[1]);
@@ -61,7 +61,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation OnFirstTwoQubitsAC (op : ((Qubit, Qubit) => Unit : Adjoint, Controlled), qubits : Qubit[]) : Unit {
+    operation OnFirstTwoQubitsAC (op : ((Qubit, Qubit) => Unit is Adj + Ctl), qubits : Qubit[]) : Unit {
         
         body (...) {
             op(qubits[0], qubits[1]);
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation OnFirstThreeQubitsAC (op : ((Qubit, Qubit, Qubit) => Unit : Adjoint, Controlled), qubits : Qubit[]) : Unit {
+    operation OnFirstThreeQubitsAC (op : ((Qubit, Qubit, Qubit) => Unit is Adj + Ctl), qubits : Qubit[]) : Unit {
         
         body (...) {
             op(qubits[0], qubits[1], qubits[2]);
@@ -91,7 +91,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation OnOneQubitA (op : (Qubit[] => Unit : Adjoint), qubit : Qubit) : Unit {
+    operation OnOneQubitA (op : (Qubit[] => Unit is Adj), qubit : Qubit) : Unit {
         
         body (...) {
             op([qubit]);
@@ -101,7 +101,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation OnOneQubitAC (op : (Qubit[] => Unit : Adjoint, Controlled), qubit : Qubit) : Unit {
+    operation OnOneQubitAC (op : (Qubit[] => Unit is Adj + Ctl), qubit : Qubit) : Unit {
         
         body (...) {
             op([qubit]);

--- a/src/Simulation/Simulators.Tests/QuantumTestSuite/AssertQubitUnitary.qs
+++ b/src/Simulation/Simulators.Tests/QuantumTestSuite/AssertQubitUnitary.qs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation AssertQubitUnitaryWithAdjoint (unitaryMatrix : RowMajorMatrix, unitaryOp : (Qubit => Unit : Adjoint)) : Unit {
+    operation AssertQubitUnitaryWithAdjoint (unitaryMatrix : RowMajorMatrix, unitaryOp : (Qubit => Unit is Adj)) : Unit {
         
         if (Length(unitaryMatrix!) != 2) {
             fail $"qubit unitary matrix must have two rows";

--- a/src/Simulation/Simulators.Tests/QuantumTestSuite/AssertUnitary.qs
+++ b/src/Simulation/Simulators.Tests/QuantumTestSuite/AssertUnitary.qs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation AssertUnitaryWithAdjoint (unitaryMatrix : RowMajorMatrix, unitaryOp : (Qubit[] => Unit : Adjoint), qubits : Qubit[]) : Unit {
+    operation AssertUnitaryWithAdjoint (unitaryMatrix : RowMajorMatrix, unitaryOp : (Qubit[] => Unit is Adj), qubits : Qubit[]) : Unit {
         
         
         if (Length(unitaryMatrix!) != 2 ^ Length(qubits)) {

--- a/src/Simulation/Simulators.Tests/QuantumTestSuite/ControlledOperationTester.qs
+++ b/src/Simulation/Simulators.Tests/QuantumTestSuite/ControlledOperationTester.qs
@@ -6,7 +6,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     open Microsoft.Quantum.Diagnostics;
     
     
-    operation ControlledQubitOperationTester (actual : (Qubit => Unit : Controlled, Adjoint), expected : (Qubit => Unit : Controlled, Adjoint), numberOfQubits : Int) : Unit {
+    operation ControlledQubitOperationTester (actual : (Qubit => Unit is Ctl + Adj), expected : (Qubit => Unit is Ctl + Adj), numberOfQubits : Int) : Unit {
         
         Message($"Testing operation: {actual} against {expected}");
         
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation ControlledOperationTester (actual : (Qubit[] => Unit : Controlled, Adjoint), expected : (Qubit[] => Unit : Controlled, Adjoint), numberOfQubits : Int, numberOfControls : Int) : Unit {
+    operation ControlledOperationTester (actual : (Qubit[] => Unit is Ctl + Adj), expected : (Qubit[] => Unit is Ctl + Adj), numberOfQubits : Int, numberOfControls : Int) : Unit {
         
         Message($"Testing operation: {actual} against {expected}");
         

--- a/src/Simulation/Simulators.Tests/QuantumTestSuite/ControlledOperationsTestUtils.qs
+++ b/src/Simulation/Simulators.Tests/QuantumTestSuite/ControlledOperationsTestUtils.qs
@@ -8,7 +8,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     open Microsoft.Quantum.Intrinsic;
     
     
-    operation MultiControlledQubitTestHelper (qubitOperation : (Qubit => Unit : Controlled, Adjoint), controls : Int, target : Qubit[]) : Unit {
+    operation MultiControlledQubitTestHelper (qubitOperation : (Qubit => Unit is Ctl + Adj), controls : Int, target : Qubit[]) : Unit {
         
         body (...) {
             
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation MultiControlledTestHelper (testOperation : (Qubit[] => Unit : Controlled, Adjoint), controlsCount : Int, targetCount : Int, target : Qubit[]) : Unit {
+    operation MultiControlledTestHelper (testOperation : (Qubit[] => Unit is Ctl + Adj), controlsCount : Int, targetCount : Int, target : Qubit[]) : Unit {
         
         body (...) {
             

--- a/src/Simulation/Simulators.Tests/QuantumTestSuite/OneQubitTestList.qs
+++ b/src/Simulation/Simulators.Tests/QuantumTestSuite/OneQubitTestList.qs
@@ -9,7 +9,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     open Microsoft.Quantum.Convert;
     
     
-    newtype SingleQubitOperationDescription = ((Qubit => Unit : Adjoint, Controlled), RowMajorMatrix, Int, Bool);
+    newtype SingleQubitOperationDescription = ((Qubit => Unit is Adj + Ctl), RowMajorMatrix, Int, Bool);
     
     
     function FixesComputationalBasis (record : SingleQubitOperationDescription) : Bool {
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    function OperationMap (record : SingleQubitOperationDescription) : (Qubit => Unit : Adjoint, Controlled) {
+    function OperationMap (record : SingleQubitOperationDescription) : (Qubit => Unit is Adj + Ctl) {
         
         let (operationMap, operationMatrix, levelOfCliffordHierarchy, fixesComputationalBasis) = record!;
         return operationMap;

--- a/src/Simulation/Simulators.Tests/QuantumTestSuite/TwoQubitUnitaries.qs
+++ b/src/Simulation/Simulators.Tests/QuantumTestSuite/TwoQubitUnitaries.qs
@@ -7,7 +7,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     open Microsoft.Quantum.Intrinsic;
     
     
-    operation TwoQubitUnitaryTestHelper (matrix : RowMajorMatrix, unitary : (Qubit[] => Unit : Adjoint)) : Unit {
+    operation TwoQubitUnitaryTestHelper (matrix : RowMajorMatrix, unitary : (Qubit[] => Unit is Adj)) : Unit {
         let totalQubits = MaxQubitsToAllocateForTwoQubitTests();
         
         using (qubits = Qubit[totalQubits]) {            
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Simulation.TestSuite {
     }
     
     
-    operation ControlledTestHelper (qubitOperation : (Qubit => Unit : Controlled, Adjoint), target : Qubit[]) : Unit {
+    operation ControlledTestHelper (qubitOperation : (Qubit => Unit is Ctl + Adj), target : Qubit[]) : Unit {
         
         body (...) {
             


### PR DESCRIPTION
This is needed to unblock microsoft/qsharp-compiler#789, which removes this deprecated syntax.