### PR TITLE
Updating ClassicalControls to reduce intrinsics

### DIFF
--- a/src/QirRuntime/test/QIR-static/qsharp/main.cs
+++ b/src/QirRuntime/test/QIR-static/qsharp/main.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Currently, compiling to QIR has to suppress C# generation but then we need to provide Main function ourselves.
+namespace CompilerWorkaround
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/QirRuntime/test/QIR-static/qsharp/qir-gen.csproj
+++ b/src/QirRuntime/test/QIR-static/qsharp/qir-gen.csproj
@@ -1,9 +1,15 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129370-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <QirGeneration>True</QirGeneration>
+    <CSharpGeneration>false</CSharpGeneration>
+    <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Simulation\QSharpCore\Microsoft.Quantum.QSharp.Core.csproj" /> 
+  </ItemGroup>
 
 </Project>

--- a/src/Simulation/CSharpGeneration/Microsoft.Quantum.CSharpGeneration.fsproj
+++ b/src/Simulation/CSharpGeneration/Microsoft.Quantum.CSharpGeneration.fsproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.15.210222819-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.15.2102129527-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\Simulators.Dev.props" />

--- a/src/Simulation/QSharpCore/Microsoft.Quantum.QSharp.Core.csproj
+++ b/src/Simulation/QSharpCore/Microsoft.Quantum.QSharp.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
   <Import Project="..\TargetDefinitions\TargetPackages\QSharpCore.Package.props" />
 
   <PropertyGroup>

--- a/src/Simulation/QSharpFoundation/ClassicalControl.qs
+++ b/src/Simulation/QSharpFoundation/ClassicalControl.qs
@@ -29,20 +29,36 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor.Extensions //ToDo: updat
     }
 
     operation ApplyIfElseIntrinsicA(measurementResult : Result, onResultZeroOp : (Unit => Unit is Adj) , onResultOneOp : (Unit => Unit is Adj)) : Unit is Adj {
-        body intrinsic;
-        adjoint intrinsic;
+        body (...) {
+            ApplyIfElseIntrinsic(measurementResult, onResultZeroOp, onResultOneOp);
+        }
+        adjoint (...) {
+            ApplyIfElseIntrinsic(measurementResult, Adjoint onResultZeroOp, Adjoint onResultOneOp);
+        }
     }
 
     operation ApplyIfElseIntrinsicC(measurementResult : Result, onResultZeroOp : (Unit => Unit is Ctl) , onResultOneOp : (Unit => Unit is Ctl)) : Unit is Ctl {
-        body intrinsic;
-        controlled intrinsic;
+        body (...) {
+            ApplyIfElseIntrinsic(measurementResult, onResultZeroOp, onResultOneOp);
+        }
+        controlled (ctls, ...) {
+            ApplyIfElseIntrinsic(measurementResult, Controlled onResultZeroOp(ctls, _), Controlled onResultOneOp(ctls, _));
+        }
     }
 
     operation ApplyIfElseIntrinsicCA(measurementResult : Result, onResultZeroOp : (Unit => Unit is Ctl + Adj) , onResultOneOp : (Unit => Unit is Ctl + Adj)) : Unit is Ctl + Adj {
-        body intrinsic;
-        adjoint intrinsic;
-        controlled intrinsic;
-        controlled adjoint intrinsic;
+        body (...) {
+            ApplyIfElseIntrinsic(measurementResult, onResultZeroOp, onResultOneOp);
+        }
+        adjoint (...) {
+            ApplyIfElseIntrinsic(measurementResult, Adjoint onResultZeroOp, Adjoint onResultOneOp);
+        }
+        controlled (ctls, ...) {
+            ApplyIfElseIntrinsic(measurementResult, Controlled onResultZeroOp(ctls, _), Controlled onResultOneOp(ctls, _));
+        }
+        controlled adjoint (ctls, ...) {
+            ApplyIfElseIntrinsic(measurementResult, Controlled Adjoint onResultZeroOp(ctls, _), Controlled Adjoint onResultOneOp(ctls, _));
+        }
     }
 
 
@@ -52,20 +68,36 @@ namespace Microsoft.Quantum.Simulation.QuantumProcessor.Extensions //ToDo: updat
     }
 
     operation ApplyConditionallyIntrinsicA(measurementResults : Result[], resultsValues : Result[], onEqualOp : (Unit => Unit is Adj) , onNonEqualOp : (Unit => Unit is Adj)) : Unit is Adj {
-        body intrinsic;
-        adjoint intrinsic;
+        body (...) {
+            ApplyConditionallyIntrinsic(measurementResults, resultsValues, onEqualOp, onNonEqualOp);
+        }
+        adjoint (...) {
+            ApplyConditionallyIntrinsic(measurementResults, resultsValues, Adjoint onEqualOp, Adjoint onNonEqualOp);
+        }
     }
 
     operation ApplyConditionallyIntrinsicC(measurementResults : Result[], resultsValues : Result[], onEqualOp : (Unit => Unit is Ctl) , onNonEqualOp : (Unit => Unit is Ctl)) : Unit is Ctl {
-        body intrinsic;
-        controlled intrinsic;
+        body (...) {
+            ApplyConditionallyIntrinsic(measurementResults, resultsValues, onEqualOp, onNonEqualOp);
+        }
+        controlled (ctls, ...) {
+            ApplyConditionallyIntrinsic(measurementResults, resultsValues, Controlled onEqualOp(ctls, _), Controlled onNonEqualOp(ctls, _));
+        }
     }
 
     operation ApplyConditionallyIntrinsicCA(measurementResults : Result[], resultsValues : Result[], onEqualOp : (Unit => Unit is Ctl + Adj) , onNonEqualOp : (Unit => Unit is Ctl + Adj)) : Unit is Ctl + Adj {
-        body intrinsic;
-        adjoint intrinsic;
-        controlled intrinsic;
-        controlled adjoint intrinsic;
+        body (...) {
+            ApplyConditionallyIntrinsic(measurementResults, resultsValues, onEqualOp, onNonEqualOp);
+        }
+        adjoint (...) {
+            ApplyConditionallyIntrinsic(measurementResults, resultsValues, Adjoint onEqualOp, Adjoint onNonEqualOp);
+        }
+        controlled (ctls, ...) {
+            ApplyConditionallyIntrinsic(measurementResults, resultsValues, Controlled onEqualOp(ctls, _), Controlled onNonEqualOp(ctls, _));
+        }
+        controlled adjoint (ctls, ...) {
+            ApplyConditionallyIntrinsic(measurementResults, resultsValues, Controlled Adjoint onEqualOp(ctls, _), Controlled Adjoint onNonEqualOp(ctls, _));
+        }
     }
 
 

--- a/src/Simulation/QSharpFoundation/Microsoft.Quantum.QSharp.Foundation.csproj
+++ b/src/Simulation/QSharpFoundation/Microsoft.Quantum.QSharp.Foundation.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />
@@ -8,6 +8,7 @@
     <QSharpDocsGeneration>true</QSharpDocsGeneration>
     <CSharpGeneration>false</CSharpGeneration> <!-- we will provide our own -->
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
+    <QscVerbosity>D</QscVerbosity>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CSharpGeneration>false</CSharpGeneration>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/QSharpExe/QSharpExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QSharpExe/QSharpExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\Common\Simulators.Test.props" />
 

--- a/src/Simulation/Simulators.Type1.Tests/Tests.Microsoft.Quantum.Simulators.Type1.csproj
+++ b/src/Simulation/Simulators.Type1.Tests/Tests.Microsoft.Quantum.Simulators.Type1.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\Common\Simulators.Test.props" />
 

--- a/src/Simulation/Simulators.Type2.Tests/Tests.Microsoft.Quantum.Simulators.Type2.csproj
+++ b/src/Simulation/Simulators.Type2.Tests/Tests.Microsoft.Quantum.Simulators.Type2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222819-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\Common\Simulators.Test.props" />
 

--- a/src/Simulation/Simulators.Type3.Tests/Tests.Microsoft.Quantum.Simulators.Type3.csproj
+++ b/src/Simulation/Simulators.Type3.Tests/Tests.Microsoft.Quantum.Simulators.Type3.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2101126940">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\Common\Simulators.Test.props" />
 

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Type1Core/Microsoft.Quantum.Type1.Core.csproj
+++ b/src/Simulation/Type1Core/Microsoft.Quantum.Type1.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\TargetDefinitions\TargetPackages\Type1.Package.props" />
 

--- a/src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.csproj
+++ b/src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210222838-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\TargetDefinitions\TargetPackages\Type2.Package.props" />
 

--- a/src/Simulation/Type3Core/Microsoft.Quantum.Type3.Core.csproj
+++ b/src/Simulation/Type3Core/Microsoft.Quantum.Type3.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2101126940">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
 
   <Import Project="..\TargetDefinitions\TargetPackages\Type3.Package.props" />
 


### PR DESCRIPTION
This updates the structure of the classical control ApplyIf* and ApplyControlled* callables in terms of each other to reduce 8 intrinsics to 2 intrinsics. Also updates the qir-gen.csproj to use the local QSharp.Core project instead of the one from the QDK for easier testing.