### PR TITLE
```Q# → ```qsharp

### DIFF
--- a/src/Simulation/QSharpCore/Arrays/Empty.qs
+++ b/src/Simulation/QSharpCore/Arrays/Empty.qs
@@ -14,7 +14,7 @@ namespace Microsoft.Quantum.Arrays {
     /// The empty array.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let empty = EmptyArray<Int>();
     /// ```
     function EmptyArray<'TElement>() : 'TElement[] {

--- a/src/Simulation/QSharpCore/Arrays/Enumeration.qs
+++ b/src/Simulation/QSharpCore/Arrays/Enumeration.qs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Arrays {
     ///
     /// # Example
     /// The following `for` loops are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// for (idx in IndexRange(array)) { ... }
     /// for (idx in IndexRange(array)) { ... }
     /// ```

--- a/src/Simulation/QSharpCore/Diagnostics/AssertQubit.qs
+++ b/src/Simulation/QSharpCore/Diagnostics/AssertQubit.qs
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// See remarks below for details.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// using (qubits = Qubit[2]) {
     ///     // Both qubits are initialized as |0〉: a=(1 + 0*i), b=(0 + 0*i)
     ///     AssertQubitIsInStateWithinTolerance((Complex(1., 0.), Complex(0., 0.)), qubits[0], 1e-5);

--- a/src/Simulation/QSharpCore/Diagnostics/Facts.qs
+++ b/src/Simulation/QSharpCore/Diagnostics/Facts.qs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Diagnostics {
     ///
     /// # Example
     /// The following Q# snippet will fail:
-    /// ```Q#
+    /// ```qsharp
     /// Fact(false, "Expected true.");
     /// ```
     function Fact(actual : Bool, message : String) : Unit {
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Diagnostics {
     ///
     /// # Example
     /// The following Q# code will print "Hello, world":
-    /// ```Q#
+    /// ```qsharp
     /// Contradiction(2 == 3, "2 is not equal to 3.");
     /// Message("Hello, world.");
     /// ```

--- a/src/Simulation/QSharpCore/Random/Convienence.qs
+++ b/src/Simulation/QSharpCore/Random/Convienence.qs
@@ -76,7 +76,7 @@ namespace Microsoft.Quantum.Random {
     ///
     /// # Example
     /// The following Q# snippet chooses an element at random from an array:
-    /// ```Q#
+    /// ```qsharp
     /// let (succeeded, element) = MaybeChooseElement(
     ///     data,
     ///     DiscreteUniformDistribution(0, Length(data) - 1)
@@ -106,7 +106,7 @@ namespace Microsoft.Quantum.Random {
     ///
     /// # Example
     /// The following Q# snippet samples flips from a biased coin:
-    /// ```Q#
+    /// ```qsharp
     /// let flips = DrawMany(DrawRandomBool, 10, 0.6);
     /// ```
     operation DrawRandomBool(successProbability : Double) : Bool {

--- a/src/Simulation/QSharpCore/Random/Intrinsic.qs
+++ b/src/Simulation/QSharpCore/Random/Intrinsic.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Random {
     ///
     /// # Example
     /// The following Q# snippet randomly rolls a six-sided die:
-    /// ```Q#
+    /// ```qsharp
     /// let roll = DrawRandomInt(1, 6);
     /// ```
     ///
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.Random {
     ///
     /// # Example
     /// The following Q# snippet randomly draws an angle between $0$ and $2 \pi$:
-    /// ```Q#
+    /// ```qsharp
     /// let angle = DrawRandomDouble(0.0, 2.0 * PI());
     /// ```
     ///

--- a/src/Simulation/QSharpCore/Random/Normal.qs
+++ b/src/Simulation/QSharpCore/Random/Normal.qs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Random {
     ///
     /// # Example
     /// The following draws 10 samples from the standard normal distribution:
-    /// ```Q#
+    /// ```qsharp
     /// let samples = DrawMany((StandardNormalDistribution())::Sample, 10, ());
     /// ```
     ///
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.Random {
     /// # Example
     /// The following draws 10 samples from the normal distribution with mean
     /// 2 and standard deviation 0.1:
-    /// ```Q#
+    /// ```qsharp
     /// let samples = DrawMany(
     ///     (NormalDistribution(2.0, PowD(0.1, 2.0)))::Sample,
     ///     10, ()

--- a/src/Simulation/QSharpCore/Random/Types.qs
+++ b/src/Simulation/QSharpCore/Random/Types.qs
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Random {
     /// # Example
     /// The following Q# code will display 0 with probability 30% and 1 with
     /// probability 70%:
-    /// ```Q#
+    /// ```qsharp
     /// let dist = CategoricalDistribution([0.3, 0.7]);
     /// Message($"Got sample: {dist::Sample()}");
     /// ```
@@ -102,7 +102,7 @@ namespace Microsoft.Quantum.Random {
     ///
     /// # Example
     /// The following two distributions are identical:
-    /// ```Q#
+    /// ```qsharp
     /// let dist1 = ContinuousUniformDistribution(1.0, 2.0);
     /// let dist2 = TransformedContinuousDistribution(
     ///     PlusD(1.0, _),

--- a/src/Simulation/QSharpCore/Random/Uniform.qs
+++ b/src/Simulation/QSharpCore/Random/Uniform.qs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Random {
     ///
     /// # Example
     /// The following Q# snippet randomly draws an angle between $0$ and $2 \pi$:
-    /// ```Q#
+    /// ```qsharp
     /// let angleDistribution = ContinuousUniformDistribution(0.0, 2.0 * PI());
     /// let angle = angleDistribution::Sample();
     /// ```
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.Random {
     ///
     /// # Example
     /// The following Q# snippet randomly rolls a six-sided die:
-    /// ```Q#
+    /// ```qsharp
     /// let dieDistribution = DiscreteUniformDistribution(1, 6);
     /// let dieRoll = dieDistribution::Sample();
     /// ```


### PR DESCRIPTION
This PR fixes documentation comments to use ```qsharp instead of ```Q#, fixing a lack of syntax highlighting reported by @guenp.

See https://github.com/microsoft/QuantumLibraries/pull/402.