### PR TITLE
QirRuntime: eliminate usage of word 'dummy'

### DIFF
--- a/src/QirRuntime/lib/QIR/CMakeLists.txt
+++ b/src/QirRuntime/lib/QIR/CMakeLists.txt
@@ -1,25 +1,18 @@
-#
-# The bridge funtions calls into the rt so on Linux the dependency requires to
-# introduce a new target that sits on top of both and links them in the correct
-# order. This top target doesn't have any code of its own but CMake insists on
-# providing a source file, thus __dummy.cpp...
-#
-
-set(CLANG_ARGS "-c")
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-set(CLANG_ARGS
-  "${CLANG_ARGS}"
-  "-O0"
-  "-D_DEBUG"
-)
-endif()
+# The downstream consumers but must pick up both the native support lib and the utility
+# lib, produced from ll bridge files when linking against either qir-rt or qir-qis.
 
 #+++++++++++++++++++++++++++++++++++++
 # qir-rt
 #+++++++++++++++++++++++++++++++++++++
 
 #===============================================================================
-# Step 1: create qir-rt-support lib from the C++ sources
+# create a utility lib from bridge-rt.ll
+#
+set(bridge_rt_target "bridge_rt_target")
+compile_from_qir(bridge-rt ${bridge_rt_target})
+
+#===============================================================================
+# create qir-rt-support lib from the C++ sources
 #
 set(rt_sup_source_files
   "allocationsTracker.cpp"
@@ -40,33 +33,20 @@ add_library(qir-rt-support-obj OBJECT ${rt_sup_source_files})
 target_include_directories(qir-rt-support-obj PUBLIC ${public_includes})
 set_property(TARGET qir-rt-support-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-#===============================================================================
-# Step 2: create a utility lib from bridge-rt.ll
-#
-set(bridge_rt_target "bridge_rt_target")
-compile_from_qir(bridge-rt ${bridge_rt_target})
-
-#===============================================================================
-# Step 3: combine the utility lib and the support lib into a single static qir-rt
-# library, the clients can link against.
-#
-add_library(qir-rt STATIC __dummy.cpp)
-
-target_link_libraries(qir-rt PUBLIC
-  ${QIR_UTILITY_LIB} # set in compile_from_qir
-  qir-rt-support
-  ${CMAKE_DL_LIBS}
-)
-add_dependencies(qir-rt ${bridge_rt_target})
-
+add_dependencies(qir-rt-support ${bridge_rt_target})
 
 #+++++++++++++++++++++++++++++++++++++
-# QIR_QIS
-# (the same dance as for qir-rt)
+# qir-qis
 #+++++++++++++++++++++++++++++++++++++
 
 #===============================================================================
-# Step 1: create qir-qis-support lib from the C++ sources
+# create a utility lib from bridge-qis.ll
+#
+set(bridge_qis_target "bridge_qis_target")
+compile_from_qir(bridge-qis ${bridge_qis_target})
+
+#===============================================================================
+# create qir-qis-support lib from the C++ sources
 #
 set(qis_sup_source_files
   "intrinsics.cpp"
@@ -82,25 +62,7 @@ add_library(qir-qis-support-obj OBJECT ${qis_sup_source_files})
 target_include_directories(qir-qis-support-obj PUBLIC ${public_includes})
 set_property(TARGET qir-qis-support-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-#===============================================================================
-# Step 2: create a utility lib from bridge-qis.ll
-#
-set(bridge_qis_target "bridge_qis_target")
-compile_from_qir(bridge-qis ${bridge_qis_target})
-
-#===============================================================================
-# Step 3: combine the utility lib and the support lib into a single static qir-qis
-# library, the clients can link against.
-#
-add_library(qir-qis STATIC __dummy.cpp)
-
-target_link_libraries(qir-qis PUBLIC
-  ${QIR_UTILITY_LIB}  # set in compile_from_qir
-  qir-qis-support
-  ${CMAKE_DL_LIBS}
-)
-
-add_dependencies(qir-qis ${bridge_qis_target})
+add_dependencies(qir-qis-support ${bridge_qis_target})
 
 
 

--- a/src/QirRuntime/lib/QIR/__dummy.cpp
+++ b/src/QirRuntime/lib/QIR/__dummy.cpp
@@ -1,3 +1,0 @@
-/* In order to combine the bridge and native support libs into a single
-   static library for the clients to link against, we have to provide a
-   source file to use in CMake target definitions... */

--- a/src/QirRuntime/test/FullstateSimulator/CMakeLists.txt
+++ b/src/QirRuntime/test/FullstateSimulator/CMakeLists.txt
@@ -6,8 +6,10 @@ add_executable(fullstate-simulator-tests
 
 target_link_libraries(fullstate-simulator-tests PUBLIC
   ${QIR_UTILITY_LIB} # created by compile_from_qir
-  qir-rt
-  qir-qis
+  ${QIR_BRIDGE_UTILITY_LIB}
+  ${QIR_BRIDGE_QIS_UTILITY_LIB}
+  qir-rt-support
+  qir-qis-support
   simulators
 )
 

--- a/src/QirRuntime/test/unittests/QirRuntimeTests.cpp
+++ b/src/QirRuntime/test/unittests/QirRuntimeTests.cpp
@@ -912,10 +912,10 @@ TEST_CASE("Allocation tracking for tuples", "[qir_support]")
     CHECK_NOTHROW(ReleaseQirContext());
 }
 
-static void DummyCallableEntry(PTuple, PTuple, PTuple) {}
+static void NoopCallableEntry(PTuple, PTuple, PTuple) {}
 TEST_CASE("Allocation tracking for callables", "[qir_support]")
 {
-    t_CallableEntry entries[4] = {DummyCallableEntry, nullptr, nullptr, nullptr};
+    t_CallableEntry entries[4] = {NoopCallableEntry, nullptr, nullptr, nullptr};
 
     InitializeQirContext(nullptr /*don't need a simulator*/, true /*track allocations*/);
 
@@ -940,7 +940,7 @@ TEST_CASE("Allocation tracking for callables", "[qir_support]")
 TEST_CASE("Callables: copy elision", "[qir_support]")
 {
     QirContextScope qirctx(nullptr, true);
-    t_CallableEntry entries[4] = {DummyCallableEntry, nullptr, nullptr, nullptr};
+    t_CallableEntry entries[4] = {NoopCallableEntry, nullptr, nullptr, nullptr};
 
     QirCallable* original =
         quantum__rt__callable_create(entries, nullptr /*capture callbacks*/, nullptr /*capture tuple*/);


### PR DESCRIPTION
Renames + removed qir-rt/qir-qis libs as they didn't work as expected on linux and had to replaces with explicit includes of the corresponding utility and native support libraries anyway.