### PR TITLE
Add space between -D and name in CMake command

### DIFF
--- a/src/QirRuntime/build-qir-runtime.ps1
+++ b/src/QirRuntime/build-qir-runtime.ps1
@@ -37,7 +37,7 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
 
     Push-Location $qirRuntimeBuildFolder
 
-    cmake -G Ninja -DCMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ../..
+    cmake -G Ninja -D CMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ../..
     cmake --build . --target install
 
     Pop-Location
@@ -52,4 +52,3 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
 } else {
     Write-Host "To enable build of QIR Runtime set ENABLE_QIRRUNTIME environment variable to 'true'"
 }
-

--- a/src/Simulation/Native/build-native-simulator.ps1
+++ b/src/Simulation/Native/build-native-simulator.ps1
@@ -10,28 +10,28 @@ if (-not (Test-Path $nativeBuild)) {
 }
 Push-Location $nativeBuild
 
-# There should be no space after -DCMAKE_BUILD_TYPE= but if we provide the environment variable inline, without
-# the space it doesn't seem to get substituted... With invalid -DCMAKE_BUILD_TYPE argument cmake silently produces
+# There should be no space after -D CMAKE_BUILD_TYPE= but if we provide the environment variable inline, without
+# the space it doesn't seem to get substituted... With invalid -D CMAKE_BUILD_TYPE argument cmake silently produces
 # a DEBUG build.
 if (($IsWindows) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Win"))))
 {
     Write-Host "On Windows build native simulator using the default C/C++ compiler (should be MSVC)"
-    cmake -DBUILD_SHARED_LIBS:BOOL="1" -DCMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ..
+    cmake -D BUILD_SHARED_LIBS:BOOL="1" -D CMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ..
 }
 elseif (($IsLinux) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Lin"))))
 {
     Write-Host "On Linux build native simulator using gcc (needed for OpenMP)"
-    cmake -DBUILD_SHARED_LIBS:BOOL="1" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ..
+    cmake -D BUILD_SHARED_LIBS:BOOL="1" -D CMAKE_C_COMPILER=gcc -D CMAKE_CXX_COMPILER=g++ -D CMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ..
 }
 elseif (($IsMacOS) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Darwin"))))
 {
     Write-Host "On MacOS build native simulator using gcc (needed for OpenMP)"
     # `gcc`on Darwin seems to be a shim that redirects to AppleClang, to get real gcc, must point to the specific
     # version of gcc we've installed.
-    cmake -DBUILD_SHARED_LIBS:BOOL="1" -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 -DCMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ..
+    cmake -D BUILD_SHARED_LIBS:BOOL="1" -D CMAKE_C_COMPILER=gcc-7 -D CMAKE_CXX_COMPILER=g++-7 -D CMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ..
 }
 else {
-    cmake -DBUILD_SHARED_LIBS:BOOL="1" -DCMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ..
+    cmake -D BUILD_SHARED_LIBS:BOOL="1" -D CMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ..
 }
 cmake --build . --config "$Env:BUILD_CONFIGURATION" --target install
 
@@ -41,4 +41,3 @@ Pop-Location
 if ($LastExitCode -ne 0) {
     Write-Host "##vso[task.logissue type=error;]Failed to build Native simulator."
 }
-


### PR DESCRIPTION
After updating from CMake 3.16 to 3.19.3, the bootstrap.ps1/build-native-simulator.ps1 scripts stopped working:

```
PS C:\Users\samarsha\Source\Repos\microsoft\qsharp-runtime> .\bootstrap.ps1
Setting up build environment variables

...

On Windows build native simulator using the default C/C++ compiler (should be MSVC)
CMake Error: Parse error in command line argument: -DBUILD_SHARED_LIBS:
Should be: VAR:type=value

CMake Error: Problem processing arguments. Aborting.

Error: could not load cache
##vso[task.logissue type=error;]Failed to build Native simulator.
```

Adding a space between `-D` and the variable name seems to fix the problem. That's also the format that `cmake --help` prefers:

```
> cmake --help
Usage
...

Options
...
  -D <var>[:<type>]=<value>    = Create or update a cmake cache entry.
```