### PR TITLE
Update QirRuntime to reflect departure of %TupleHeader from QIR

### DIFF
--- a/src/QirRuntime/lib/QIR/bridge-qis.ll
+++ b/src/QirRuntime/lib/QIR/bridge-qis.ll
@@ -13,7 +13,6 @@
 %Range = type { i64, i64, i64 }
 %Result = type opaque
 %String = type opaque
-%TupleHeader = type { i32 }
 %Pauli = type {i2}
 
 ;=======================================================================================================================
@@ -30,7 +29,6 @@
 %struct.QirCallable = type opaque
 %struct.QirRange = type { i64, i64, i64 }
 %struct.QirString = type opaque
-%struct.QirTupleHeader = type { i32 }
 
 ;===============================================================================
 ; declarations of the native methods this bridge delegates to

--- a/src/QirRuntime/lib/QIR/bridge-qis.ll
+++ b/src/QirRuntime/lib/QIR/bridge-qis.ll
@@ -59,14 +59,14 @@ define double @__quantum__qis__intAsDouble(i64 %i)
   ret double %d
 }
 
-define void @__quantum__qis__cnot__(%Qubit* %.qc, %Qubit* %.qt) {
+define void @__quantum__qis__cnot__body(%Qubit* %.qc, %Qubit* %.qt) {
   %qc = bitcast %Qubit* %.qc to %class.QUBIT*
   %qt = bitcast %Qubit* %.qt to %class.QUBIT*
   call void @quantum__qis__cnot(%class.QUBIT* %qc, %class.QUBIT* %qt)
   ret void
 }
 
-define void @__quantum__qis__h__(%Qubit* %.q) {
+define void @__quantum__qis__h__body(%Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__h(%class.QUBIT* %q)
   ret void
@@ -87,63 +87,62 @@ define %Result* @__quantum__qis__mz(%Qubit* %.q) {
   ret %Result* %.r
 }
 
-define void @__quantum__qis__s__(%Qubit* %.q) {
+define void @__quantum__qis__s__body(%Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__s(%class.QUBIT* %q)
   ret void
 }
 
-define void @__quantum__qis__t__(%Qubit* %.q) {
+define void @__quantum__qis__t__body(%Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__t(%class.QUBIT* %q)
   ret void
 }
 
-define void @__quantum__qis__rx__(double %.theta, %Qubit* %.q) {
+define void @__quantum__qis__rx__body(double %.theta, %Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__rx(double %.theta, %class.QUBIT* %q)
   ret void
 }
 
-define void @__quantum__qis__ry__(double %.theta, %Qubit* %.q) {
+define void @__quantum__qis__ry__body(double %.theta, %Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__ry(double %.theta, %class.QUBIT* %q)
   ret void
 }
 
-define void @__quantum__qis__rz__(double %.theta, %Qubit* %.q) {
+define void @__quantum__qis__rz__body(double %.theta, %Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__rz(double %.theta, %class.QUBIT* %q)
   ret void
 }
 
-define void @__quantum__qis__x__(%Qubit* %.q) {
+define void @__quantum__qis__x__body(%Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__x(%class.QUBIT* %q)
   ret void
 }
 
-define void @__quantum__qis__y__(%Qubit* %.q) {
+define void @__quantum__qis__y__body(%Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__y(%class.QUBIT* %q)
   ret void
 }
 
-define void @__quantum__qis__z__(%Qubit* %.q) {
+define void @__quantum__qis__z__body(%Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   call void @quantum__qis__z(%class.QUBIT* %q)
   ret void
 }
 
-
-define void @__quantum__qis__crx__(%Array* %.ctls, double %.theta, %Qubit* %.q) {
+define void @__quantum__qis__crx__body(%Array* %.ctls, double %.theta, %Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   %ctls = bitcast %Array* %.ctls to %struct.QirArray*
   call void @quantum__qis__crx(%struct.QirArray* %ctls, double %.theta, %class.QUBIT* %q)
   ret void
 }
 
-define void @__quantum__qis__crz__(%Array* %.ctls, double %.theta, %Qubit* %.q) {
+define void @__quantum__qis__crz__body(%Array* %.ctls, double %.theta, %Qubit* %.q) {
   %q = bitcast %Qubit* %.q to %class.QUBIT*
   %ctls = bitcast %Array* %.ctls to %struct.QirArray*
   call void @quantum__qis__crz(%struct.QirArray* %ctls, double %.theta, %class.QUBIT* %q)

--- a/src/QirRuntime/lib/QIR/qirTypes.hpp
+++ b/src/QirRuntime/lib/QIR/qirTypes.hpp
@@ -78,7 +78,7 @@ struct QirString
     Tuples are opaque to the runtime and the type of the data contained in them isn't (generally) known, thus, we use
     char* to represent the tuples QIR operates with. However, we need to manage tuples' lifetime and in case of nested
     controlled callables we also need to peek into the tuple's content. To do this we associate with each tuple's buffer
-    a header that contains the relevant data. The header immediately precedes the tuple's buffer in memeory when the
+    a header that contains the relevant data. The header immediately precedes the tuple's buffer in memory when the
     tuple is created.
 ======================================================================================================================*/
 using PTuple = char*;

--- a/src/QirRuntime/lib/QIR/qirTypes.hpp
+++ b/src/QirRuntime/lib/QIR/qirTypes.hpp
@@ -87,9 +87,12 @@ struct QirTupleHeader
     int refCount = 0;
     int tupleSize = 0; // when creating the tuple, must be set to the size of the tuple's data buffer
 
+    // flexible array member, must be last in the struct
+    char data[];
+
     PTuple AsTuple()
     {
-        return reinterpret_cast<PTuple>(this) + sizeof(QirTupleHeader);
+        return data;
     }
 
     int AddRef();
@@ -97,7 +100,11 @@ struct QirTupleHeader
 
     static QirTupleHeader* Create(int size);
     static QirTupleHeader* CreateWithCopiedData(QirTupleHeader* other);
-    static QirTupleHeader* GetHeader(PTuple tuple);
+
+    static QirTupleHeader* GetHeader(PTuple tuple)
+    {
+        return reinterpret_cast<QirTupleHeader*>(tuple - offsetof(QirTupleHeader, data));
+    }
 };
 
 /*======================================================================================================================
@@ -125,7 +132,7 @@ struct TupleWithControls
 
     QirTupleHeader* GetHeader()
     {
-        return QirTupleHeader::GetHeader(reinterpret_cast<PTuple>(this));
+        return QirTupleHeader::GetHeader(this->AsTuple());
     }
 };
 static_assert(

--- a/src/QirRuntime/lib/QIR/qirTypes.hpp
+++ b/src/QirRuntime/lib/QIR/qirTypes.hpp
@@ -24,7 +24,7 @@ We'll allow that and will treat reference count dropping to zero the same as if 
 called.
 
 When creating an array that doesn't own qubits (even if it's populated with qubit pointers), the client must provide
-the count of elements and the size of each. The array is allocated with reference count equal 1 and will release its 
+the count of elements and the size of each. The array is allocated with reference count equal 1 and will release its
 buffer on reference count going to zero:
   %0 = call %Array* @__quantum__rt__array_create_1d(i32 8, i32 1, i64 %count)
   %1 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 0)
@@ -33,7 +33,7 @@ buffer on reference count going to zero:
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* %1, i8* %3, i64 %2, i1 false)
   call void @__quantum__rt__array_unreference(%Array* %0)
 Note, that in this case the client is responsible for releasing individual qubits (if they were stored into the array).
-==============================================================================*/
+======================================================================================================================*/
 struct QirArray
 {
     int64_t count = 0; // overall size of the array across all dimensions
@@ -63,9 +63,9 @@ struct QirArray
     void Append(const QirArray* other);
 };
 
-/*==============================================================================
+/*======================================================================================================================
     QirString is just a wrapper around std::string
-==============================================================================*/
+======================================================================================================================*/
 struct QirString
 {
     long refCount = 1;
@@ -74,57 +74,114 @@ struct QirString
     QirString(std::string&& str);
 };
 
-/*==============================================================================
-    The types and methods, expected by QIR for tuples:
-    %TupleHeader = type { i32, i32 }
-    declare %TupleHeader* @__quantum__rt__tuple_create(i64)
-
-    Argument passed to __quantum__rt__tuple_create is the size (in bytes) of the tuple, including the header.
-    For example:
-    ; to calculate the size of a tuple pretend having an array of them and get
-    ; offset to the first element
-    %t1 = getelementptr { %TupleHeader, %Callable*, %Array* }, { %TupleHeader, %Callable*, %Array* }* null, i32 1
-    ; convert the offset to int and call __quantum__rt__tuple_create
-    %t2 = ptrtoint { %TupleHeader, %Callable*, %Array* }* %t1 to i64
-    %0 = call %TupleHeader* @__quantum__rt__tuple_create(i62 %t2)
-
-    Notice, that the TupleHeader is included into the Tuple's buffer.
-==============================================================================*/
+/*======================================================================================================================
+    Tuples are opaque to the runtime and the type of the data contained in them isn't (generally) known, thus, we use
+    char* to represent the tuples QIR operates with. However, we need to manage tuples' lifetime and in case of nested
+    controlled callables we also need to peek into the tuple's content. To do this we associate with each tuple's buffer
+    a header that contains the relevant data. The header immediately precedes the tuple's buffer in memeory when the
+    tuple is created.
+======================================================================================================================*/
 struct QirTupleHeader
 {
     int refCount = 0;
-    int tupleSize = 0; // when creating the tuple, must be set to: size of this header + size of the tuple's data buffer
+    int tupleSize = 0; // when creating the tuple, must be set to the size of the tuple's data buffer
 
-    char* Data()
+    char* AsTuple()
     {
         return reinterpret_cast<char*>(this) + sizeof(QirTupleHeader);
     }
+
+    int AddRef()
+    {
+        assert(refCount > 0);
+        return ++refCount;
+    }
+
+    int Release()
+    {
+        --refCount;
+        if (refCount == 0)
+        {
+            char* buffer = reinterpret_cast<char*>(this);
+            delete[] buffer;
+        }
+        return refCount;
+    }
+
+    static QirTupleHeader* CreateWithCopiedData(QirTupleHeader* other)
+    {
+        const int size = other->tupleSize;
+        char* buffer = new char[sizeof(QirTupleHeader) + size];
+
+        QirTupleHeader* th = reinterpret_cast<QirTupleHeader*>(buffer);
+        th->refCount = 1;
+        th->tupleSize = size;
+        memcpy(th->AsTuple(), other->AsTuple(), size);
+
+        return th;
+    }
+
+    static QirTupleHeader* GetHeader(char* tuple)
+    {
+        return reinterpret_cast<QirTupleHeader*>(tuple - sizeof(QirTupleHeader));
+    }
 };
 
-/*==============================================================================
+/*======================================================================================================================
+    A helper type for unpacking tuples used by multi-level controlled callables
+======================================================================================================================*/
+struct TupleWithControls
+{
+    QirArray* controls;
+    TupleWithControls* innerTuple;
+
+    char* AsTuple()
+    {
+        return reinterpret_cast<char*>(this);
+    }
+
+    static TupleWithControls* FromTuple(char* tuple)
+    {
+        return reinterpret_cast<TupleWithControls*>(tuple);
+    }
+
+    static TupleWithControls* FromTupleHeader(QirTupleHeader* th)
+    {
+        return FromTuple(th->AsTuple());
+    }
+
+    QirTupleHeader* GetHeader()
+    {
+        return QirTupleHeader::GetHeader(reinterpret_cast<char*>(this));
+    }
+};
+static_assert(
+    sizeof(TupleWithControls) == 2 * sizeof(void*),
+    L"TupleWithControls must be tightly packed for FlattenControlArrays to be correct");
+
+/*======================================================================================================================
     Example of creating a callable
 
     ; Single entry of a callable
     ; (a callable might provide entries for body, controlled, adjoint and controlled-adjoint)
-    define void @UpdateAnsatz-body(
-        %TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) { ... }
+    define void @callable-body(
+        %Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) { ... }
 
-    ; Definition of the callable
-    @UpdateAnsatz =
-        constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]
+    ; Definition of the callable that doesn't support any functors
+    @callable =
+        constant [4 x void (%Tuple*, %Tuple*, %Tuple*)*]
         [
-            void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @UpdateAnsatz-body,
-            void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null,
-            void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null,
-            void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null
+            void (%Tuple*, %Tuple*, %Tuple*)* @collable-body,
+            void (%Tuple*, %Tuple*, %Tuple*)* null,
+            void (%Tuple*, %Tuple*, %Tuple*)* null,
+            void (%Tuple*, %Tuple*, %Tuple*)* null
         ]
 
     %3 = call %Callable* @__quantum__rt__callable_create(
-        [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @UpdateAnsatz,
-        %TupleHeader* null)
+        [4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @callable, %Tuple* null)
 
-==============================================================================*/
-typedef void (*t_CallableEntry)(QirTupleHeader*, QirTupleHeader*, QirTupleHeader*);
+======================================================================================================================*/
+typedef void (*t_CallableEntry)(char*, char*, char*);
 struct QirCallable
 {
     static int constexpr Adjoint = 1;
@@ -136,7 +193,7 @@ struct QirCallable
         QirCallable::Adjoint + QirCallable::Controlled < QirCallable::TableSize,
         L"functor kind is used as index into the functionTable");
 
-    long refCount = 1;
+    int refCount = 1;
 
     // If the callable doesn't support Adjoint or Controlled functors, the corresponding entries in the table should be
     // set to nullptr.
@@ -144,11 +201,11 @@ struct QirCallable
 
     // The callable stores the capture, it's given at creation, and passes it to the functions from the function table,
     // but the runtime doesn't have any knowledge about what the tuple actually is.
-    QirTupleHeader* const capture = nullptr;
+    char* const capture = nullptr;
 
     // By default the callable is neither adjoint nor controlled.
     int appliedFunctor = 0;
-    
+
     // Per https://github.com/microsoft/qsharp-language/blob/main/Specifications/QIR/Callables.md, the callable must
     // unpack the nested controls from the input tuples. Because the tuples aren't typed, the callable will assume
     // that its input tuples are formed in a particular way and will extract the controls to match its tracked depth.
@@ -158,11 +215,12 @@ struct QirCallable
     ~QirCallable();
 
   public:
-    QirCallable(const t_CallableEntry* ftEntries, QirTupleHeader* capture);
+    QirCallable(const t_CallableEntry* ftEntries, char* capture);
     QirCallable(const QirCallable& other);
 
-    long AddRef();
-    long Release();
-    void Invoke(QirTupleHeader* args, QirTupleHeader* result);
+    int AddRef();
+    int Release();
+
+    void Invoke(char* args, char* result);
     void ApplyFunctor(int functor);
 };

--- a/src/QirRuntime/lib/QIR/quantum__qis.hpp
+++ b/src/QirRuntime/lib/QIR/quantum__qis.hpp
@@ -14,7 +14,6 @@
 #endif
 
 struct QirArray;
-struct QirTupleHeader;
 struct QirCallable;
 struct QirString;
 struct QirBigInt;

--- a/src/QirRuntime/lib/QIR/quantum__rt.hpp
+++ b/src/QirRuntime/lib/QIR/quantum__rt.hpp
@@ -9,7 +9,6 @@
 #include "CoreTypes.hpp"
 
 struct QirArray;
-struct QirTupleHeader;
 struct QirCallable;
 struct QirString;
 struct QirBigInt;
@@ -91,13 +90,13 @@ extern "C"
     // ------------------------------------------------------------------------
 
     // Allocates space for a tuple requiring the given number of bytes and sets the reference count to 1.
-    QIR_SHARED_API QirTupleHeader* quantum__rt__tuple_create(int64_t); // NOLINT
+    QIR_SHARED_API char* quantum__rt__tuple_create(int64_t); // NOLINT
 
     // Indicates that a new reference has been added.
-    QIR_SHARED_API void quantum__rt__tuple_reference(QirTupleHeader*); // NOLINT
+    QIR_SHARED_API void quantum__rt__tuple_reference(char*); // NOLINT
 
     // Indicates that an existing reference has been removed and potentially releases the tuple.
-    QIR_SHARED_API void quantum__rt__tuple_unreference(QirTupleHeader*); // NOLINT
+    QIR_SHARED_API void quantum__rt__tuple_unreference(char*); // NOLINT
 
     // ------------------------------------------------------------------------
     // Arrrays
@@ -158,8 +157,8 @@ extern "C"
 
     // Initializes the callable with the provided function table and capture tuple. The capture tuple pointer
     // should be null if there is no capture.
-    typedef void (*t_CallableEntry)(QirTupleHeader*, QirTupleHeader*, QirTupleHeader*);          // NOLINT
-    QIR_SHARED_API QirCallable* quantum__rt__callable_create(t_CallableEntry*, QirTupleHeader*); // NOLINT
+    typedef void (*t_CallableEntry)(char*, char*, char*);                      // NOLINT
+    QIR_SHARED_API QirCallable* quantum__rt__callable_create(t_CallableEntry*, char*); // NOLINT
 
     // Indicates that a new reference has been added.
     QIR_SHARED_API void quantum__rt__callable_reference(QirCallable*); // NOLINT
@@ -171,7 +170,7 @@ extern "C"
     QIR_SHARED_API QirCallable* quantum__rt__callable_copy(QirCallable*); // NOLINT
 
     // Invokes the callable with the provided argument tuple and fills in the result tuple.
-    QIR_SHARED_API void quantum__rt__callable_invoke(QirCallable*, QirTupleHeader*, QirTupleHeader*); // NOLINT
+    QIR_SHARED_API void quantum__rt__callable_invoke(QirCallable*, char*, char*); // NOLINT
 
     // Updates the callable by applying the Adjoint functor.
     QIR_SHARED_API void quantum__rt__callable_make_adjoint(QirCallable*); // NOLINT

--- a/src/QirRuntime/lib/QIR/quantum__rt.hpp
+++ b/src/QirRuntime/lib/QIR/quantum__rt.hpp
@@ -7,6 +7,7 @@
 #include <stdarg.h> // for va_list
 
 #include "CoreTypes.hpp"
+#include "qirTypes.hpp"
 
 struct QirArray;
 struct QirCallable;
@@ -90,13 +91,13 @@ extern "C"
     // ------------------------------------------------------------------------
 
     // Allocates space for a tuple requiring the given number of bytes and sets the reference count to 1.
-    QIR_SHARED_API char* quantum__rt__tuple_create(int64_t); // NOLINT
+    QIR_SHARED_API PTuple quantum__rt__tuple_create(int64_t); // NOLINT
 
     // Indicates that a new reference has been added.
-    QIR_SHARED_API void quantum__rt__tuple_reference(char*); // NOLINT
+    QIR_SHARED_API void quantum__rt__tuple_reference(PTuple); // NOLINT
 
     // Indicates that an existing reference has been removed and potentially releases the tuple.
-    QIR_SHARED_API void quantum__rt__tuple_unreference(char*); // NOLINT
+    QIR_SHARED_API void quantum__rt__tuple_unreference(PTuple); // NOLINT
 
     // ------------------------------------------------------------------------
     // Arrrays
@@ -157,8 +158,8 @@ extern "C"
 
     // Initializes the callable with the provided function table and capture tuple. The capture tuple pointer
     // should be null if there is no capture.
-    typedef void (*t_CallableEntry)(char*, char*, char*);                      // NOLINT
-    QIR_SHARED_API QirCallable* quantum__rt__callable_create(t_CallableEntry*, char*); // NOLINT
+    typedef void (*t_CallableEntry)(PTuple, PTuple, PTuple);                      // NOLINT
+    QIR_SHARED_API QirCallable* quantum__rt__callable_create(t_CallableEntry*, PTuple); // NOLINT
 
     // Indicates that a new reference has been added.
     QIR_SHARED_API void quantum__rt__callable_reference(QirCallable*); // NOLINT
@@ -170,7 +171,7 @@ extern "C"
     QIR_SHARED_API QirCallable* quantum__rt__callable_copy(QirCallable*); // NOLINT
 
     // Invokes the callable with the provided argument tuple and fills in the result tuple.
-    QIR_SHARED_API void quantum__rt__callable_invoke(QirCallable*, char*, char*); // NOLINT
+    QIR_SHARED_API void quantum__rt__callable_invoke(QirCallable*, PTuple, PTuple); // NOLINT
 
     // Updates the callable by applying the Adjoint functor.
     QIR_SHARED_API void quantum__rt__callable_make_adjoint(QirCallable*); // NOLINT

--- a/src/QirRuntime/test/QIR-dynamic/qir-test-random-lnx.ll
+++ b/src/QirRuntime/test/QIR-dynamic/qir-test-random-lnx.ll
@@ -1,10 +1,8 @@
 
 %Result = type opaque
 %Range = type { i64, i64, i64 }
-%TupleHeader = type { i32, i32 }
-%Array = type opaque
 %Qubit = type opaque
-%String = type opaque
+%Array = type opaque
 
 @ResultZero = external global %Result*
 @ResultOne = external global %Result*
@@ -15,37 +13,6 @@
 @EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
 
 @Microsoft_Quantum_Testing_QIR_QuantumRandomNumberGenerator = alias i64 (), i64 ()* @Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__body
-
-define %TupleHeader* @Microsoft__Quantum__Core__Attribute__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__EntryPoint__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__Inline__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-declare i64 @Microsoft__Quantum__Core__Length__body(%Array*)
-
-declare %Range @Microsoft__Quantum__Core__RangeReverse__body(%Range)
-
-declare void @Microsoft__Quantum__Intrinsic__H____body(%Qubit*)
-
-define void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__h__(%Qubit* %qb)
-  ret void
-}
-
-declare void @__quantum__qis__h__(%Qubit*)
-
-declare %Result* @Microsoft__Quantum__Intrinsic__M__body(%Qubit*)
 
 define i64 @Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__body() #0 {
 entry:
@@ -65,7 +32,7 @@ header__1:                                        ; preds = %exiting__1, %prehea
 
 body__1:                                          ; preds = %header__1
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
-  call void @__quantum__qis__h__(%Qubit* %q)
+  call void @__quantum__qis__h__body(%Qubit* %q)
   %3 = load i64, i64* %randomNumber
   %4 = shl i64 %3, 1
   store i64 %4, i64* %randomNumber
@@ -82,6 +49,8 @@ then0__1:                                         ; preds = %body__1
 
 continue__1:                                      ; preds = %then0__1, %body__1
   call void @__quantum__rt__qubit_release(%Qubit* %q)
+  call void @__quantum__rt__result_unreference(%Result* %5)
+  call void @__quantum__rt__result_unreference(%Result* %6)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %continue__1
@@ -97,24 +66,20 @@ declare %Qubit* @__quantum__rt__qubit_allocate()
 
 declare %Array* @__quantum__rt__qubit_allocate_array(i64)
 
+declare void @__quantum__qis__h__body(%Qubit*)
+
 declare %Result* @__quantum__qis__mz(%Qubit*)
 
 declare i1 @__quantum__rt__result_equal(%Result*, %Result*)
 
 declare void @__quantum__rt__qubit_release(%Qubit*)
 
-define { %TupleHeader, %String* }* @Microsoft__Quantum__Targeting__TargetInstruction__body(%String* %arg0) {
+declare void @__quantum__rt__result_unreference(%Result*)
+
+define void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qb) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %String* }* getelementptr ({ %TupleHeader, %String* }, { %TupleHeader, %String* }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %String* }*
-  %2 = getelementptr { %TupleHeader, %String* }, { %TupleHeader, %String* }* %1, i64 0, i32 1
-  store %String* %arg0, %String** %2
-  call void @__quantum__rt__string_reference(%String* %arg0)
-  ret { %TupleHeader, %String* }* %1
+  call void @__quantum__qis__h__body(%Qubit* %qb)
+  ret void
 }
-
-declare %TupleHeader* @__quantum__rt__tuple_create(i64)
-
-declare void @__quantum__rt__string_reference(%String*)
 
 attributes #0 = { "EntryPoint" }

--- a/src/QirRuntime/test/QIR-dynamic/qir-test-random-win.ll
+++ b/src/QirRuntime/test/QIR-dynamic/qir-test-random-win.ll
@@ -1,10 +1,8 @@
 
 %Result = type opaque
 %Range = type { i64, i64, i64 }
-%TupleHeader = type { i32, i32 }
-%Array = type opaque
 %Qubit = type opaque
-%String = type opaque
+%Array = type opaque
 
 @ResultZero = external dllimport global %Result*
 @ResultOne = external dllimport global %Result*
@@ -15,37 +13,6 @@
 @EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
 
 @Microsoft_Quantum_Testing_QIR_QuantumRandomNumberGenerator = alias i64 (), i64 ()* @Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__body
-
-define %TupleHeader* @Microsoft__Quantum__Core__Attribute__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__EntryPoint__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__Inline__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-declare i64 @Microsoft__Quantum__Core__Length__body(%Array*)
-
-declare %Range @Microsoft__Quantum__Core__RangeReverse__body(%Range)
-
-declare void @Microsoft__Quantum__Intrinsic__H____body(%Qubit*)
-
-define void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__h__(%Qubit* %qb)
-  ret void
-}
-
-declare void @__quantum__qis__h__(%Qubit*)
-
-declare %Result* @Microsoft__Quantum__Intrinsic__M__body(%Qubit*)
 
 define i64 @Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__body() #0 {
 entry:
@@ -65,7 +32,7 @@ header__1:                                        ; preds = %exiting__1, %prehea
 
 body__1:                                          ; preds = %header__1
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
-  call void @__quantum__qis__h__(%Qubit* %q)
+  call void @__quantum__qis__h__body(%Qubit* %q)
   %3 = load i64, i64* %randomNumber
   %4 = shl i64 %3, 1
   store i64 %4, i64* %randomNumber
@@ -82,6 +49,8 @@ then0__1:                                         ; preds = %body__1
 
 continue__1:                                      ; preds = %then0__1, %body__1
   call void @__quantum__rt__qubit_release(%Qubit* %q)
+  call void @__quantum__rt__result_unreference(%Result* %5)
+  call void @__quantum__rt__result_unreference(%Result* %6)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %continue__1
@@ -97,24 +66,20 @@ declare %Qubit* @__quantum__rt__qubit_allocate()
 
 declare %Array* @__quantum__rt__qubit_allocate_array(i64)
 
+declare void @__quantum__qis__h__body(%Qubit*)
+
 declare %Result* @__quantum__qis__mz(%Qubit*)
 
 declare i1 @__quantum__rt__result_equal(%Result*, %Result*)
 
 declare void @__quantum__rt__qubit_release(%Qubit*)
 
-define { %TupleHeader, %String* }* @Microsoft__Quantum__Targeting__TargetInstruction__body(%String* %arg0) {
+declare void @__quantum__rt__result_unreference(%Result*)
+
+define void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qb) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %String* }* getelementptr ({ %TupleHeader, %String* }, { %TupleHeader, %String* }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %String* }*
-  %2 = getelementptr { %TupleHeader, %String* }, { %TupleHeader, %String* }* %1, i64 0, i32 1
-  store %String* %arg0, %String** %2
-  call void @__quantum__rt__string_reference(%String* %arg0)
-  ret { %TupleHeader, %String* }* %1
+  call void @__quantum__qis__h__body(%Qubit* %qb)
+  ret void
 }
-
-declare %TupleHeader* @__quantum__rt__tuple_create(i64)
-
-declare void @__quantum__rt__string_reference(%String*)
 
 attributes #0 = { "EntryPoint" }

--- a/src/QirRuntime/test/QIR-static/qir-driver.cpp
+++ b/src/QirRuntime/test/QIR-static/qir-driver.cpp
@@ -286,11 +286,11 @@ struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
 };
 FunctorsTestSimulator* g_ctrqapi = nullptr;
 extern "C" int64_t Microsoft__Quantum__Testing__QIR__TestControlled__body(); // NOLINT
-extern "C" void __quantum__qis__k__(Qubit q)                                 // NOLINT
+extern "C" void __quantum__qis__k__body(Qubit q)                                 // NOLINT
 {
     g_ctrqapi->X(q);
 }
-extern "C" void __quantum__qis__kctl__(QirArray* controls, Qubit q) // NOLINT
+extern "C" void __quantum__qis__k__ctl(QirArray* controls, Qubit q) // NOLINT
 {
     g_ctrqapi->ControlledX(controls->count, reinterpret_cast<Qubit*>(controls->buffer), q);
 }

--- a/src/QirRuntime/test/QIR-static/qir-test-arrays.ll
+++ b/src/QirRuntime/test/QIR-static/qir-test-arrays.ll
@@ -1,15 +1,12 @@
 
 %Result = type opaque
 %Range = type { i64, i64, i64 }
-%TupleHeader = type { i32, i32 }
 %String = type opaque
 %Array = type opaque
 
 @ResultZero = external global %Result*
 @ResultOne = external global %Result*
 @EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
-
-declare %TupleHeader* @__quantum__rt__tuple_create(i64)
 
 define i64 @Microsoft__Quantum__Testing__QIR__Test_Arrays__body(%Array* %array, i64 %index, i64 %val) {
 entry:

--- a/src/QirRuntime/test/QIR-static/qir-test-functors.ll
+++ b/src/QirRuntime/test/QIR-static/qir-test-functors.ll
@@ -1,135 +1,46 @@
 
 %Result = type opaque
 %Range = type { i64, i64, i64 }
-%TupleHeader = type { i32, i32 }
+%Tuple = type opaque
 %Qubit = type opaque
 %Array = type opaque
 %Callable = type opaque
-%String = type opaque
 
 @ResultZero = external global %Result*
 @ResultOne = external global %Result*
 @EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
-@Microsoft__Quantum__Testing__QIR__Qop = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Testing__QIR__Qop__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Testing__QIR__Qop__adj__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Testing__QIR__Qop__ctrl__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Testing__QIR__Qop__ctrladj__wrapper]
-@PartialApplication__1 = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__1__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__1__adj__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__1__ctrl__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__1__ctrladj__wrapper]
+@Microsoft__Quantum__Testing__QIR__Qop = constant [4 x void (%Tuple*, %Tuple*, %Tuple*)*] [void (%Tuple*, %Tuple*, %Tuple*)* @Microsoft__Quantum__Testing__QIR__Qop__body__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* @Microsoft__Quantum__Testing__QIR__Qop__adj__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* @Microsoft__Quantum__Testing__QIR__Qop__ctl__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* @Microsoft__Quantum__Testing__QIR__Qop__ctladj__wrapper]
+@PartialApplication__1 = constant [4 x void (%Tuple*, %Tuple*, %Tuple*)*] [void (%Tuple*, %Tuple*, %Tuple*)* @Lifted__PartialApplication__1__body__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* @Lifted__PartialApplication__1__adj__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* @Lifted__PartialApplication__1__ctl__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* @Lifted__PartialApplication__1__ctladj__wrapper]
 
 @Microsoft_Quantum_Testing_QIR_TestControlled = alias i64 (), i64 ()* @Microsoft__Quantum__Testing__QIR__TestControlled__body
 
-declare %Result* @Microsoft__Quantum__Intrinsic__M__body(%Qubit*)
-
-declare void @Microsoft__Quantum__Intrinsic__K____body(%Qubit*)
-
-declare void @Microsoft__Quantum__Intrinsic__KCtl____body(%Array*, %Qubit*)
-
 define void @Microsoft__Quantum__Intrinsic__K__body(%Qubit* %q) {
 entry:
-  call void @__quantum__qis__k__(%Qubit* %q)
+  call void @__quantum__qis__k__body(%Qubit* %q)
   ret void
 }
 
-declare void @__quantum__qis__k__(%Qubit*)
+declare void @__quantum__qis__k__body(%Qubit*)
 
-define void @Microsoft__Quantum__Intrinsic__K__ctrl(%Array* %__controlQubits__, %Qubit* %q) {
+define void @Microsoft__Quantum__Intrinsic__K__ctl(%Array* %__controlQubits__, %Qubit* %q) {
 entry:
-  call void @__quantum__qis__kctl__(%Array* %__controlQubits__, %Qubit* %q)
+  call void @__quantum__qis__k__ctl(%Array* %__controlQubits__, %Qubit* %q)
   ret void
 }
 
-declare void @__quantum__qis__kctl__(%Array*, %Qubit*)
-
-define %TupleHeader* @Microsoft__Quantum__Core__Attribute__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__EntryPoint__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__Inline__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-declare i64 @Microsoft__Quantum__Core__Length__body(%Array*)
-
-declare %Range @Microsoft__Quantum__Core__RangeReverse__body(%Range)
-
-define void @Microsoft__Quantum__Testing__QIR__Qop__body(%Qubit* %q, i64 %n) {
-entry:
-  %0 = srem i64 %n, 2
-  %1 = icmp eq i64 %0, 1
-  br i1 %1, label %then0__1, label %continue__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__k__(%Qubit* %q)
-  br label %continue__1
-
-continue__1:                                      ; preds = %then0__1, %entry
-  ret void
-}
-
-define void @Microsoft__Quantum__Testing__QIR__Qop__adj(%Qubit* %q, i64 %n) {
-entry:
-  %0 = srem i64 %n, 2
-  %1 = icmp eq i64 %0, 1
-  br i1 %1, label %then0__1, label %continue__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__k__(%Qubit* %q)
-  br label %continue__1
-
-continue__1:                                      ; preds = %then0__1, %entry
-  ret void
-}
-
-define void @Microsoft__Quantum__Testing__QIR__Qop__ctrl(%Array* %ctrls, { %TupleHeader, %Qubit*, i64 }* %arg__1) {
-entry:
-  %0 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %arg__1, i64 0, i32 1
-  %.q = load %Qubit*, %Qubit** %0
-  %1 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %arg__1, i64 0, i32 2
-  %2 = load i64, i64* %1
-  %3 = srem i64 %2, 2
-  %4 = icmp eq i64 %3, 1
-  br i1 %4, label %then0__1, label %continue__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__kctl__(%Array* %ctrls, %Qubit* %.q)
-  br label %continue__1
-
-continue__1:                                      ; preds = %then0__1, %entry
-  ret void
-}
-
-define void @Microsoft__Quantum__Testing__QIR__Qop__ctrladj(%Array* %__controlQubits__, { %TupleHeader, %Qubit*, i64 }* %arg__1) {
-entry:
-  %0 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %arg__1, i64 0, i32 1
-  %.q = load %Qubit*, %Qubit** %0
-  %1 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %arg__1, i64 0, i32 2
-  %2 = load i64, i64* %1
-  %3 = srem i64 %2, 2
-  %4 = icmp eq i64 %3, 1
-  br i1 %4, label %then0__1, label %continue__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__kctl__(%Array* %__controlQubits__, %Qubit* %.q)
-  br label %continue__1
-
-continue__1:                                      ; preds = %then0__1, %entry
-  ret void
-}
+declare void @__quantum__qis__k__ctl(%Array*, %Qubit*)
 
 define i64 @Microsoft__Quantum__Testing__QIR__TestControlled__body() #0 {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, i64 }* getelementptr ({ %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %Callable*, i64 }*
-  %2 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %1, i64 0, i32 1
-  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__Qop, %TupleHeader* null)
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i64 }* getelementptr ({ %Callable*, i64 }, { %Callable*, i64 }* null, i32 1) to i64))
+  %1 = bitcast %Tuple* %0 to { %Callable*, i64 }*
+  %2 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %1, i64 0, i32 0
+  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__Qop, %Tuple* null)
   store %Callable* %3, %Callable** %2
-  %4 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %1, i64 0, i32 2
+  call void @__quantum__rt__callable_reference(%Callable* %3)
+  %4 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %1, i64 0, i32 1
   store i64 1, i64* %4
-  %qop = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__1, %TupleHeader* %0)
+  %qop = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %0)
   %adj_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %adj_qop)
   %ctl_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
@@ -144,135 +55,151 @@ entry:
   %q1 = call %Qubit* @__quantum__rt__qubit_allocate()
   %q2 = call %Qubit* @__quantum__rt__qubit_allocate()
   %q3 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %5 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* null, i32 1) to i64))
-  %6 = bitcast %TupleHeader* %5 to { %TupleHeader, %Qubit* }*
-  %7 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %6, i64 0, i32 1
+  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %6 = bitcast %Tuple* %5 to { %Qubit* }*
+  %7 = getelementptr { %Qubit* }, { %Qubit* }* %6, i64 0, i32 0
   store %Qubit* %q1, %Qubit** %7
-  call void @__quantum__rt__callable_invoke(%Callable* %qop, %TupleHeader* %5, %TupleHeader* null)
-  %8 = call %Result* @__quantum__qis__mz(%Qubit* %q1)
-  %9 = load %Result*, %Result** @ResultOne
-  %10 = call i1 @__quantum__rt__result_equal(%Result* %8, %Result* %9)
-  %11 = xor i1 %10, true
-  br i1 %11, label %then0__1, label %else__1
+  %8 = bitcast { %Qubit* }* %6 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %qop, %Tuple* %8, %Tuple* null)
+  %9 = call %Result* @__quantum__qis__mz(%Qubit* %q1)
+  %10 = load %Result*, %Result** @ResultOne
+  %11 = call i1 @__quantum__rt__result_equal(%Result* %9, %Result* %10)
+  %12 = xor i1 %11, true
+  br i1 %12, label %then0__1, label %else__1
 
 then0__1:                                         ; preds = %entry
   store i64 1, i64* %error_code
   br label %continue__1
 
 else__1:                                          ; preds = %entry
-  %12 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* null, i32 1) to i64))
-  %13 = bitcast %TupleHeader* %12 to { %TupleHeader, %Qubit* }*
-  %14 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %13, i64 0, i32 1
-  store %Qubit* %q2, %Qubit** %14
-  call void @__quantum__rt__callable_invoke(%Callable* %adj_qop, %TupleHeader* %12, %TupleHeader* null)
-  %15 = call %Result* @__quantum__qis__mz(%Qubit* %q2)
-  %16 = load %Result*, %Result** @ResultOne
-  %17 = call i1 @__quantum__rt__result_equal(%Result* %15, %Result* %16)
-  %18 = xor i1 %17, true
-  br i1 %18, label %then0__2, label %else__2
+  %13 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %14 = bitcast %Tuple* %13 to { %Qubit* }*
+  %15 = getelementptr { %Qubit* }, { %Qubit* }* %14, i64 0, i32 0
+  store %Qubit* %q2, %Qubit** %15
+  %16 = bitcast { %Qubit* }* %14 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %adj_qop, %Tuple* %16, %Tuple* null)
+  %17 = call %Result* @__quantum__qis__mz(%Qubit* %q2)
+  %18 = load %Result*, %Result** @ResultOne
+  %19 = call i1 @__quantum__rt__result_equal(%Result* %17, %Result* %18)
+  %20 = xor i1 %19, true
+  br i1 %20, label %then0__2, label %else__2
 
 then0__2:                                         ; preds = %else__1
   store i64 2, i64* %error_code
   br label %continue__2
 
 else__2:                                          ; preds = %else__1
-  %19 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %Qubit* }* getelementptr ({ %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* null, i32 1) to i64))
-  %20 = bitcast %TupleHeader* %19 to { %TupleHeader, %Array*, %Qubit* }*
   %21 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %22 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %21, i64 0)
   %23 = bitcast i8* %22 to %Qubit**
   store %Qubit* %q1, %Qubit** %23
-  %24 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %20, i64 0, i32 1
-  store %Array* %21, %Array** %24
-  %25 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %20, i64 0, i32 2
-  store %Qubit* %q3, %Qubit** %25
-  call void @__quantum__rt__callable_invoke(%Callable* %ctl_qop, %TupleHeader* %19, %TupleHeader* null)
-  %26 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
-  %27 = load %Result*, %Result** @ResultOne
-  %28 = call i1 @__quantum__rt__result_equal(%Result* %26, %Result* %27)
-  %29 = xor i1 %28, true
-  br i1 %29, label %then0__3, label %else__3
+  %24 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %25 = bitcast %Tuple* %24 to { %Array*, %Qubit* }*
+  %26 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %25, i64 0, i32 0
+  %27 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %25, i64 0, i32 1
+  store %Array* %21, %Array** %26
+  call void @__quantum__rt__array_reference(%Array* %21)
+  store %Qubit* %q3, %Qubit** %27
+  %28 = bitcast { %Array*, %Qubit* }* %25 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %ctl_qop, %Tuple* %28, %Tuple* null)
+  %29 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
+  %30 = load %Result*, %Result** @ResultOne
+  %31 = call i1 @__quantum__rt__result_equal(%Result* %29, %Result* %30)
+  %32 = xor i1 %31, true
+  br i1 %32, label %then0__3, label %else__3
 
 then0__3:                                         ; preds = %else__2
   store i64 3, i64* %error_code
   br label %continue__3
 
 else__3:                                          ; preds = %else__2
-  %30 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %Qubit* }* getelementptr ({ %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* null, i32 1) to i64))
-  %31 = bitcast %TupleHeader* %30 to { %TupleHeader, %Array*, %Qubit* }*
-  %32 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %33 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %32, i64 0)
-  %34 = bitcast i8* %33 to %Qubit**
-  store %Qubit* %q2, %Qubit** %34
-  %35 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %31, i64 0, i32 1
-  store %Array* %32, %Array** %35
-  %36 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %31, i64 0, i32 2
-  store %Qubit* %q3, %Qubit** %36
-  call void @__quantum__rt__callable_invoke(%Callable* %adj_ctl_qop, %TupleHeader* %30, %TupleHeader* null)
-  %37 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
-  %38 = load %Result*, %Result** @ResultZero
-  %39 = call i1 @__quantum__rt__result_equal(%Result* %37, %Result* %38)
-  %40 = xor i1 %39, true
-  br i1 %40, label %then0__4, label %else__4
+  %33 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %34 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %33, i64 0)
+  %35 = bitcast i8* %34 to %Qubit**
+  store %Qubit* %q2, %Qubit** %35
+  %36 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %37 = bitcast %Tuple* %36 to { %Array*, %Qubit* }*
+  %38 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %37, i64 0, i32 0
+  %39 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %37, i64 0, i32 1
+  store %Array* %33, %Array** %38
+  call void @__quantum__rt__array_reference(%Array* %33)
+  store %Qubit* %q3, %Qubit** %39
+  %40 = bitcast { %Array*, %Qubit* }* %37 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %adj_ctl_qop, %Tuple* %40, %Tuple* null)
+  %41 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
+  %42 = load %Result*, %Result** @ResultZero
+  %43 = call i1 @__quantum__rt__result_equal(%Result* %41, %Result* %42)
+  %44 = xor i1 %43, true
+  br i1 %44, label %then0__4, label %else__4
 
 then0__4:                                         ; preds = %else__3
   store i64 4, i64* %error_code
   br label %continue__4
 
 else__4:                                          ; preds = %else__3
-  %41 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* getelementptr ({ %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* null, i32 1) to i64))
-  %42 = bitcast %TupleHeader* %41 to { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }*
-  %43 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %44 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %43, i64 0)
-  %45 = bitcast i8* %44 to %Qubit**
-  store %Qubit* %q1, %Qubit** %45
-  %46 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* %42, i64 0, i32 1
-  store %Array* %43, %Array** %46
-  %47 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %Qubit* }* getelementptr ({ %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* null, i32 1) to i64))
-  %48 = bitcast %TupleHeader* %47 to { %TupleHeader, %Array*, %Qubit* }*
-  %49 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* %42, i64 0, i32 2
-  store { %TupleHeader, %Array*, %Qubit* }* %48, { %TupleHeader, %Array*, %Qubit* }** %49
-  %50 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %51 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %50, i64 0)
-  %52 = bitcast i8* %51 to %Qubit**
-  store %Qubit* %q2, %Qubit** %52
-  %53 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %48, i64 0, i32 1
-  store %Array* %50, %Array** %53
-  %54 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %48, i64 0, i32 2
+  %45 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %46 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %45, i64 0)
+  %47 = bitcast i8* %46 to %Qubit**
+  store %Qubit* %q1, %Qubit** %47
+  %48 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %49 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %48, i64 0)
+  %50 = bitcast i8* %49 to %Qubit**
+  store %Qubit* %q2, %Qubit** %50
+  %51 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %52 = bitcast %Tuple* %51 to { %Array*, %Qubit* }*
+  %53 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %52, i64 0, i32 0
+  %54 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %52, i64 0, i32 1
+  store %Array* %48, %Array** %53
+  call void @__quantum__rt__array_reference(%Array* %48)
   store %Qubit* %q3, %Qubit** %54
-  call void @__quantum__rt__callable_invoke(%Callable* %ctl_ctl_qop, %TupleHeader* %41, %TupleHeader* null)
-  %55 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
-  %56 = load %Result*, %Result** @ResultOne
-  %57 = call i1 @__quantum__rt__result_equal(%Result* %55, %Result* %56)
-  %58 = xor i1 %57, true
-  br i1 %58, label %then0__5, label %else__5
+  %55 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %56 = bitcast %Tuple* %55 to { %Array*, { %Array*, %Qubit* }* }*
+  %57 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %56, i64 0, i32 0
+  %58 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %56, i64 0, i32 1
+  store %Array* %45, %Array** %57
+  call void @__quantum__rt__array_reference(%Array* %45)
+  store { %Array*, %Qubit* }* %52, { %Array*, %Qubit* }** %58
+  %59 = bitcast { %Array*, %Qubit* }* %52 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %59)
+  %60 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %52, i64 0, i32 0
+  %61 = load %Array*, %Array** %60
+  call void @__quantum__rt__array_reference(%Array* %61)
+  %62 = bitcast { %Array*, { %Array*, %Qubit* }* }* %56 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %ctl_ctl_qop, %Tuple* %62, %Tuple* null)
+  %63 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
+  %64 = load %Result*, %Result** @ResultOne
+  %65 = call i1 @__quantum__rt__result_equal(%Result* %63, %Result* %64)
+  %66 = xor i1 %65, true
+  br i1 %66, label %then0__5, label %else__5
 
 then0__5:                                         ; preds = %else__4
   store i64 5, i64* %error_code
   br label %continue__5
 
 else__5:                                          ; preds = %else__4
-  %59 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %Qubit* }* getelementptr ({ %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* null, i32 1) to i64))
-  %60 = bitcast %TupleHeader* %59 to { %TupleHeader, %Array*, %Qubit* }*
-  %61 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 2)
-  %62 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %61, i64 0)
-  %63 = bitcast i8* %62 to %Qubit**
-  store %Qubit* %q1, %Qubit** %63
-  %64 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %61, i64 1)
-  %65 = bitcast i8* %64 to %Qubit**
-  store %Qubit* %q2, %Qubit** %65
-  %66 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %60, i64 0, i32 1
-  store %Array* %61, %Array** %66
-  %67 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %60, i64 0, i32 2
-  store %Qubit* %q3, %Qubit** %67
-  %68 = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %68)
-  call void @__quantum__rt__callable_invoke(%Callable* %68, %TupleHeader* %59, %TupleHeader* null)
-  %69 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
-  %70 = load %Result*, %Result** @ResultZero
-  %71 = call i1 @__quantum__rt__result_equal(%Result* %69, %Result* %70)
-  %72 = xor i1 %71, true
-  br i1 %72, label %then0__6, label %else__6
+  %67 = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %67)
+  %68 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 2)
+  %69 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %68, i64 0)
+  %70 = bitcast i8* %69 to %Qubit**
+  store %Qubit* %q1, %Qubit** %70
+  %71 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %68, i64 1)
+  %72 = bitcast i8* %71 to %Qubit**
+  store %Qubit* %q2, %Qubit** %72
+  %73 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %74 = bitcast %Tuple* %73 to { %Array*, %Qubit* }*
+  %75 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %74, i64 0, i32 0
+  %76 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %74, i64 0, i32 1
+  store %Array* %68, %Array** %75
+  call void @__quantum__rt__array_reference(%Array* %68)
+  store %Qubit* %q3, %Qubit** %76
+  %77 = bitcast { %Array*, %Qubit* }* %74 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %67, %Tuple* %77, %Tuple* null)
+  %78 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
+  %79 = load %Result*, %Result** @ResultZero
+  %80 = call i1 @__quantum__rt__result_equal(%Result* %78, %Result* %79)
+  %81 = xor i1 %80, true
+  br i1 %81, label %then0__6, label %else__6
 
 then0__6:                                         ; preds = %else__5
   store i64 6, i64* %error_code
@@ -280,52 +207,74 @@ then0__6:                                         ; preds = %else__5
 
 else__6:                                          ; preds = %else__5
   %q4 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %73 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* null, i32 1) to i64))
-  %74 = bitcast %TupleHeader* %73 to { %TupleHeader, %Qubit* }*
-  %75 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %74, i64 0, i32 1
-  store %Qubit* %q3, %Qubit** %75
-  %76 = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %76)
-  call void @__quantum__rt__callable_invoke(%Callable* %76, %TupleHeader* %73, %TupleHeader* null)
-  %77 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* }* getelementptr ({ %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* }* null, i32 1) to i64))
-  %78 = bitcast %TupleHeader* %77 to { %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* }*
-  %79 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %80 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %79, i64 0)
-  %81 = bitcast i8* %80 to %Qubit**
-  store %Qubit* %q1, %Qubit** %81
-  %82 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* }* %78, i64 0, i32 1
-  store %Array* %79, %Array** %82
-  %83 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* getelementptr ({ %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* null, i32 1) to i64))
-  %84 = bitcast %TupleHeader* %83 to { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }*
-  %85 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* }* %78, i64 0, i32 2
-  store { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* %84, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }** %85
-  %86 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %87 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %86, i64 0)
-  %88 = bitcast i8* %87 to %Qubit**
-  store %Qubit* %q2, %Qubit** %88
-  %89 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* %84, i64 0, i32 1
-  store %Array* %86, %Array** %89
-  %90 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %Qubit* }* getelementptr ({ %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* null, i32 1) to i64))
-  %91 = bitcast %TupleHeader* %90 to { %TupleHeader, %Array*, %Qubit* }*
-  %92 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }* %84, i64 0, i32 2
-  store { %TupleHeader, %Array*, %Qubit* }* %91, { %TupleHeader, %Array*, %Qubit* }** %92
-  %93 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %94 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %93, i64 0)
-  %95 = bitcast i8* %94 to %Qubit**
-  store %Qubit* %q3, %Qubit** %95
-  %96 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %91, i64 0, i32 1
-  store %Array* %93, %Array** %96
-  %97 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %91, i64 0, i32 2
-  store %Qubit* %q4, %Qubit** %97
-  %98 = call %Callable* @__quantum__rt__callable_copy(%Callable* %ctl_ctl_qop)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %98)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %98)
-  call void @__quantum__rt__callable_invoke(%Callable* %98, %TupleHeader* %77, %TupleHeader* null)
-  %99 = call %Result* @__quantum__qis__mz(%Qubit* %q4)
-  %100 = load %Result*, %Result** @ResultOne
-  %101 = call i1 @__quantum__rt__result_equal(%Result* %99, %Result* %100)
-  %102 = xor i1 %101, true
-  br i1 %102, label %then0__7, label %continue__7
+  %82 = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %82)
+  %83 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %84 = bitcast %Tuple* %83 to { %Qubit* }*
+  %85 = getelementptr { %Qubit* }, { %Qubit* }* %84, i64 0, i32 0
+  store %Qubit* %q3, %Qubit** %85
+  %86 = bitcast { %Qubit* }* %84 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %82, %Tuple* %86, %Tuple* null)
+  %87 = call %Callable* @__quantum__rt__callable_copy(%Callable* %ctl_ctl_qop)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %87)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %87)
+  %88 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %89 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %88, i64 0)
+  %90 = bitcast i8* %89 to %Qubit**
+  store %Qubit* %q1, %Qubit** %90
+  %91 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %92 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %91, i64 0)
+  %93 = bitcast i8* %92 to %Qubit**
+  store %Qubit* %q2, %Qubit** %93
+  %94 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %95 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %94, i64 0)
+  %96 = bitcast i8* %95 to %Qubit**
+  store %Qubit* %q3, %Qubit** %96
+  %97 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %98 = bitcast %Tuple* %97 to { %Array*, %Qubit* }*
+  %99 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %98, i64 0, i32 0
+  %100 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %98, i64 0, i32 1
+  store %Array* %94, %Array** %99
+  call void @__quantum__rt__array_reference(%Array* %94)
+  store %Qubit* %q4, %Qubit** %100
+  %101 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %102 = bitcast %Tuple* %101 to { %Array*, { %Array*, %Qubit* }* }*
+  %103 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 0
+  %104 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 1
+  store %Array* %91, %Array** %103
+  call void @__quantum__rt__array_reference(%Array* %91)
+  store { %Array*, %Qubit* }* %98, { %Array*, %Qubit* }** %104
+  %105 = bitcast { %Array*, %Qubit* }* %98 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %105)
+  %106 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %98, i64 0, i32 0
+  %107 = load %Array*, %Array** %106
+  call void @__quantum__rt__array_reference(%Array* %107)
+  %108 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %109 = bitcast %Tuple* %108 to { %Array*, { %Array*, { %Array*, %Qubit* }* }* }*
+  %110 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 0
+  %111 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 1
+  store %Array* %88, %Array** %110
+  call void @__quantum__rt__array_reference(%Array* %88)
+  store { %Array*, { %Array*, %Qubit* }* }* %102, { %Array*, { %Array*, %Qubit* }* }** %111
+  %112 = bitcast { %Array*, { %Array*, %Qubit* }* }* %102 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %112)
+  %113 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 0
+  %114 = load %Array*, %Array** %113
+  call void @__quantum__rt__array_reference(%Array* %114)
+  %115 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 1
+  %116 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %115
+  %117 = bitcast { %Array*, %Qubit* }* %116 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %117)
+  %118 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %116, i64 0, i32 0
+  %119 = load %Array*, %Array** %118
+  call void @__quantum__rt__array_reference(%Array* %119)
+  %120 = bitcast { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %87, %Tuple* %120, %Tuple* null)
+  %121 = call %Result* @__quantum__qis__mz(%Qubit* %q4)
+  %122 = load %Result*, %Result** @ResultOne
+  %123 = call i1 @__quantum__rt__result_equal(%Result* %121, %Result* %122)
+  %124 = xor i1 %123, true
+  br i1 %124, label %then0__7, label %continue__7
 
 then0__7:                                         ; preds = %else__6
   store i64 7, i64* %error_code
@@ -333,140 +282,233 @@ then0__7:                                         ; preds = %else__6
 
 continue__7:                                      ; preds = %then0__7, %else__6
   call void @__quantum__rt__qubit_release(%Qubit* %q4)
-  call void @__quantum__rt__callable_unreference(%Callable* %76)
-  call void @__quantum__rt__array_unreference(%Array* %79)
-  call void @__quantum__rt__array_unreference(%Array* %86)
-  call void @__quantum__rt__array_unreference(%Array* %93)
-  call void @__quantum__rt__callable_unreference(%Callable* %98)
+  call void @__quantum__rt__callable_unreference(%Callable* %82)
+  %125 = bitcast { %Qubit* }* %84 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %125)
+  call void @__quantum__rt__callable_unreference(%Callable* %87)
+  call void @__quantum__rt__array_unreference(%Array* %88)
+  call void @__quantum__rt__array_unreference(%Array* %91)
+  call void @__quantum__rt__array_unreference(%Array* %94)
+  %126 = bitcast { %Array*, %Qubit* }* %98 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %126)
+  %127 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %98, i64 0, i32 0
+  %128 = load %Array*, %Array** %127
+  call void @__quantum__rt__array_unreference(%Array* %128)
+  %129 = bitcast { %Array*, { %Array*, %Qubit* }* }* %102 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %129)
+  %130 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 0
+  %131 = load %Array*, %Array** %130
+  call void @__quantum__rt__array_unreference(%Array* %131)
+  %132 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 1
+  %133 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %132
+  %134 = bitcast { %Array*, %Qubit* }* %133 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %134)
+  %135 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %133, i64 0, i32 0
+  %136 = load %Array*, %Array** %135
+  call void @__quantum__rt__array_unreference(%Array* %136)
+  %137 = bitcast { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %137)
+  %138 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 0
+  %139 = load %Array*, %Array** %138
+  call void @__quantum__rt__array_unreference(%Array* %139)
+  %140 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 1
+  %141 = load { %Array*, { %Array*, %Qubit* }* }*, { %Array*, { %Array*, %Qubit* }* }** %140
+  %142 = bitcast { %Array*, { %Array*, %Qubit* }* }* %141 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %142)
+  %143 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %141, i64 0, i32 0
+  %144 = load %Array*, %Array** %143
+  call void @__quantum__rt__array_unreference(%Array* %144)
+  %145 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %141, i64 0, i32 1
+  %146 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %145
+  %147 = bitcast { %Array*, %Qubit* }* %146 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %147)
+  %148 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %146, i64 0, i32 0
+  %149 = load %Array*, %Array** %148
+  call void @__quantum__rt__array_unreference(%Array* %149)
+  call void @__quantum__rt__result_unreference(%Result* %121)
+  call void @__quantum__rt__result_unreference(%Result* %122)
   br label %continue__6
 
 continue__6:                                      ; preds = %continue__7, %then0__6
-  call void @__quantum__rt__array_unreference(%Array* %61)
-  call void @__quantum__rt__callable_unreference(%Callable* %68)
+  call void @__quantum__rt__callable_unreference(%Callable* %67)
+  call void @__quantum__rt__array_unreference(%Array* %68)
+  %150 = bitcast { %Array*, %Qubit* }* %74 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %150)
+  %151 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %74, i64 0, i32 0
+  %152 = load %Array*, %Array** %151
+  call void @__quantum__rt__array_unreference(%Array* %152)
+  call void @__quantum__rt__result_unreference(%Result* %78)
+  call void @__quantum__rt__result_unreference(%Result* %79)
   br label %continue__5
 
 continue__5:                                      ; preds = %continue__6, %then0__5
-  call void @__quantum__rt__array_unreference(%Array* %43)
-  call void @__quantum__rt__array_unreference(%Array* %50)
+  call void @__quantum__rt__array_unreference(%Array* %45)
+  call void @__quantum__rt__array_unreference(%Array* %48)
+  %153 = bitcast { %Array*, %Qubit* }* %52 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %153)
+  %154 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %52, i64 0, i32 0
+  %155 = load %Array*, %Array** %154
+  call void @__quantum__rt__array_unreference(%Array* %155)
+  %156 = bitcast { %Array*, { %Array*, %Qubit* }* }* %56 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %156)
+  %157 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %56, i64 0, i32 0
+  %158 = load %Array*, %Array** %157
+  call void @__quantum__rt__array_unreference(%Array* %158)
+  %159 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %56, i64 0, i32 1
+  %160 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %159
+  %161 = bitcast { %Array*, %Qubit* }* %160 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %161)
+  %162 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %160, i64 0, i32 0
+  %163 = load %Array*, %Array** %162
+  call void @__quantum__rt__array_unreference(%Array* %163)
+  call void @__quantum__rt__result_unreference(%Result* %63)
+  call void @__quantum__rt__result_unreference(%Result* %64)
   br label %continue__4
 
 continue__4:                                      ; preds = %continue__5, %then0__4
-  call void @__quantum__rt__array_unreference(%Array* %32)
+  call void @__quantum__rt__array_unreference(%Array* %33)
+  %164 = bitcast { %Array*, %Qubit* }* %37 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %164)
+  %165 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %37, i64 0, i32 0
+  %166 = load %Array*, %Array** %165
+  call void @__quantum__rt__array_unreference(%Array* %166)
+  call void @__quantum__rt__result_unreference(%Result* %41)
+  call void @__quantum__rt__result_unreference(%Result* %42)
   br label %continue__3
 
 continue__3:                                      ; preds = %continue__4, %then0__3
   call void @__quantum__rt__array_unreference(%Array* %21)
+  %167 = bitcast { %Array*, %Qubit* }* %25 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %167)
+  %168 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %25, i64 0, i32 0
+  %169 = load %Array*, %Array** %168
+  call void @__quantum__rt__array_unreference(%Array* %169)
+  call void @__quantum__rt__result_unreference(%Result* %29)
+  call void @__quantum__rt__result_unreference(%Result* %30)
   br label %continue__2
 
 continue__2:                                      ; preds = %continue__3, %then0__2
+  %170 = bitcast { %Qubit* }* %14 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %170)
+  call void @__quantum__rt__result_unreference(%Result* %17)
+  call void @__quantum__rt__result_unreference(%Result* %18)
   br label %continue__1
 
 continue__1:                                      ; preds = %continue__2, %then0__1
   call void @__quantum__rt__qubit_release(%Qubit* %q1)
   call void @__quantum__rt__qubit_release(%Qubit* %q2)
   call void @__quantum__rt__qubit_release(%Qubit* %q3)
-  %103 = load i64, i64* %error_code
+  %171 = bitcast { %Qubit* }* %6 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %171)
+  call void @__quantum__rt__result_unreference(%Result* %9)
+  call void @__quantum__rt__result_unreference(%Result* %10)
+  %172 = load i64, i64* %error_code
+  call void @__quantum__rt__callable_unreference(%Callable* %3)
   call void @__quantum__rt__callable_unreference(%Callable* %qop)
   call void @__quantum__rt__callable_unreference(%Callable* %adj_qop)
   call void @__quantum__rt__callable_unreference(%Callable* %ctl_qop)
   call void @__quantum__rt__callable_unreference(%Callable* %adj_ctl_qop)
   call void @__quantum__rt__callable_unreference(%Callable* %ctl_ctl_qop)
-  ret i64 %103
+  ret i64 %172
 }
 
-declare %TupleHeader* @__quantum__rt__tuple_create(i64)
+declare %Tuple* @__quantum__rt__tuple_create(i64)
 
-define void @Microsoft__Quantum__Testing__QIR__Qop__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Microsoft__Quantum__Testing__QIR__Qop__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit*, i64 }*
-  %1 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %0, i64 0, i32 1
-  %2 = load %Qubit*, %Qubit** %1
-  %3 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %0, i64 0, i32 2
-  %4 = load i64, i64* %3
-  call void @Microsoft__Quantum__Testing__QIR__Qop__body(%Qubit* %2, i64 %4)
+  %0 = bitcast %Tuple* %arg-tuple to { %Qubit*, i64 }*
+  %1 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %0, i64 0, i32 0
+  %2 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %0, i64 0, i32 1
+  %3 = load %Qubit*, %Qubit** %1
+  %4 = load i64, i64* %2
+  call void @Microsoft__Quantum__Testing__QIR__Qop__body(%Qubit* %3, i64 %4)
   ret void
 }
 
-define void @Microsoft__Quantum__Testing__QIR__Qop__adj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Microsoft__Quantum__Testing__QIR__Qop__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit*, i64 }*
-  %1 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %0, i64 0, i32 1
-  %2 = load %Qubit*, %Qubit** %1
-  %3 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %0, i64 0, i32 2
-  %4 = load i64, i64* %3
-  call void @Microsoft__Quantum__Testing__QIR__Qop__adj(%Qubit* %2, i64 %4)
+  %0 = bitcast %Tuple* %arg-tuple to { %Qubit*, i64 }*
+  %1 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %0, i64 0, i32 0
+  %2 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %0, i64 0, i32 1
+  %3 = load %Qubit*, %Qubit** %1
+  %4 = load i64, i64* %2
+  call void @Microsoft__Quantum__Testing__QIR__Qop__adj(%Qubit* %3, i64 %4)
   ret void
 }
 
-define void @Microsoft__Quantum__Testing__QIR__Qop__ctrl__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Microsoft__Quantum__Testing__QIR__Qop__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }*
-  %1 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }, { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }* %0, i64 0, i32 1
-  %2 = load %Array*, %Array** %1
-  %3 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }, { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }* %0, i64 0, i32 2
-  %4 = load { %TupleHeader, %Qubit*, i64 }*, { %TupleHeader, %Qubit*, i64 }** %3
-  call void @Microsoft__Quantum__Testing__QIR__Qop__ctrl(%Array* %2, { %TupleHeader, %Qubit*, i64 }* %4)
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Qubit*, i64 }* }*
+  %1 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 0
+  %2 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 1
+  %3 = load %Array*, %Array** %1
+  %4 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %2
+  call void @Microsoft__Quantum__Testing__QIR__Qop__ctl(%Array* %3, { %Qubit*, i64 }* %4)
   ret void
 }
 
-define void @Microsoft__Quantum__Testing__QIR__Qop__ctrladj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Microsoft__Quantum__Testing__QIR__Qop__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }*
-  %1 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }, { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }* %0, i64 0, i32 1
-  %2 = load %Array*, %Array** %1
-  %3 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }, { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }* %0, i64 0, i32 2
-  %4 = load { %TupleHeader, %Qubit*, i64 }*, { %TupleHeader, %Qubit*, i64 }** %3
-  call void @Microsoft__Quantum__Testing__QIR__Qop__ctrladj(%Array* %2, { %TupleHeader, %Qubit*, i64 }* %4)
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Qubit*, i64 }* }*
+  %1 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 0
+  %2 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 1
+  %3 = load %Array*, %Array** %1
+  %4 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %2
+  call void @Microsoft__Quantum__Testing__QIR__Qop__ctladj(%Array* %3, { %Qubit*, i64 }* %4)
   ret void
 }
 
-declare %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]*, %TupleHeader*)
+declare %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]*, %Tuple*)
 
-define void @Lifted__PartialApplication__1__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+declare void @__quantum__rt__callable_reference(%Callable*)
+
+define void @Lifted__PartialApplication__1__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, i64 }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit* }*
-  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, i64 }* getelementptr ({ %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* null, i32 1) to i64))
-  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, %Qubit*, i64 }*
-  %4 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %3, i64 0, i32 1
-  %5 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
+  %1 = bitcast %Tuple* %arg-tuple to { %Qubit* }*
+  %2 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %3 = bitcast %Tuple* %2 to { %Qubit*, i64 }*
+  %4 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %3, i64 0, i32 0
+  %5 = getelementptr { %Qubit* }, { %Qubit* }* %1, i64 0, i32 0
   %6 = load %Qubit*, %Qubit** %5
   store %Qubit* %6, %Qubit** %4
-  %7 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %3, i64 0, i32 2
-  %8 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 2
+  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %3, i64 0, i32 1
+  %8 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
   %9 = load i64, i64* %8
   store i64 %9, i64* %7
-  %10 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 1
+  %10 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
   %11 = load %Callable*, %Callable** %10
-  call void @__quantum__rt__callable_invoke(%Callable* %11, %TupleHeader* %2, %TupleHeader* %result-tuple)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %2)
+  call void @__quantum__rt__callable_invoke(%Callable* %11, %Tuple* %2, %Tuple* %result-tuple)
+  %12 = bitcast { %Qubit*, i64 }* %3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
   ret void
 }
 
-declare void @__quantum__rt__callable_invoke(%Callable*, %TupleHeader*, %TupleHeader*)
+declare void @__quantum__rt__callable_invoke(%Callable*, %Tuple*, %Tuple*)
 
-declare void @__quantum__rt__tuple_unreference(%TupleHeader*)
+declare void @__quantum__rt__tuple_unreference(%Tuple*)
 
-define void @Lifted__PartialApplication__1__adj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Lifted__PartialApplication__1__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, i64 }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit* }*
-  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, i64 }* getelementptr ({ %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* null, i32 1) to i64))
-  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, %Qubit*, i64 }*
-  %4 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %3, i64 0, i32 1
-  %5 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
+  %1 = bitcast %Tuple* %arg-tuple to { %Qubit* }*
+  %2 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %3 = bitcast %Tuple* %2 to { %Qubit*, i64 }*
+  %4 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %3, i64 0, i32 0
+  %5 = getelementptr { %Qubit* }, { %Qubit* }* %1, i64 0, i32 0
   %6 = load %Qubit*, %Qubit** %5
   store %Qubit* %6, %Qubit** %4
-  %7 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %3, i64 0, i32 2
-  %8 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 2
+  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %3, i64 0, i32 1
+  %8 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
   %9 = load i64, i64* %8
   store i64 %9, i64* %7
-  %10 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 1
+  %10 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
   %11 = load %Callable*, %Callable** %10
   %12 = call %Callable* @__quantum__rt__callable_copy(%Callable* %11)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %12)
-  call void @__quantum__rt__callable_invoke(%Callable* %12, %TupleHeader* %2, %TupleHeader* %result-tuple)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %2)
+  call void @__quantum__rt__callable_invoke(%Callable* %12, %Tuple* %2, %Tuple* %result-tuple)
+  %13 = bitcast { %Qubit*, i64 }* %3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
   call void @__quantum__rt__callable_unreference(%Callable* %12)
   ret void
 }
@@ -477,71 +519,89 @@ declare void @__quantum__rt__callable_make_adjoint(%Callable*)
 
 declare void @__quantum__rt__callable_unreference(%Callable*)
 
-define void @Lifted__PartialApplication__1__ctrl__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Lifted__PartialApplication__1__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, i64 }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, %Qubit* }*
-  %2 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %1, i64 0, i32 1
-  %3 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %1, i64 0, i32 2
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
+  %1 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
+  %2 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 0
+  %3 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 1
   %4 = load %Qubit*, %Qubit** %3
-  %5 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, i64 }* getelementptr ({ %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* null, i32 1) to i64))
-  %6 = bitcast %TupleHeader* %5 to { %TupleHeader, %Qubit*, i64 }*
-  %7 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %6, i64 0, i32 1
+  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %6 = bitcast %Tuple* %5 to { %Qubit*, i64 }*
+  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 0
   store %Qubit* %4, %Qubit** %7
-  %8 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %6, i64 0, i32 2
-  %9 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 2
+  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 1
+  %9 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
   %10 = load i64, i64* %9
   store i64 %10, i64* %8
-  %11 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %TupleHeader* }* getelementptr ({ %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* null, i32 1) to i64))
-  %12 = bitcast %TupleHeader* %11 to { %TupleHeader, %Array*, %TupleHeader* }*
-  %13 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %12, i64 0, i32 1
+  %11 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %12 = bitcast %Tuple* %11 to { %Array*, %Tuple* }*
+  %13 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
   %14 = load %Array*, %Array** %2
   store %Array* %14, %Array** %13
-  %15 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %12, i64 0, i32 2
-  store %TupleHeader* %5, %TupleHeader** %15
-  %16 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 1
+  %15 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 1
+  store %Tuple* %5, %Tuple** %15
+  %16 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
   %17 = load %Callable*, %Callable** %16
   %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17)
   call void @__quantum__rt__callable_make_controlled(%Callable* %18)
-  call void @__quantum__rt__callable_invoke(%Callable* %18, %TupleHeader* %11, %TupleHeader* %result-tuple)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %5)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %11)
+  call void @__quantum__rt__callable_invoke(%Callable* %18, %Tuple* %11, %Tuple* %result-tuple)
+  %19 = bitcast { %Qubit*, i64 }* %6 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %19)
+
+  %parr = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
+  %arr = load %Array*, %Array** %parr
+  call void @__quantum__rt__array_unreference(%Array* %arr)
+
+  %20 = bitcast { %Array*, %Tuple* }* %12 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
+
   call void @__quantum__rt__callable_unreference(%Callable* %18)
   ret void
 }
 
 declare void @__quantum__rt__callable_make_controlled(%Callable*)
 
-define void @Lifted__PartialApplication__1__ctrladj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+declare void @__quantum__rt__array_unreference(%Array*)
+
+define void @Lifted__PartialApplication__1__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, i64 }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, %Qubit* }*
-  %2 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %1, i64 0, i32 1
-  %3 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %1, i64 0, i32 2
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
+  %1 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
+  %2 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 0
+  %3 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 1
   %4 = load %Qubit*, %Qubit** %3
-  %5 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, i64 }* getelementptr ({ %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* null, i32 1) to i64))
-  %6 = bitcast %TupleHeader* %5 to { %TupleHeader, %Qubit*, i64 }*
-  %7 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %6, i64 0, i32 1
+  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %6 = bitcast %Tuple* %5 to { %Qubit*, i64 }*
+  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 0
   store %Qubit* %4, %Qubit** %7
-  %8 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %6, i64 0, i32 2
-  %9 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 2
+  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 1
+  %9 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
   %10 = load i64, i64* %9
   store i64 %10, i64* %8
-  %11 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %TupleHeader* }* getelementptr ({ %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* null, i32 1) to i64))
-  %12 = bitcast %TupleHeader* %11 to { %TupleHeader, %Array*, %TupleHeader* }*
-  %13 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %12, i64 0, i32 1
+  %11 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %12 = bitcast %Tuple* %11 to { %Array*, %Tuple* }*
+  %13 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
   %14 = load %Array*, %Array** %2
   store %Array* %14, %Array** %13
-  %15 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %12, i64 0, i32 2
-  store %TupleHeader* %5, %TupleHeader** %15
-  %16 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 1
+  %15 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 1
+  store %Tuple* %5, %Tuple** %15
+  %16 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
   %17 = load %Callable*, %Callable** %16
   %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %18)
   call void @__quantum__rt__callable_make_controlled(%Callable* %18)
-  call void @__quantum__rt__callable_invoke(%Callable* %18, %TupleHeader* %11, %TupleHeader* %result-tuple)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %5)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %11)
+  call void @__quantum__rt__callable_invoke(%Callable* %18, %Tuple* %11, %Tuple* %result-tuple)
+
+  %parr = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
+  %arr = load %Array*, %Array** %parr
+  call void @__quantum__rt__array_unreference(%Array* %arr)
+
+  %19 = bitcast { %Qubit*, i64 }* %6 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %19)
+  %20 = bitcast { %Array*, %Tuple* }* %12 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
+
   call void @__quantum__rt__callable_unreference(%Callable* %18)
   ret void
 }
@@ -558,20 +618,113 @@ declare %Array* @__quantum__rt__array_create_1d(i32, i64)
 
 declare i8* @__quantum__rt__array_get_element_ptr_1d(%Array*, i64)
 
+declare void @__quantum__rt__array_reference(%Array*)
+
+declare void @__quantum__rt__tuple_reference(%Tuple*)
+
 declare void @__quantum__rt__qubit_release(%Qubit*)
 
-declare void @__quantum__rt__array_unreference(%Array*)
+declare void @__quantum__rt__result_unreference(%Result*)
 
-define { %TupleHeader, %String* }* @Microsoft__Quantum__Targeting__TargetInstruction__body(%String* %arg0) {
+define void @Microsoft__Quantum__Testing__QIR__Qop__body(%Qubit* %q, i64 %n) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %String* }* getelementptr ({ %TupleHeader, %String* }, { %TupleHeader, %String* }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %String* }*
-  %2 = getelementptr { %TupleHeader, %String* }, { %TupleHeader, %String* }* %1, i64 0, i32 1
-  store %String* %arg0, %String** %2
-  call void @__quantum__rt__string_reference(%String* %arg0)
-  ret { %TupleHeader, %String* }* %1
+  %0 = srem i64 %n, 2
+  %1 = icmp eq i64 %0, 1
+  br i1 %1, label %then0__1, label %continue__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__k__body(%Qubit* %q)
+  br label %continue__1
+
+continue__1:                                      ; preds = %then0__1, %entry
+  ret void
 }
 
-declare void @__quantum__rt__string_reference(%String*)
+define void @Microsoft__Quantum__Testing__QIR__Qop__adj(%Qubit* %q, i64 %n) {
+entry:
+  %0 = srem i64 %n, 2
+  %1 = icmp eq i64 %0, 1
+  br i1 %1, label %then0__1, label %continue__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__k__body(%Qubit* %q)
+  br label %continue__1
+
+continue__1:                                      ; preds = %then0__1, %entry
+  ret void
+}
+
+define void @Microsoft__Quantum__Testing__QIR__Qop__ctl(%Array* %ctrls, { %Qubit*, i64 }* %arg__1) {
+entry:
+  %0 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %arg__1, i64 0, i32 0
+  %q = load %Qubit*, %Qubit** %0
+  %1 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %arg__1, i64 0, i32 1
+  %n = load i64, i64* %1
+  %2 = srem i64 %n, 2
+  %3 = icmp eq i64 %2, 1
+  br i1 %3, label %then0__1, label %continue__1
+
+then0__1:                                         ; preds = %entry
+  %4 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %5 = bitcast %Tuple* %4 to { %Array*, %Qubit* }*
+  %6 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
+  %7 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 1
+  store %Array* %ctrls, %Array** %6
+  call void @__quantum__rt__array_reference(%Array* %ctrls)
+  store %Qubit* %q, %Qubit** %7
+  %8 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
+  %.__controlQubits__ = load %Array*, %Array** %8
+  %9 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 1
+  %.q = load %Qubit*, %Qubit** %9
+  call void @__quantum__qis__k__ctl(%Array* %.__controlQubits__, %Qubit* %.q)
+
+  %parr = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
+  %arr = load %Array*, %Array** %parr
+  call void @__quantum__rt__array_unreference(%Array* %arr)
+
+  %10 = bitcast { %Array*, %Qubit* }* %5 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %10)
+  br label %continue__1
+
+continue__1:                                      ; preds = %then0__1, %entry
+  ret void
+}
+
+define void @Microsoft__Quantum__Testing__QIR__Qop__ctladj(%Array* %__controlQubits__, { %Qubit*, i64 }* %arg__1) {
+entry:
+  %0 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %arg__1, i64 0, i32 0
+  %q = load %Qubit*, %Qubit** %0
+  %1 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %arg__1, i64 0, i32 1
+  %n = load i64, i64* %1
+  %2 = srem i64 %n, 2
+  %3 = icmp eq i64 %2, 1
+  br i1 %3, label %then0__1, label %continue__1
+
+then0__1:                                         ; preds = %entry
+  %4 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %5 = bitcast %Tuple* %4 to { %Array*, %Qubit* }*
+  %6 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
+  %7 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 1
+  store %Array* %__controlQubits__, %Array** %6
+  call void @__quantum__rt__array_reference(%Array* %__controlQubits__)
+  store %Qubit* %q, %Qubit** %7
+  %8 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
+  %.__controlQubits__ = load %Array*, %Array** %8
+  %9 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 1
+  %.q = load %Qubit*, %Qubit** %9
+  call void @__quantum__qis__k__ctl(%Array* %.__controlQubits__, %Qubit* %.q)
+
+  %parr = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
+  %arr = load %Array*, %Array** %parr
+  call void @__quantum__rt__array_unreference(%Array* %arr)
+
+  %10 = bitcast { %Array*, %Qubit* }* %5 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %10)
+
+  br label %continue__1
+
+continue__1:                                      ; preds = %then0__1, %entry
+  ret void
+}
 
 attributes #0 = { "EntryPoint" }

--- a/src/QirRuntime/test/QIR-static/qir-test-functors.ll
+++ b/src/QirRuntime/test/QIR-static/qir-test-functors.ll
@@ -159,11 +159,11 @@ else__4:                                          ; preds = %else__3
   store %Array* %45, %Array** %57
   call void @__quantum__rt__array_reference(%Array* %45)
   store { %Array*, %Qubit* }* %52, { %Array*, %Qubit* }** %58
-  %59 = bitcast { %Array*, %Qubit* }* %52 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %59)
-  %60 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %52, i64 0, i32 0
-  %61 = load %Array*, %Array** %60
-  call void @__quantum__rt__array_reference(%Array* %61)
+  %59 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %52, i64 0, i32 0
+  %60 = load %Array*, %Array** %59
+  call void @__quantum__rt__array_reference(%Array* %60)
+  %61 = bitcast { %Array*, %Qubit* }* %52 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %61)
   %62 = bitcast { %Array*, { %Array*, %Qubit* }* }* %56 to %Tuple*
   call void @__quantum__rt__callable_invoke(%Callable* %ctl_ctl_qop, %Tuple* %62, %Tuple* null)
   %63 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
@@ -244,11 +244,11 @@ else__6:                                          ; preds = %else__5
   store %Array* %91, %Array** %103
   call void @__quantum__rt__array_reference(%Array* %91)
   store { %Array*, %Qubit* }* %98, { %Array*, %Qubit* }** %104
-  %105 = bitcast { %Array*, %Qubit* }* %98 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %105)
-  %106 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %98, i64 0, i32 0
-  %107 = load %Array*, %Array** %106
-  call void @__quantum__rt__array_reference(%Array* %107)
+  %105 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %98, i64 0, i32 0
+  %106 = load %Array*, %Array** %105
+  call void @__quantum__rt__array_reference(%Array* %106)
+  %107 = bitcast { %Array*, %Qubit* }* %98 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %107)
   %108 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %109 = bitcast %Tuple* %108 to { %Array*, { %Array*, { %Array*, %Qubit* }* }* }*
   %110 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 0
@@ -256,18 +256,18 @@ else__6:                                          ; preds = %else__5
   store %Array* %88, %Array** %110
   call void @__quantum__rt__array_reference(%Array* %88)
   store { %Array*, { %Array*, %Qubit* }* }* %102, { %Array*, { %Array*, %Qubit* }* }** %111
-  %112 = bitcast { %Array*, { %Array*, %Qubit* }* }* %102 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %112)
-  %113 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 0
-  %114 = load %Array*, %Array** %113
-  call void @__quantum__rt__array_reference(%Array* %114)
-  %115 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 1
-  %116 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %115
-  %117 = bitcast { %Array*, %Qubit* }* %116 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %117)
-  %118 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %116, i64 0, i32 0
-  %119 = load %Array*, %Array** %118
-  call void @__quantum__rt__array_reference(%Array* %119)
+  %112 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 0
+  %113 = load %Array*, %Array** %112
+  call void @__quantum__rt__array_reference(%Array* %113)
+  %114 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 1
+  %115 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %114
+  %116 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %115, i64 0, i32 0
+  %117 = load %Array*, %Array** %116
+  call void @__quantum__rt__array_reference(%Array* %117)
+  %118 = bitcast { %Array*, %Qubit* }* %115 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %118)
+  %119 = bitcast { %Array*, { %Array*, %Qubit* }* }* %102 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %119)
   %120 = bitcast { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109 to %Tuple*
   call void @__quantum__rt__callable_invoke(%Callable* %87, %Tuple* %120, %Tuple* null)
   %121 = call %Result* @__quantum__qis__mz(%Qubit* %q4)
@@ -289,42 +289,42 @@ continue__7:                                      ; preds = %then0__7, %else__6
   call void @__quantum__rt__array_unreference(%Array* %88)
   call void @__quantum__rt__array_unreference(%Array* %91)
   call void @__quantum__rt__array_unreference(%Array* %94)
-  %126 = bitcast { %Array*, %Qubit* }* %98 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %126)
-  %127 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %98, i64 0, i32 0
-  %128 = load %Array*, %Array** %127
-  call void @__quantum__rt__array_unreference(%Array* %128)
-  %129 = bitcast { %Array*, { %Array*, %Qubit* }* }* %102 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %129)
-  %130 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 0
-  %131 = load %Array*, %Array** %130
-  call void @__quantum__rt__array_unreference(%Array* %131)
-  %132 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 1
-  %133 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %132
-  %134 = bitcast { %Array*, %Qubit* }* %133 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %134)
-  %135 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %133, i64 0, i32 0
-  %136 = load %Array*, %Array** %135
-  call void @__quantum__rt__array_unreference(%Array* %136)
-  %137 = bitcast { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %137)
-  %138 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 0
-  %139 = load %Array*, %Array** %138
-  call void @__quantum__rt__array_unreference(%Array* %139)
-  %140 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 1
-  %141 = load { %Array*, { %Array*, %Qubit* }* }*, { %Array*, { %Array*, %Qubit* }* }** %140
-  %142 = bitcast { %Array*, { %Array*, %Qubit* }* }* %141 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %142)
-  %143 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %141, i64 0, i32 0
-  %144 = load %Array*, %Array** %143
-  call void @__quantum__rt__array_unreference(%Array* %144)
-  %145 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %141, i64 0, i32 1
-  %146 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %145
-  %147 = bitcast { %Array*, %Qubit* }* %146 to %Tuple*
+  %126 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %98, i64 0, i32 0
+  %127 = load %Array*, %Array** %126
+  call void @__quantum__rt__array_unreference(%Array* %127)
+  %128 = bitcast { %Array*, %Qubit* }* %98 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %128)
+  %129 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 0
+  %130 = load %Array*, %Array** %129
+  call void @__quantum__rt__array_unreference(%Array* %130)
+  %131 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %102, i64 0, i32 1
+  %132 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %131
+  %133 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %132, i64 0, i32 0
+  %134 = load %Array*, %Array** %133
+  call void @__quantum__rt__array_unreference(%Array* %134)
+  %135 = bitcast { %Array*, %Qubit* }* %132 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %135)
+  %136 = bitcast { %Array*, { %Array*, %Qubit* }* }* %102 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %136)
+  %137 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 0
+  %138 = load %Array*, %Array** %137
+  call void @__quantum__rt__array_unreference(%Array* %138)
+  %139 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109, i64 0, i32 1
+  %140 = load { %Array*, { %Array*, %Qubit* }* }*, { %Array*, { %Array*, %Qubit* }* }** %139
+  %141 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %140, i64 0, i32 0
+  %142 = load %Array*, %Array** %141
+  call void @__quantum__rt__array_unreference(%Array* %142)
+  %143 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %140, i64 0, i32 1
+  %144 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %143
+  %145 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %144, i64 0, i32 0
+  %146 = load %Array*, %Array** %145
+  call void @__quantum__rt__array_unreference(%Array* %146)
+  %147 = bitcast { %Array*, %Qubit* }* %144 to %Tuple*
   call void @__quantum__rt__tuple_unreference(%Tuple* %147)
-  %148 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %146, i64 0, i32 0
-  %149 = load %Array*, %Array** %148
-  call void @__quantum__rt__array_unreference(%Array* %149)
+  %148 = bitcast { %Array*, { %Array*, %Qubit* }* }* %140 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %148)
+  %149 = bitcast { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %109 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %149)
   call void @__quantum__rt__result_unreference(%Result* %121)
   call void @__quantum__rt__result_unreference(%Result* %122)
   br label %continue__6
@@ -332,11 +332,11 @@ continue__7:                                      ; preds = %then0__7, %else__6
 continue__6:                                      ; preds = %continue__7, %then0__6
   call void @__quantum__rt__callable_unreference(%Callable* %67)
   call void @__quantum__rt__array_unreference(%Array* %68)
-  %150 = bitcast { %Array*, %Qubit* }* %74 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %150)
-  %151 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %74, i64 0, i32 0
-  %152 = load %Array*, %Array** %151
-  call void @__quantum__rt__array_unreference(%Array* %152)
+  %150 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %74, i64 0, i32 0
+  %151 = load %Array*, %Array** %150
+  call void @__quantum__rt__array_unreference(%Array* %151)
+  %152 = bitcast { %Array*, %Qubit* }* %74 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %152)
   call void @__quantum__rt__result_unreference(%Result* %78)
   call void @__quantum__rt__result_unreference(%Result* %79)
   br label %continue__5
@@ -344,45 +344,45 @@ continue__6:                                      ; preds = %continue__7, %then0
 continue__5:                                      ; preds = %continue__6, %then0__5
   call void @__quantum__rt__array_unreference(%Array* %45)
   call void @__quantum__rt__array_unreference(%Array* %48)
-  %153 = bitcast { %Array*, %Qubit* }* %52 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %153)
-  %154 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %52, i64 0, i32 0
-  %155 = load %Array*, %Array** %154
-  call void @__quantum__rt__array_unreference(%Array* %155)
-  %156 = bitcast { %Array*, { %Array*, %Qubit* }* }* %56 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %156)
-  %157 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %56, i64 0, i32 0
-  %158 = load %Array*, %Array** %157
-  call void @__quantum__rt__array_unreference(%Array* %158)
-  %159 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %56, i64 0, i32 1
-  %160 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %159
-  %161 = bitcast { %Array*, %Qubit* }* %160 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %161)
-  %162 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %160, i64 0, i32 0
-  %163 = load %Array*, %Array** %162
-  call void @__quantum__rt__array_unreference(%Array* %163)
+  %153 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %52, i64 0, i32 0
+  %154 = load %Array*, %Array** %153
+  call void @__quantum__rt__array_unreference(%Array* %154)
+  %155 = bitcast { %Array*, %Qubit* }* %52 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %155)
+  %156 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %56, i64 0, i32 0
+  %157 = load %Array*, %Array** %156
+  call void @__quantum__rt__array_unreference(%Array* %157)
+  %158 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %56, i64 0, i32 1
+  %159 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %158
+  %160 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %159, i64 0, i32 0
+  %161 = load %Array*, %Array** %160
+  call void @__quantum__rt__array_unreference(%Array* %161)
+  %162 = bitcast { %Array*, %Qubit* }* %159 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %162)
+  %163 = bitcast { %Array*, { %Array*, %Qubit* }* }* %56 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %163)
   call void @__quantum__rt__result_unreference(%Result* %63)
   call void @__quantum__rt__result_unreference(%Result* %64)
   br label %continue__4
 
 continue__4:                                      ; preds = %continue__5, %then0__4
   call void @__quantum__rt__array_unreference(%Array* %33)
-  %164 = bitcast { %Array*, %Qubit* }* %37 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %164)
-  %165 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %37, i64 0, i32 0
-  %166 = load %Array*, %Array** %165
-  call void @__quantum__rt__array_unreference(%Array* %166)
+  %164 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %37, i64 0, i32 0
+  %165 = load %Array*, %Array** %164
+  call void @__quantum__rt__array_unreference(%Array* %165)
+  %166 = bitcast { %Array*, %Qubit* }* %37 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %166)
   call void @__quantum__rt__result_unreference(%Result* %41)
   call void @__quantum__rt__result_unreference(%Result* %42)
   br label %continue__3
 
 continue__3:                                      ; preds = %continue__4, %then0__3
   call void @__quantum__rt__array_unreference(%Array* %21)
-  %167 = bitcast { %Array*, %Qubit* }* %25 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %167)
-  %168 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %25, i64 0, i32 0
-  %169 = load %Array*, %Array** %168
-  call void @__quantum__rt__array_unreference(%Array* %169)
+  %167 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %25, i64 0, i32 0
+  %168 = load %Array*, %Array** %167
+  call void @__quantum__rt__array_unreference(%Array* %168)
+  %169 = bitcast { %Array*, %Qubit* }* %25 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %169)
   call void @__quantum__rt__result_unreference(%Result* %29)
   call void @__quantum__rt__result_unreference(%Result* %30)
   br label %continue__2
@@ -478,9 +478,10 @@ entry:
   store i64 %9, i64* %7
   %10 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
   %11 = load %Callable*, %Callable** %10
-  call void @__quantum__rt__callable_invoke(%Callable* %11, %Tuple* %2, %Tuple* %result-tuple)
   %12 = bitcast { %Qubit*, i64 }* %3 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
+  call void @__quantum__rt__callable_invoke(%Callable* %11, %Tuple* %12, %Tuple* %result-tuple)
+  %13 = bitcast { %Qubit*, i64 }* %3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
   ret void
 }
 
@@ -506,9 +507,10 @@ entry:
   %11 = load %Callable*, %Callable** %10
   %12 = call %Callable* @__quantum__rt__callable_copy(%Callable* %11)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %12)
-  call void @__quantum__rt__callable_invoke(%Callable* %12, %Tuple* %2, %Tuple* %result-tuple)
   %13 = bitcast { %Qubit*, i64 }* %3 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
+  call void @__quantum__rt__callable_invoke(%Callable* %12, %Tuple* %13, %Tuple* %result-tuple)
+  %14 = bitcast { %Qubit*, i64 }* %3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %14)
   call void @__quantum__rt__callable_unreference(%Callable* %12)
   ret void
 }
@@ -525,40 +527,49 @@ entry:
   %1 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
   %2 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 0
   %3 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 1
-  %4 = load %Qubit*, %Qubit** %3
-  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
-  %6 = bitcast %Tuple* %5 to { %Qubit*, i64 }*
-  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 0
-  store %Qubit* %4, %Qubit** %7
-  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 1
-  %9 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
-  %10 = load i64, i64* %9
-  store i64 %10, i64* %8
-  %11 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %12 = bitcast %Tuple* %11 to { %Array*, %Tuple* }*
-  %13 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
-  %14 = load %Array*, %Array** %2
-  store %Array* %14, %Array** %13
-  %15 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 1
-  store %Tuple* %5, %Tuple** %15
-  %16 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
-  %17 = load %Callable*, %Callable** %16
-  %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %18)
-  call void @__quantum__rt__callable_invoke(%Callable* %18, %Tuple* %11, %Tuple* %result-tuple)
-  %19 = bitcast { %Qubit*, i64 }* %6 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %19)
-
-  %parr = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
-  %arr = load %Array*, %Array** %parr
-  call void @__quantum__rt__array_unreference(%Array* %arr)
-
-  %20 = bitcast { %Array*, %Tuple* }* %12 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
-
-  call void @__quantum__rt__callable_unreference(%Callable* %18)
+  %4 = load %Array*, %Array** %2
+  %5 = load %Qubit*, %Qubit** %3
+  %6 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %7 = bitcast %Tuple* %6 to { %Qubit*, i64 }*
+  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %7, i64 0, i32 0
+  store %Qubit* %5, %Qubit** %8
+  %9 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %7, i64 0, i32 1
+  %10 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
+  %11 = load i64, i64* %10
+  store i64 %11, i64* %9
+  %12 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %13 = bitcast %Tuple* %12 to { %Array*, { %Qubit*, i64 }* }*
+  %14 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 0
+  %15 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 1
+  store %Array* %4, %Array** %14
+  call void @__quantum__rt__array_reference(%Array* %4)
+  store { %Qubit*, i64 }* %7, { %Qubit*, i64 }** %15
+  %16 = bitcast { %Qubit*, i64 }* %7 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %16)
+  %17 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
+  %18 = load %Callable*, %Callable** %17
+  %19 = call %Callable* @__quantum__rt__callable_copy(%Callable* %18)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %19)
+  %20 = bitcast { %Array*, { %Qubit*, i64 }* }* %13 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %19, %Tuple* %20, %Tuple* %result-tuple)
+  %21 = bitcast { %Qubit*, i64 }* %7 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %21)
+  %22 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 0
+  %23 = load %Array*, %Array** %22
+  call void @__quantum__rt__array_unreference(%Array* %23)
+  %24 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 1
+  %25 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %24
+  %26 = bitcast { %Qubit*, i64 }* %25 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %26)
+  %27 = bitcast { %Array*, { %Qubit*, i64 }* }* %13 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %27)
+  call void @__quantum__rt__callable_unreference(%Callable* %19)
   ret void
 }
+
+declare void @__quantum__rt__array_reference(%Array*)
+
+declare void @__quantum__rt__tuple_reference(%Tuple*)
 
 declare void @__quantum__rt__callable_make_controlled(%Callable*)
 
@@ -570,39 +581,44 @@ entry:
   %1 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
   %2 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 0
   %3 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 1
-  %4 = load %Qubit*, %Qubit** %3
-  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
-  %6 = bitcast %Tuple* %5 to { %Qubit*, i64 }*
-  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 0
-  store %Qubit* %4, %Qubit** %7
-  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 1
-  %9 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
-  %10 = load i64, i64* %9
-  store i64 %10, i64* %8
-  %11 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %12 = bitcast %Tuple* %11 to { %Array*, %Tuple* }*
-  %13 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
-  %14 = load %Array*, %Array** %2
-  store %Array* %14, %Array** %13
-  %15 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 1
-  store %Tuple* %5, %Tuple** %15
-  %16 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
-  %17 = load %Callable*, %Callable** %16
-  %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %18)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %18)
-  call void @__quantum__rt__callable_invoke(%Callable* %18, %Tuple* %11, %Tuple* %result-tuple)
-
-  %parr = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
-  %arr = load %Array*, %Array** %parr
-  call void @__quantum__rt__array_unreference(%Array* %arr)
-
-  %19 = bitcast { %Qubit*, i64 }* %6 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %19)
-  %20 = bitcast { %Array*, %Tuple* }* %12 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
-
-  call void @__quantum__rt__callable_unreference(%Callable* %18)
+  %4 = load %Array*, %Array** %2
+  %5 = load %Qubit*, %Qubit** %3
+  %6 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %7 = bitcast %Tuple* %6 to { %Qubit*, i64 }*
+  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %7, i64 0, i32 0
+  store %Qubit* %5, %Qubit** %8
+  %9 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %7, i64 0, i32 1
+  %10 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
+  %11 = load i64, i64* %10
+  store i64 %11, i64* %9
+  %12 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %13 = bitcast %Tuple* %12 to { %Array*, { %Qubit*, i64 }* }*
+  %14 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 0
+  %15 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 1
+  store %Array* %4, %Array** %14
+  call void @__quantum__rt__array_reference(%Array* %4)
+  store { %Qubit*, i64 }* %7, { %Qubit*, i64 }** %15
+  %16 = bitcast { %Qubit*, i64 }* %7 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %16)
+  %17 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
+  %18 = load %Callable*, %Callable** %17
+  %19 = call %Callable* @__quantum__rt__callable_copy(%Callable* %18)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %19)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %19)
+  %20 = bitcast { %Array*, { %Qubit*, i64 }* }* %13 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %19, %Tuple* %20, %Tuple* %result-tuple)
+  %21 = bitcast { %Qubit*, i64 }* %7 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %21)
+  %22 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 0
+  %23 = load %Array*, %Array** %22
+  call void @__quantum__rt__array_unreference(%Array* %23)
+  %24 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 1
+  %25 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %24
+  %26 = bitcast { %Qubit*, i64 }* %25 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %26)
+  %27 = bitcast { %Array*, { %Qubit*, i64 }* }* %13 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %27)
+  call void @__quantum__rt__callable_unreference(%Callable* %19)
   ret void
 }
 
@@ -617,10 +633,6 @@ declare i1 @__quantum__rt__result_equal(%Result*, %Result*)
 declare %Array* @__quantum__rt__array_create_1d(i32, i64)
 
 declare i8* @__quantum__rt__array_get_element_ptr_1d(%Array*, i64)
-
-declare void @__quantum__rt__array_reference(%Array*)
-
-declare void @__quantum__rt__tuple_reference(%Tuple*)
 
 declare void @__quantum__rt__qubit_release(%Qubit*)
 
@@ -677,13 +689,11 @@ then0__1:                                         ; preds = %entry
   %9 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 1
   %.q = load %Qubit*, %Qubit** %9
   call void @__quantum__qis__k__ctl(%Array* %.__controlQubits__, %Qubit* %.q)
-
-  %parr = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
-  %arr = load %Array*, %Array** %parr
-  call void @__quantum__rt__array_unreference(%Array* %arr)
-
-  %10 = bitcast { %Array*, %Qubit* }* %5 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %10)
+  %10 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
+  %11 = load %Array*, %Array** %10
+  call void @__quantum__rt__array_unreference(%Array* %11)
+  %12 = bitcast { %Array*, %Qubit* }* %5 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
   br label %continue__1
 
 continue__1:                                      ; preds = %then0__1, %entry
@@ -713,14 +723,11 @@ then0__1:                                         ; preds = %entry
   %9 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 1
   %.q = load %Qubit*, %Qubit** %9
   call void @__quantum__qis__k__ctl(%Array* %.__controlQubits__, %Qubit* %.q)
-
-  %parr = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
-  %arr = load %Array*, %Array** %parr
-  call void @__quantum__rt__array_unreference(%Array* %arr)
-
-  %10 = bitcast { %Array*, %Qubit* }* %5 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %10)
-
+  %10 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %5, i64 0, i32 0
+  %11 = load %Array*, %Array** %10
+  call void @__quantum__rt__array_unreference(%Array* %11)
+  %12 = bitcast { %Array*, %Qubit* }* %5 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
   br label %continue__1
 
 continue__1:                                      ; preds = %then0__1, %entry

--- a/src/QirRuntime/test/QIR-static/qir-test-partials.ll
+++ b/src/QirRuntime/test/QIR-static/qir-test-partials.ll
@@ -6,10 +6,9 @@
 
 @ResultZero = external global %Result*
 @ResultOne = external global %Result*
-
 @EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
 @Microsoft__Quantum__Testing__QIR__Subtract = constant [4 x void (%Tuple*, %Tuple*, %Tuple*)*] [void (%Tuple*, %Tuple*, %Tuple*)* @Microsoft__Quantum__Testing__QIR__Subtract__body__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null]
-@PartialApplication__11 = constant [4 x void (%Tuple*, %Tuple*, %Tuple*)*] [void (%Tuple*, %Tuple*, %Tuple*)* @Lifted__PartialApplication__11__body__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null]
+@PartialApplication__21 = constant [4 x void (%Tuple*, %Tuple*, %Tuple*)*] [void (%Tuple*, %Tuple*, %Tuple*)* @Lifted__PartialApplication__21__body__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null]
 
 @Microsoft_Quantum_Testing_QIR_TestPartials = alias i64 (i64, i64), i64 (i64, i64)* @Microsoft__Quantum__Testing__QIR__TestPartials__body
 
@@ -29,7 +28,7 @@ entry:
   call void @__quantum__rt__callable_reference(%Callable* %3)
   %4 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %1, i64 0, i32 1
   store i64 %x, i64* %4
-  %subtractor = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__11, %Tuple* %0)
+  %subtractor = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__21, %Tuple* %0)
   %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
   %6 = bitcast %Tuple* %5 to { i64 }*
   %7 = getelementptr { i64 }, { i64 }* %6, i64 0, i32 0
@@ -67,7 +66,7 @@ declare %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, 
 
 declare void @__quantum__rt__callable_reference(%Callable*)
 
-define void @Lifted__PartialApplication__11__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define void @Lifted__PartialApplication__21__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
   %1 = bitcast %Tuple* %arg-tuple to { i64 }*
@@ -83,9 +82,10 @@ entry:
   store i64 %9, i64* %7
   %10 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
   %11 = load %Callable*, %Callable** %10
-  call void @__quantum__rt__callable_invoke(%Callable* %11, %Tuple* %2, %Tuple* %result-tuple)
   %12 = bitcast { i64, i64 }* %3 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
+  call void @__quantum__rt__callable_invoke(%Callable* %11, %Tuple* %12, %Tuple* %result-tuple)
+  %13 = bitcast { i64, i64 }* %3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
   ret void
 }
 

--- a/src/QirRuntime/test/QIR-static/qir-test-partials.ll
+++ b/src/QirRuntime/test/QIR-static/qir-test-partials.ll
@@ -1,89 +1,98 @@
 
 %Result = type opaque
 %Range = type { i64, i64, i64 }
-%TupleHeader = type { i32, i32 }
-%String = type opaque
-%Array = type opaque
+%Tuple = type opaque
 %Callable = type opaque
 
 @ResultZero = external global %Result*
 @ResultOne = external global %Result*
+
 @EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
-@Microsoft__Quantum__Testing__QIR__Subtract = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Testing__QIR__Subtract__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null]
-@PartialApplication__2 = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__2__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null]
+@Microsoft__Quantum__Testing__QIR__Subtract = constant [4 x void (%Tuple*, %Tuple*, %Tuple*)*] [void (%Tuple*, %Tuple*, %Tuple*)* @Microsoft__Quantum__Testing__QIR__Subtract__body__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null]
+@PartialApplication__11 = constant [4 x void (%Tuple*, %Tuple*, %Tuple*)*] [void (%Tuple*, %Tuple*, %Tuple*)* @Lifted__PartialApplication__11__body__wrapper, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null, void (%Tuple*, %Tuple*, %Tuple*)* null]
 
-declare %TupleHeader* @__quantum__rt__tuple_create(i64)
-
-define i64 @Microsoft__Quantum__Testing__QIR__TestPartials__body(i64 %x, i64 %y) #0 {
-entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, i64 }* getelementptr ({ %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %Callable*, i64 }*
-  %2 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %1, i64 0, i32 1
-  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__Subtract, %TupleHeader* null)
-  store %Callable* %3, %Callable** %2
-  %4 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %1, i64 0, i32 2
-  store i64 %x, i64* %4
-  %subtractor = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__2, %TupleHeader* %0)
-  %5 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64 }* getelementptr ({ %TupleHeader, i64 }, { %TupleHeader, i64 }* null, i32 1) to i64))
-  %6 = bitcast %TupleHeader* %5 to { %TupleHeader, i64 }*
-  %7 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %6, i64 0, i32 1
-  store i64 %y, i64* %7
-  %8 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64 }* getelementptr ({ %TupleHeader, i64 }, { %TupleHeader, i64 }* null, i32 1) to i64))
-  %9 = bitcast %TupleHeader* %8 to { %TupleHeader, i64 }*
-  call void @__quantum__rt__callable_invoke(%Callable* %subtractor, %TupleHeader* %5, %TupleHeader* %8)
-  %10 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %9, i64 0, i32 1
-  %11 = load i64, i64* %10
-  call void @__quantum__rt__callable_unreference(%Callable* %subtractor)
-  ret i64 %11
-}
-
-define void @Microsoft__Quantum__Testing__QIR__Subtract__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
-entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, i64, i64 }*
-  %1 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %0, i64 0, i32 1
-  %2 = load i64, i64* %1
-  %3 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %0, i64 0, i32 2
-  %4 = load i64, i64* %3
-  %5 = call i64 @Microsoft__Quantum__Testing__QIR__Subtract__body(i64 %2, i64 %4)
-  %6 = bitcast %TupleHeader* %result-tuple to { %TupleHeader, i64 }*
-  %7 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %6, i64 0, i32 1
-  store i64 %5, i64* %7
-  ret void
-}
-
-declare %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]*, %TupleHeader*)
-
-define void @Lifted__PartialApplication__2__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
-entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, i64 }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, i64 }*
-  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64, i64 }* getelementptr ({ %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* null, i32 1) to i64))
-  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, i64, i64 }*
-  %4 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %3, i64 0, i32 1
-  %5 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 2
-  %6 = load i64, i64* %5
-  store i64 %6, i64* %4
-  %7 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %3, i64 0, i32 2
-  %8 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %1, i64 0, i32 1
-  %9 = load i64, i64* %8
-  store i64 %9, i64* %7
-  %10 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 1
-  %11 = load %Callable*, %Callable** %10
-  call void @__quantum__rt__callable_invoke(%Callable* %11, %TupleHeader* %2, %TupleHeader* %result-tuple)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %2)
-  ret void
-}
-
-declare void @__quantum__rt__callable_invoke(%Callable*, %TupleHeader*, %TupleHeader*)
-
-declare void @__quantum__rt__tuple_unreference(%TupleHeader*)
-
-declare void @__quantum__rt__callable_unreference(%Callable*)
+@Microsoft_Quantum_Testing_QIR_TestPartials = alias i64 (i64, i64), i64 (i64, i64)* @Microsoft__Quantum__Testing__QIR__TestPartials__body
 
 define i64 @Microsoft__Quantum__Testing__QIR__Subtract__body(i64 %from, i64 %what) {
 entry:
   %0 = sub i64 %from, %what
   ret i64 %0
 }
+
+define i64 @Microsoft__Quantum__Testing__QIR__TestPartials__body(i64 %x, i64 %y) #0 {
+entry:
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i64 }* getelementptr ({ %Callable*, i64 }, { %Callable*, i64 }* null, i32 1) to i64))
+  %1 = bitcast %Tuple* %0 to { %Callable*, i64 }*
+  %2 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %1, i64 0, i32 0
+  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__Subtract, %Tuple* null)
+  store %Callable* %3, %Callable** %2
+  call void @__quantum__rt__callable_reference(%Callable* %3)
+  %4 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %1, i64 0, i32 1
+  store i64 %x, i64* %4
+  %subtractor = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__11, %Tuple* %0)
+  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %6 = bitcast %Tuple* %5 to { i64 }*
+  %7 = getelementptr { i64 }, { i64 }* %6, i64 0, i32 0
+  store i64 %y, i64* %7
+  %8 = bitcast { i64 }* %6 to %Tuple*
+  %9 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %10 = bitcast %Tuple* %9 to { i64 }*
+  call void @__quantum__rt__callable_invoke(%Callable* %subtractor, %Tuple* %8, %Tuple* %9)
+  %11 = getelementptr { i64 }, { i64 }* %10, i64 0, i32 0
+  %12 = load i64, i64* %11
+  call void @__quantum__rt__callable_unreference(%Callable* %3)
+  call void @__quantum__rt__callable_unreference(%Callable* %subtractor)
+  %13 = bitcast { i64 }* %6 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
+  ret i64 %12
+}
+
+declare %Tuple* @__quantum__rt__tuple_create(i64)
+
+define void @Microsoft__Quantum__Testing__QIR__Subtract__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+entry:
+  %0 = bitcast %Tuple* %arg-tuple to { i64, i64 }*
+  %1 = getelementptr { i64, i64 }, { i64, i64 }* %0, i64 0, i32 0
+  %2 = getelementptr { i64, i64 }, { i64, i64 }* %0, i64 0, i32 1
+  %3 = load i64, i64* %1
+  %4 = load i64, i64* %2
+  %5 = call i64 @Microsoft__Quantum__Testing__QIR__Subtract__body(i64 %3, i64 %4)
+  %6 = bitcast %Tuple* %result-tuple to { i64 }*
+  %7 = getelementptr { i64 }, { i64 }* %6, i64 0, i32 0
+  store i64 %5, i64* %7
+  ret void
+}
+
+declare %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]*, %Tuple*)
+
+declare void @__quantum__rt__callable_reference(%Callable*)
+
+define void @Lifted__PartialApplication__11__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+entry:
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
+  %1 = bitcast %Tuple* %arg-tuple to { i64 }*
+  %2 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %3 = bitcast %Tuple* %2 to { i64, i64 }*
+  %4 = getelementptr { i64, i64 }, { i64, i64 }* %3, i64 0, i32 0
+  %5 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
+  %6 = load i64, i64* %5
+  store i64 %6, i64* %4
+  %7 = getelementptr { i64, i64 }, { i64, i64 }* %3, i64 0, i32 1
+  %8 = getelementptr { i64 }, { i64 }* %1, i64 0, i32 0
+  %9 = load i64, i64* %8
+  store i64 %9, i64* %7
+  %10 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
+  %11 = load %Callable*, %Callable** %10
+  call void @__quantum__rt__callable_invoke(%Callable* %11, %Tuple* %2, %Tuple* %result-tuple)
+  %12 = bitcast { i64, i64 }* %3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
+  ret void
+}
+
+declare void @__quantum__rt__callable_invoke(%Callable*, %Tuple*, %Tuple*)
+
+declare void @__quantum__rt__tuple_unreference(%Tuple*)
+
+declare void @__quantum__rt__callable_unreference(%Callable*)
 
 attributes #0 = { "EntryPoint" }

--- a/src/QirRuntime/test/QIR-static/qir-test-qubits-results.ll
+++ b/src/QirRuntime/test/QIR-static/qir-test-qubits-results.ll
@@ -2,7 +2,6 @@
 %Result = type opaque
 %Range = type { i64, i64, i64 }
 %Qubit = type opaque
-%TupleHeader = type { i32, i32 }
 %Array = type opaque
 %String = type opaque
 

--- a/src/QirRuntime/test/QIR-static/qir-test-qubits-results.ll
+++ b/src/QirRuntime/test/QIR-static/qir-test-qubits-results.ll
@@ -15,7 +15,7 @@
 
 @Microsoft_Quantum_Testing_QIR_Test_Qubit_Result_Management = alias i1 (), i1 ()* @Microsoft__Quantum__Testing__QIR__Test_Qubit_Result_Management__body
 
-declare void @__quantum__qis__x__(%Qubit*)
+declare void @__quantum__qis__x__body(%Qubit*)
 
 
 define i1 @Microsoft__Quantum__Testing__QIR__Test_Qubit_Result_Management__body() #0 {
@@ -24,7 +24,7 @@ entry:
   %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %1 = bitcast i8* %0 to %Qubit**
   %.qb = load %Qubit*, %Qubit** %1
-  call void @__quantum__qis__x__(%Qubit* %.qb)
+  call void @__quantum__qis__x__body(%Qubit* %.qb)
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
   %2 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %3 = bitcast i8* %2 to %Qubit**
@@ -35,7 +35,7 @@ entry:
   br i1 %7, label %then0__1, label %continue__1
 
 then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__x__(%Qubit* %q)
+  call void @__quantum__qis__x__body(%Qubit* %q)
   br label %continue__1
 
 continue__1:                                      ; preds = %then0__1, %entry

--- a/src/QirRuntime/test/unittests/QIRSupport.cpp
+++ b/src/QirRuntime/test/unittests/QIRSupport.cpp
@@ -739,12 +739,12 @@ TEST_CASE("Unpacking input tuples of nested callables (case2)", "[qir_support]")
     QirArray* controlsInner = quantum__rt__qubit_allocate_array(3);
     QirArray* controlsOuter = quantum__rt__qubit_allocate_array(2);
 
-    char* inner = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*Qubit*/ void*));
+    PTuple inner = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*Qubit*/ void*));
     TupleWithControls* innerWithControls = TupleWithControls::FromTuple(inner);
     innerWithControls->controls = controlsInner;
     *reinterpret_cast<Qubit*>(innerWithControls->AsTuple() + sizeof(/*QirArrray*/ void*)) = target;
 
-    char* outer = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
+    PTuple outer = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
     TupleWithControls* outerWithControls = TupleWithControls::FromTuple(outer);
     outerWithControls->controls = controlsOuter;
     outerWithControls->innerTuple = innerWithControls;
@@ -775,16 +775,16 @@ TEST_CASE("Unpacking input tuples of nested callables (case1)", "[qir_support]")
     QirArray* controlsInner = quantum__rt__qubit_allocate_array(3);
     QirArray* controlsOuter = quantum__rt__qubit_allocate_array(2);
 
-    char* args = quantum__rt__tuple_create(+sizeof(/*Qubit*/ void*) + sizeof(int));
+    PTuple args = quantum__rt__tuple_create(+sizeof(/*Qubit*/ void*) + sizeof(int));
     *reinterpret_cast<Qubit*>(args) = target;
     *reinterpret_cast<int*>(args + sizeof(/*Qubit*/ void*)) = 42;
 
-    char* inner = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*Tuple*/ void*));
+    PTuple inner = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*Tuple*/ void*));
     TupleWithControls* innerWithControls = TupleWithControls::FromTuple(inner);
     innerWithControls->controls = controlsInner;
-    *reinterpret_cast<char**>(innerWithControls->AsTuple() + sizeof(/*QirArrray*/ void*)) = args;
+    *reinterpret_cast<PTuple*>(innerWithControls->AsTuple() + sizeof(/*QirArrray*/ void*)) = args;
 
-    char* outer = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
+    PTuple outer = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
     TupleWithControls* outerWithControls = TupleWithControls::FromTuple(outer);
     outerWithControls->controls = controlsOuter;
     outerWithControls->innerTuple = innerWithControls;
@@ -795,7 +795,7 @@ TEST_CASE("Unpacking input tuples of nested callables (case1)", "[qir_support]")
     REQUIRE(!combined->ownsQubits);
 
     QirTupleHeader* unpackedArgs =
-        QirTupleHeader::GetHeader(*reinterpret_cast<char**>(unpacked->AsTuple() + sizeof(/*QirArrray*/ void*)));
+        QirTupleHeader::GetHeader(*reinterpret_cast<PTuple*>(unpacked->AsTuple() + sizeof(/*QirArrray*/ void*)));
     REQUIRE(target == *reinterpret_cast<Qubit*>(unpackedArgs->AsTuple()));
     REQUIRE(42 == *reinterpret_cast<int*>(unpackedArgs->AsTuple() + sizeof(/*Qubit*/ void*)));
 

--- a/src/QirRuntime/test/unittests/QIRSupport.cpp
+++ b/src/QirRuntime/test/unittests/QIRSupport.cpp
@@ -712,12 +712,6 @@ TEST_CASE("Qubits: allocate, release, dump", "[qir_support]")
     SetSimulatorForQIR(nullptr);
 }
 
-// `src` tuple header must point to a tuple with the following structure (example for depth = 2):
-// case1: { %TupleHeader, %Array*, { %TupleHeader, %Array*, { %TupleHeader, i64, %Qubit* }* }* }
-// case2: { %TupleHeader, %Array*, { %TupleHeader, %Array*, %Qubit* }* }
-// The function will create a new tuple, where the array contains elements of all nested arrays, respectively:
-// case1: { %TupleHeader, %Array*, { %TupleHeader, i64, %Qubit* }* }
-// case2: { %TupleHeader, %Array*, %Qubit* }
 QirTupleHeader* FlattenControlArrays(QirTupleHeader* nestedTuple, int depth);
 struct ControlledCallablesTestSimulator : public SimulatorStub
 {
@@ -745,22 +739,23 @@ TEST_CASE("Unpacking input tuples of nested callables (case2)", "[qir_support]")
     QirArray* controlsInner = quantum__rt__qubit_allocate_array(3);
     QirArray* controlsOuter = quantum__rt__qubit_allocate_array(2);
 
-    QirTupleHeader* inner =
-        quantum__rt__tuple_create(sizeof(QirTupleHeader) + sizeof(/*QirArrray*/ void*) + sizeof(/*Qubit*/ void*));
-    *reinterpret_cast<QirArray**>(inner->Data()) = controlsInner;
-    *reinterpret_cast<Qubit*>(inner->Data() + sizeof(/*QirArrray*/ void*)) = target;
-    QirTupleHeader* outer = quantum__rt__tuple_create(
-        sizeof(QirTupleHeader) + sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
-    *reinterpret_cast<QirArray**>(outer->Data()) = controlsOuter;
-    *reinterpret_cast<QirTupleHeader**>(outer->Data() + sizeof(/*QirArrray*/ void*)) = inner;
+    char* inner = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*Qubit*/ void*));
+    TupleWithControls* innerWithControls = TupleWithControls::FromTuple(inner);
+    innerWithControls->controls = controlsInner;
+    *reinterpret_cast<Qubit*>(innerWithControls->AsTuple() + sizeof(/*QirArrray*/ void*)) = target;
 
-    QirTupleHeader* unpacked = FlattenControlArrays(outer, 2 /*depth*/);
-    QirArray* combined = *(reinterpret_cast<QirArray**>(unpacked->Data()));
+    char* outer = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
+    TupleWithControls* outerWithControls = TupleWithControls::FromTuple(outer);
+    outerWithControls->controls = controlsOuter;
+    outerWithControls->innerTuple = innerWithControls;
+
+    QirTupleHeader* unpacked = FlattenControlArrays(outerWithControls->GetHeader(), 2 /*depth*/);
+    QirArray* combined = *(reinterpret_cast<QirArray**>(unpacked->AsTuple()));
     REQUIRE(5 == combined->count);
     REQUIRE(!combined->ownsQubits);
-    REQUIRE(target == *reinterpret_cast<Qubit*>(unpacked->Data() + sizeof(/*QirArrray*/ void*)));
+    REQUIRE(target == *reinterpret_cast<Qubit*>(unpacked->AsTuple() + sizeof(/*QirArrray*/ void*)));
 
-    quantum__rt__tuple_unreference(unpacked);
+    unpacked->Release();
     quantum__rt__array_unreference(combined);
     quantum__rt__tuple_unreference(outer);
     quantum__rt__tuple_unreference(inner);
@@ -780,27 +775,31 @@ TEST_CASE("Unpacking input tuples of nested callables (case1)", "[qir_support]")
     QirArray* controlsInner = quantum__rt__qubit_allocate_array(3);
     QirArray* controlsOuter = quantum__rt__qubit_allocate_array(2);
 
-    QirTupleHeader* args = quantum__rt__tuple_create(sizeof(QirTupleHeader) + sizeof(/*Qubit*/ void*) + sizeof(int));
-    *reinterpret_cast<Qubit*>(args->Data()) = target;
-    *reinterpret_cast<int*>(args->Data() + sizeof(/*Qubit*/ void*)) = 42;
-    QirTupleHeader* inner = quantum__rt__tuple_create(
-        sizeof(QirTupleHeader) + sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
-    *reinterpret_cast<QirArray**>(inner->Data()) = controlsInner;
-    *reinterpret_cast<QirTupleHeader**>(inner->Data() + sizeof(/*QirArrray*/ void*)) = args;
-    QirTupleHeader* outer = quantum__rt__tuple_create(
-        sizeof(QirTupleHeader) + sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
-    *reinterpret_cast<QirArray**>(outer->Data()) = controlsOuter;
-    *reinterpret_cast<QirTupleHeader**>(outer->Data() + sizeof(/*QirArrray*/ void*)) = inner;
+    char* args = quantum__rt__tuple_create(+sizeof(/*Qubit*/ void*) + sizeof(int));
+    *reinterpret_cast<Qubit*>(args) = target;
+    *reinterpret_cast<int*>(args + sizeof(/*Qubit*/ void*)) = 42;
 
-    QirTupleHeader* unpacked = FlattenControlArrays(outer, 2 /*depth*/);
-    QirArray* combined = *(reinterpret_cast<QirArray**>(unpacked->Data()));
+    char* inner = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*Tuple*/ void*));
+    TupleWithControls* innerWithControls = TupleWithControls::FromTuple(inner);
+    innerWithControls->controls = controlsInner;
+    *reinterpret_cast<char**>(innerWithControls->AsTuple() + sizeof(/*QirArrray*/ void*)) = args;
+
+    char* outer = quantum__rt__tuple_create(sizeof(/*QirArrray*/ void*) + sizeof(/*QirTupleHeader*/ void*));
+    TupleWithControls* outerWithControls = TupleWithControls::FromTuple(outer);
+    outerWithControls->controls = controlsOuter;
+    outerWithControls->innerTuple = innerWithControls;
+
+    QirTupleHeader* unpacked = FlattenControlArrays(outerWithControls->GetHeader(), 2 /*depth*/);
+    QirArray* combined = *(reinterpret_cast<QirArray**>(unpacked->AsTuple()));
     REQUIRE(5 == combined->count);
     REQUIRE(!combined->ownsQubits);
-    QirTupleHeader* unpackedArgs = *reinterpret_cast<QirTupleHeader**>(unpacked->Data() + sizeof(/*QirArrray*/ void*));
-    REQUIRE(target == *reinterpret_cast<Qubit*>(unpackedArgs->Data()));
-    REQUIRE(42 == *reinterpret_cast<int*>(unpackedArgs->Data() + sizeof(/*Qubit*/ void*)));
 
-    quantum__rt__tuple_unreference(unpacked);
+    QirTupleHeader* unpackedArgs =
+        QirTupleHeader::GetHeader(*reinterpret_cast<char**>(unpacked->AsTuple() + sizeof(/*QirArrray*/ void*)));
+    REQUIRE(target == *reinterpret_cast<Qubit*>(unpackedArgs->AsTuple()));
+    REQUIRE(42 == *reinterpret_cast<int*>(unpackedArgs->AsTuple() + sizeof(/*Qubit*/ void*)));
+
+    unpacked->Release();
     quantum__rt__array_unreference(combined);
     quantum__rt__tuple_unreference(outer);
     quantum__rt__tuple_unreference(inner);


### PR DESCRIPTION
Updated tuples handling and the QIR tests to be compatible with qsharp-compiler 7d182f37. The main change in the QIR is that there is no %TupleHeader anymore, embedded into the concrete tuple types. However, the runtime still uses the headers to store some necessary metadata for each tuple.