### PR TITLE
Tracer: Fix the target.qs file and link in QIS lib

### DIFF
--- a/src/QirRuntime/test/QIR-tracer/CMakeLists.txt
+++ b/src/QirRuntime/test/QIR-tracer/CMakeLists.txt
@@ -13,8 +13,10 @@ target_link_libraries(qir-tracer-tests PUBLIC
   ${QIR_UTILITY_LIB} # set by compile_from_qir
   ${QIR_BRIDGE_UTILITY_LIB}
   ${QIR_BRIDGE_TRACER_UTILITY_LIB}
+  ${QIR_BRIDGE_QIS_UTILITY_LIB}
   tracer
   qir-rt-support
+  qir-qis-support
 )
 
 target_include_directories(qir-tracer-tests PUBLIC

--- a/src/QirRuntime/test/QIR-tracer/generate.py
+++ b/src/QirRuntime/test/QIR-tracer/generate.py
@@ -35,7 +35,12 @@ if __name__ == '__main__':
 
   # Compile as a lib so all functions are retained and don't have to workaround the current limitations of
   # @EntryPoint attribute.
-  command = (qsc + " build --qir s --input " + files_to_process + " --proj " + output_file)
+  command = (qsc + " build --qir qir --input " + files_to_process + " --proj " + output_file)
   log("Executing: " + command)
   subprocess.run(command, shell = True)
+
+  # copy the generated file into tracer's input files
+  generated_file = os.path.join(root_dir, "qir", output_file) + ".ll"
+  build_input_file = os.path.join(root_dir, output_file) + ".ll"
+  shutil.copyfile(generated_file, build_input_file)
 

--- a/src/QirRuntime/test/QIR-tracer/tracer-qir.ll
+++ b/src/QirRuntime/test/QIR-tracer/tracer-qir.ll
@@ -1,9 +1,13 @@
+;This file was generated using:
+;commit 722ec70a97b65f8d3ee1085368142a91183969db (HEAD, origin/swernli/standalone-llvm-2)
+;Author: Stefan J. Wernli <swernli@microsoft.com>
+;Date:   Wed Feb 24 21:51:15 2021 -0800
 
 %Result = type opaque
 %Range = type { i64, i64, i64 }
-%Tuple = type opaque
-%Qubit = type opaque
 %Array = type opaque
+%Qubit = type opaque
+%Tuple = type opaque
 %String = type opaque
 
 @ResultZero = external global %Result*
@@ -13,812 +17,6 @@
 @PauliY = constant i2 -1
 @PauliZ = constant i2 -2
 @EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
-
-define %Tuple* @Microsoft__Quantum__Core__Attribute__body() {
-entry:
-  ret %Tuple* null
-}
-
-define %Tuple* @Microsoft__Quantum__Core__EntryPoint__body() {
-entry:
-  ret %Tuple* null
-}
-
-define %Tuple* @Microsoft__Quantum__Core__Inline__body() {
-entry:
-  ret %Tuple* null
-}
-
-define void @Microsoft__Quantum__Intrinsic__CNOT__body(%Qubit* %control, %Qubit* %target) {
-entry:
-  %ctls = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %ctls, i64 0)
-  %1 = bitcast i8* %0 to %Qubit**
-  store %Qubit* %control, %Qubit** %1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  br i1 true, label %then0__1, label %else__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls, %Qubit* %target)
-  br label %continue__1
-
-else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls, %Qubit* %target)
-  br label %continue__1
-
-continue__1:                                      ; preds = %else__1, %then0__1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-declare %Array* @__quantum__rt__array_create_1d(i32, i64)
-
-declare i8* @__quantum__rt__array_get_element_ptr_1d(%Array*, i64)
-
-declare void @__quantum__rt__array_update_alias_count(%Array*, i64)
-
-declare void @__quantum__qis__single_qubit_op_ctl(i64, i64, %Array*, %Qubit*)
-
-declare void @__quantum__rt__array_update_reference_count(%Array*, i64)
-
-define void @Microsoft__Quantum__Intrinsic__CNOT__adj(%Qubit* %control, %Qubit* %target) {
-entry:
-  %ctls = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %ctls, i64 0)
-  %1 = bitcast i8* %0 to %Qubit**
-  store %Qubit* %control, %Qubit** %1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  br i1 true, label %then0__1, label %else__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls, %Qubit* %target)
-  br label %continue__1
-
-else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls, %Qubit* %target)
-  br label %continue__1
-
-continue__1:                                      ; preds = %else__1, %then0__1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 9, i64 1, %Qubit* %qb)
-  ret void
-}
-
-declare void @__quantum__qis__single_qubit_op(i64, i64, %Qubit*)
-
-define void @Microsoft__Quantum__Intrinsic__H__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 9, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__H__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 10, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__H__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 10, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define %Result* @Microsoft__Quantum__Intrinsic__M__body(%Qubit* %qb) {
-entry:
-  %0 = call %Result* @__quantum__qis__single_qubit_measure(i64 100, i64 1, %Qubit* %qb)
-  ret %Result* %0
-}
-
-declare %Result* @__quantum__qis__single_qubit_measure(i64, i64, %Qubit*)
-
-define %Result* @Microsoft__Quantum__Intrinsic__Measure__body(%Array* %paulis, %Array* %qubits) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %paulis, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
-  %0 = load %Result*, %Result** @ResultOne
-  %res = alloca %Result*
-  store %Result* %0, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %0, i64 1)
-  %haveY = alloca i1
-  store i1 false, i1* %haveY
-  %1 = call i64 @__quantum__rt__array_get_size_1d(%Array* %paulis)
-  %2 = sub i64 %1, 1
-  br label %header__1
-
-header__1:                                        ; preds = %exiting__1, %entry
-  %i = phi i64 [ 0, %entry ], [ %15, %exiting__1 ]
-  %3 = icmp sle i64 %i, %2
-  br i1 %3, label %body__1, label %exit__1
-
-body__1:                                          ; preds = %header__1
-  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 %i)
-  %5 = bitcast i8* %4 to i2*
-  %6 = load i2, i2* %5
-  %7 = load i2, i2* @PauliY
-  %8 = icmp eq i2 %6, %7
-  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 %i)
-  %10 = bitcast i8* %9 to i2*
-  %11 = load i2, i2* %10
-  %12 = load i2, i2* @PauliI
-  %13 = icmp eq i2 %11, %12
-  %14 = or i1 %8, %13
-  br i1 %14, label %then0__1, label %continue__1
-
-then0__1:                                         ; preds = %body__1
-  store i1 true, i1* %haveY
-  br label %continue__1
-
-continue__1:                                      ; preds = %then0__1, %body__1
-  br label %exiting__1
-
-exiting__1:                                       ; preds = %continue__1
-  %15 = add i64 %i, 1
-  br label %header__1
-
-exit__1:                                          ; preds = %header__1
-  %16 = load i1, i1* %haveY
-  br i1 %16, label %then0__2, label %test1__1
-
-then0__2:                                         ; preds = %exit__1
-  %17 = call %Result* @__quantum__qis__joint_measure(i64 106, i64 1, %Array* %qubits)
-  call void @__quantum__rt__result_update_reference_count(%Result* %17, i64 1)
-  store %Result* %17, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %17, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %0, i64 -1)
-  br label %continue__2
-
-test1__1:                                         ; preds = %exit__1
-  %18 = icmp sgt i64 %1, 2
-  br i1 %18, label %then1__1, label %test2__1
-
-then1__1:                                         ; preds = %test1__1
-  %19 = call %Result* @__quantum__qis__joint_measure(i64 107, i64 1, %Array* %qubits)
-  call void @__quantum__rt__result_update_reference_count(%Result* %19, i64 1)
-  %20 = load %Result*, %Result** %res
-  store %Result* %19, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %19, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %20, i64 -1)
-  br label %continue__2
-
-test2__1:                                         ; preds = %test1__1
-  %21 = icmp eq i64 %1, 1
-  br i1 %21, label %then2__1, label %test3__1
-
-then2__1:                                         ; preds = %test2__1
-  %22 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
-  %23 = bitcast i8* %22 to i2*
-  %24 = load i2, i2* %23
-  %25 = load i2, i2* @PauliX
-  %26 = icmp eq i2 %24, %25
-  br i1 %26, label %then0__3, label %else__1
-
-then0__3:                                         ; preds = %then2__1
-  %27 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qubits, i64 0)
-  %28 = bitcast i8* %27 to %Qubit**
-  %qb = load %Qubit*, %Qubit** %28
-  %29 = call %Result* @__quantum__qis__single_qubit_measure(i64 101, i64 1, %Qubit* %qb)
-  call void @__quantum__rt__result_update_reference_count(%Result* %29, i64 1)
-  %30 = load %Result*, %Result** %res
-  store %Result* %29, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %29, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %30, i64 -1)
-  br label %continue__3
-
-else__1:                                          ; preds = %then2__1
-  %31 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qubits, i64 0)
-  %32 = bitcast i8* %31 to %Qubit**
-  %qb__1 = load %Qubit*, %Qubit** %32
-  %33 = call %Result* @__quantum__qis__single_qubit_measure(i64 100, i64 1, %Qubit* %qb__1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %33, i64 1)
-  %34 = load %Result*, %Result** %res
-  store %Result* %33, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %33, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %34, i64 -1)
-  br label %continue__3
-
-continue__3:                                      ; preds = %else__1, %then0__3
-  br label %continue__2
-
-test3__1:                                         ; preds = %test2__1
-  %35 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
-  %36 = bitcast i8* %35 to i2*
-  %37 = load i2, i2* %36
-  %38 = load i2, i2* @PauliX
-  %39 = icmp eq i2 %37, %38
-  %40 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 1)
-  %41 = bitcast i8* %40 to i2*
-  %42 = load i2, i2* %41
-  %43 = load i2, i2* @PauliX
-  %44 = icmp eq i2 %42, %43
-  %45 = and i1 %39, %44
-  br i1 %45, label %then3__1, label %test4__1
-
-then3__1:                                         ; preds = %test3__1
-  %46 = call %Result* @__quantum__qis__joint_measure(i64 108, i64 1, %Array* %qubits)
-  call void @__quantum__rt__result_update_reference_count(%Result* %46, i64 1)
-  %47 = load %Result*, %Result** %res
-  store %Result* %46, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %46, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %47, i64 -1)
-  br label %continue__2
-
-test4__1:                                         ; preds = %test3__1
-  %48 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
-  %49 = bitcast i8* %48 to i2*
-  %50 = load i2, i2* %49
-  %51 = load i2, i2* @PauliX
-  %52 = icmp eq i2 %50, %51
-  %53 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 1)
-  %54 = bitcast i8* %53 to i2*
-  %55 = load i2, i2* %54
-  %56 = load i2, i2* @PauliZ
-  %57 = icmp eq i2 %55, %56
-  %58 = and i1 %52, %57
-  br i1 %58, label %then4__1, label %test5__1
-
-then4__1:                                         ; preds = %test4__1
-  %59 = call %Result* @__quantum__qis__joint_measure(i64 109, i64 1, %Array* %qubits)
-  call void @__quantum__rt__result_update_reference_count(%Result* %59, i64 1)
-  %60 = load %Result*, %Result** %res
-  store %Result* %59, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %59, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %60, i64 -1)
-  br label %continue__2
-
-test5__1:                                         ; preds = %test4__1
-  %61 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
-  %62 = bitcast i8* %61 to i2*
-  %63 = load i2, i2* %62
-  %64 = load i2, i2* @PauliZ
-  %65 = icmp eq i2 %63, %64
-  %66 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 1)
-  %67 = bitcast i8* %66 to i2*
-  %68 = load i2, i2* %67
-  %69 = load i2, i2* @PauliX
-  %70 = icmp eq i2 %68, %69
-  %71 = and i1 %65, %70
-  br i1 %71, label %then5__1, label %test6__1
-
-then5__1:                                         ; preds = %test5__1
-  %72 = call %Result* @__quantum__qis__joint_measure(i64 110, i64 1, %Array* %qubits)
-  call void @__quantum__rt__result_update_reference_count(%Result* %72, i64 1)
-  %73 = load %Result*, %Result** %res
-  store %Result* %72, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %72, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %73, i64 -1)
-  br label %continue__2
-
-test6__1:                                         ; preds = %test5__1
-  %74 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
-  %75 = bitcast i8* %74 to i2*
-  %76 = load i2, i2* %75
-  %77 = load i2, i2* @PauliZ
-  %78 = icmp eq i2 %76, %77
-  %79 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 1)
-  %80 = bitcast i8* %79 to i2*
-  %81 = load i2, i2* %80
-  %82 = load i2, i2* @PauliZ
-  %83 = icmp eq i2 %81, %82
-  %84 = and i1 %78, %83
-  br i1 %84, label %then6__1, label %continue__2
-
-then6__1:                                         ; preds = %test6__1
-  %85 = call %Result* @__quantum__qis__joint_measure(i64 111, i64 1, %Array* %qubits)
-  call void @__quantum__rt__result_update_reference_count(%Result* %85, i64 1)
-  %86 = load %Result*, %Result** %res
-  store %Result* %85, %Result** %res
-  call void @__quantum__rt__result_update_reference_count(%Result* %85, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %86, i64 -1)
-  br label %continue__2
-
-continue__2:                                      ; preds = %then6__1, %test6__1, %then5__1, %then4__1, %then3__1, %continue__3, %then1__1, %then0__2
-  %87 = load %Result*, %Result** %res
-  call void @__quantum__rt__array_update_alias_count(%Array* %paulis, i64 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
-  ret %Result* %87
-}
-
-declare void @__quantum__rt__result_update_reference_count(%Result*, i64)
-
-declare i64 @__quantum__rt__array_get_size_1d(%Array*)
-
-declare %Result* @__quantum__qis__joint_measure(i64, i64, %Array*)
-
-define %Result* @Microsoft__Quantum__Intrinsic__Mx__body(%Qubit* %qb) {
-entry:
-  %0 = call %Result* @__quantum__qis__single_qubit_measure(i64 101, i64 1, %Qubit* %qb)
-  ret %Result* %0
-}
-
-define %Result* @Microsoft__Quantum__Intrinsic__Mxx__body(%Array* %qubits) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
-  %0 = call %Result* @__quantum__qis__joint_measure(i64 105, i64 1, %Array* %qubits)
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
-  ret %Result* %0
-}
-
-define %Result* @Microsoft__Quantum__Intrinsic__Mxz__body(%Array* %qubits) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
-  %0 = call %Result* @__quantum__qis__joint_measure(i64 103, i64 1, %Array* %qubits)
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
-  ret %Result* %0
-}
-
-define %Result* @Microsoft__Quantum__Intrinsic__Mz__body(%Qubit* %qb) {
-entry:
-  %0 = call %Result* @__quantum__qis__single_qubit_measure(i64 100, i64 1, %Qubit* %qb)
-  ret %Result* %0
-}
-
-define %Result* @Microsoft__Quantum__Intrinsic__Mzx__body(%Array* %qubits) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
-  %0 = call %Result* @__quantum__qis__joint_measure(i64 104, i64 1, %Array* %qubits)
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
-  ret %Result* %0
-}
-
-define %Result* @Microsoft__Quantum__Intrinsic__Mzz__body(%Array* %qubits) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
-  %0 = call %Result* @__quantum__qis__joint_measure(i64 102, i64 1, %Array* %qubits)
-  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
-  ret %Result* %0
-}
-
-define void @Microsoft__Quantum__Intrinsic__Rx__body(double %theta, %Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 19, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Rx__adj(double %theta, %Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 19, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Rx__ctl(%Array* %ctls, { double, %Qubit* }* %0) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
-  %theta = load double, double* %1
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
-  %qb = load %Qubit*, %Qubit** %2
-  call void @__quantum__qis__single_qubit_op_ctl(i64 20, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Rx__ctladj(%Array* %ctls, { double, %Qubit* }* %0) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
-  %theta = load double, double* %1
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
-  %qb = load %Qubit*, %Qubit** %2
-  call void @__quantum__qis__single_qubit_op_ctl(i64 20, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Ry__body(double %theta, %Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 21, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Ry__adj(double %theta, %Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 21, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Ry__ctl(%Array* %ctls, { double, %Qubit* }* %0) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
-  %theta = load double, double* %1
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
-  %qb = load %Qubit*, %Qubit** %2
-  call void @__quantum__qis__single_qubit_op_ctl(i64 22, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Ry__ctladj(%Array* %ctls, { double, %Qubit* }* %0) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
-  %theta = load double, double* %1
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
-  %qb = load %Qubit*, %Qubit** %2
-  call void @__quantum__qis__single_qubit_op_ctl(i64 22, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Rz__body(double %theta, %Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 23, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Rz__adj(double %theta, %Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 24, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Rz__ctl(%Array* %ctls, { double, %Qubit* }* %0) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
-  %theta = load double, double* %1
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
-  %qb = load %Qubit*, %Qubit** %2
-  call void @__quantum__qis__single_qubit_op_ctl(i64 25, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Rz__ctladj(%Array* %ctls, { double, %Qubit* }* %0) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
-  %theta = load double, double* %1
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
-  %qb = load %Qubit*, %Qubit** %2
-  call void @__quantum__qis__single_qubit_op_ctl(i64 25, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__S__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__S__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__S__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__S__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Sx__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 17, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Sx__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 17, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Sx__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 18, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Sx__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 18, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Sz__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Sz__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Sz__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Sz__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__T__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__T__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__T__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__T__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Tx__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 13, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Tx__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 13, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Tx__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 14, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Tx__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 14, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Tz__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Tz__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Tz__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Tz__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls, %Qubit* %qb)
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__X__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 0, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__X__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 0, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__X__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
-  %1 = icmp eq i64 %0, 1
-  br i1 %1, label %then0__1, label %else__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-continue__1:                                      ; preds = %else__1, %then0__1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__X__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
-  %1 = icmp eq i64 %0, 1
-  br i1 %1, label %then0__1, label %else__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-continue__1:                                      ; preds = %else__1, %then0__1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Y__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 3, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Y__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 3, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Y__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
-  %1 = icmp eq i64 %0, 1
-  br i1 %1, label %then0__1, label %else__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 4, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 5, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-continue__1:                                      ; preds = %else__1, %then0__1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Y__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
-  %1 = icmp eq i64 %0, 1
-  br i1 %1, label %then0__1, label %else__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 4, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 5, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-continue__1:                                      ; preds = %else__1, %then0__1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Z__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 6, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Z__adj(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__single_qubit_op(i64 6, i64 1, %Qubit* %qb)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Z__ctl(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
-  %1 = icmp eq i64 %0, 1
-  br i1 %1, label %then0__1, label %else__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 7, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 8, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-continue__1:                                      ; preds = %else__1, %then0__1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
-
-define void @Microsoft__Quantum__Intrinsic__Z__ctladj(%Array* %ctls, %Qubit* %qb) {
-entry:
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
-  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
-  %1 = icmp eq i64 %0, 1
-  br i1 %1, label %then0__1, label %else__1
-
-then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 7, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 8, i64 1, %Array* %ctls, %Qubit* %qb)
-  br label %continue__1
-
-continue__1:                                      ; preds = %else__1, %then0__1
-  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
-  ret void
-}
 
 define void @Microsoft__Quantum__Testing__Tracer__Fixup__body(%Array* %qs) {
 entry:
@@ -847,6 +45,14 @@ exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__array_update_alias_count(%Array* %qs, i64 -1)
   ret void
 }
+
+declare void @__quantum__rt__array_update_alias_count(%Array*, i64)
+
+declare i64 @__quantum__rt__array_get_size_1d(%Array*)
+
+declare i8* @__quantum__rt__array_get_element_ptr_1d(%Array*, i64)
+
+declare void @__quantum__qis__single_qubit_op(i64, i64, %Qubit*)
 
 define void @Microsoft__Quantum__Testing__Tracer__TestCoreIntrinsics__body() {
 entry:
@@ -895,23 +101,23 @@ entry:
   %23 = bitcast i8* %22 to %Qubit**
   %qb__9 = load %Qubit*, %Qubit** %23
   call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb__9)
-  call void @__quantum__qis__inject_barrier(i64 42, i64 1)
+  call void @__quantum__qis__inject_barrier(i64 42, i64 0)
   %24 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %25 = bitcast i8* %24 to %Qubit**
   %qb__11 = load %Qubit*, %Qubit** %25
   call void @__quantum__qis__single_qubit_op(i64 0, i64 1, %Qubit* %qb__11)
   %26 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %27 = bitcast i8* %26 to %Qubit**
-  %qb__12 = load %Qubit*, %Qubit** %27
-  call void @__quantum__qis__single_qubit_op(i64 3, i64 1, %Qubit* %qb__12)
+  %qb__13 = load %Qubit*, %Qubit** %27
+  call void @__quantum__qis__single_qubit_op(i64 3, i64 1, %Qubit* %qb__13)
   %28 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %29 = bitcast i8* %28 to %Qubit**
-  %qb__13 = load %Qubit*, %Qubit** %29
-  call void @__quantum__qis__single_qubit_op(i64 6, i64 1, %Qubit* %qb__13)
+  %qb__15 = load %Qubit*, %Qubit** %29
+  call void @__quantum__qis__single_qubit_op(i64 6, i64 1, %Qubit* %qb__15)
   %30 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %31 = bitcast i8* %30 to %Qubit**
-  %qb__14 = load %Qubit*, %Qubit** %31
-  call void @__quantum__qis__single_qubit_op(i64 9, i64 1, %Qubit* %qb__14)
+  %qb__17 = load %Qubit*, %Qubit** %31
+  call void @__quantum__qis__single_qubit_op(i64 9, i64 1, %Qubit* %qb__17)
   %32 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %33 = bitcast i8* %32 to %Qubit**
   %34 = load %Qubit*, %Qubit** %33
@@ -921,24 +127,24 @@ entry:
   call void @Microsoft__Quantum__Intrinsic__CNOT__adj(%Qubit* %34, %Qubit* %37)
   %38 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %39 = bitcast i8* %38 to %Qubit**
-  %qb__15 = load %Qubit*, %Qubit** %39
-  call void @__quantum__qis__single_qubit_op(i64 19, i64 1, %Qubit* %qb__15)
+  %qb__19 = load %Qubit*, %Qubit** %39
+  call void @__quantum__qis__single_qubit_op(i64 19, i64 1, %Qubit* %qb__19)
   %40 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %41 = bitcast i8* %40 to %Qubit**
-  %qb__16 = load %Qubit*, %Qubit** %41
-  call void @__quantum__qis__single_qubit_op(i64 21, i64 1, %Qubit* %qb__16)
+  %qb__20 = load %Qubit*, %Qubit** %41
+  call void @__quantum__qis__single_qubit_op(i64 21, i64 1, %Qubit* %qb__20)
   %42 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 2)
   %43 = bitcast i8* %42 to %Qubit**
-  %qb__17 = load %Qubit*, %Qubit** %43
-  call void @__quantum__qis__single_qubit_op(i64 24, i64 1, %Qubit* %qb__17)
+  %qb__21 = load %Qubit*, %Qubit** %43
+  call void @__quantum__qis__single_qubit_op(i64 24, i64 1, %Qubit* %qb__21)
   %44 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %45 = bitcast i8* %44 to %Qubit**
-  %qb__18 = load %Qubit*, %Qubit** %45
-  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb__18)
+  %qb__22 = load %Qubit*, %Qubit** %45
+  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb__22)
   %46 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 2)
   %47 = bitcast i8* %46 to %Qubit**
-  %qb__20 = load %Qubit*, %Qubit** %47
-  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb__20)
+  %qb__24 = load %Qubit*, %Qubit** %47
+  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb__24)
   %c = call %Qubit* @__quantum__rt__qubit_allocate()
   %ctls = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %48 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %ctls, i64 0)
@@ -947,15 +153,15 @@ entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
   %50 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %51 = bitcast i8* %50 to %Qubit**
-  %qb__22 = load %Qubit*, %Qubit** %51
+  %qb__26 = load %Qubit*, %Qubit** %51
   br i1 true, label %then0__1, label %else__1
 
 then0__1:                                         ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls, %Qubit* %qb__22)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls, %Qubit* %qb__26)
   br label %continue__1
 
 else__1:                                          ; preds = %entry
-  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls, %Qubit* %qb__22)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls, %Qubit* %qb__26)
   br label %continue__1
 
 continue__1:                                      ; preds = %else__1, %then0__1
@@ -968,15 +174,15 @@ continue__1:                                      ; preds = %else__1, %then0__1
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__1, i64 1)
   %54 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %55 = bitcast i8* %54 to %Qubit**
-  %qb__23 = load %Qubit*, %Qubit** %55
+  %qb__27 = load %Qubit*, %Qubit** %55
   br i1 true, label %then0__2, label %else__2
 
 then0__2:                                         ; preds = %continue__1
-  call void @__quantum__qis__single_qubit_op_ctl(i64 4, i64 1, %Array* %ctls__1, %Qubit* %qb__23)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 4, i64 1, %Array* %ctls__1, %Qubit* %qb__27)
   br label %continue__2
 
 else__2:                                          ; preds = %continue__1
-  call void @__quantum__qis__single_qubit_op_ctl(i64 5, i64 1, %Array* %ctls__1, %Qubit* %qb__23)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 5, i64 1, %Array* %ctls__1, %Qubit* %qb__27)
   br label %continue__2
 
 continue__2:                                      ; preds = %else__2, %then0__2
@@ -989,15 +195,15 @@ continue__2:                                      ; preds = %else__2, %then0__2
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__2, i64 1)
   %58 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %59 = bitcast i8* %58 to %Qubit**
-  %qb__24 = load %Qubit*, %Qubit** %59
+  %qb__28 = load %Qubit*, %Qubit** %59
   br i1 true, label %then0__3, label %else__3
 
 then0__3:                                         ; preds = %continue__2
-  call void @__quantum__qis__single_qubit_op_ctl(i64 7, i64 1, %Array* %ctls__2, %Qubit* %qb__24)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 7, i64 1, %Array* %ctls__2, %Qubit* %qb__28)
   br label %continue__3
 
 else__3:                                          ; preds = %continue__2
-  call void @__quantum__qis__single_qubit_op_ctl(i64 8, i64 1, %Array* %ctls__2, %Qubit* %qb__24)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 8, i64 1, %Array* %ctls__2, %Qubit* %qb__28)
   br label %continue__3
 
 continue__3:                                      ; preds = %else__3, %then0__3
@@ -1010,8 +216,8 @@ continue__3:                                      ; preds = %else__3, %then0__3
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__3, i64 1)
   %62 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %63 = bitcast i8* %62 to %Qubit**
-  %qb__25 = load %Qubit*, %Qubit** %63
-  call void @__quantum__qis__single_qubit_op_ctl(i64 10, i64 1, %Array* %ctls__3, %Qubit* %qb__25)
+  %qb__29 = load %Qubit*, %Qubit** %63
+  call void @__quantum__qis__single_qubit_op_ctl(i64 10, i64 1, %Array* %ctls__3, %Qubit* %qb__29)
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__3, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %ctls__3, i64 -1)
   %ctls__4 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
@@ -1021,8 +227,8 @@ continue__3:                                      ; preds = %else__3, %then0__3
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__4, i64 1)
   %66 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %67 = bitcast i8* %66 to %Qubit**
-  %qb__26 = load %Qubit*, %Qubit** %67
-  call void @__quantum__qis__single_qubit_op_ctl(i64 20, i64 1, %Array* %ctls__4, %Qubit* %qb__26)
+  %qb__30 = load %Qubit*, %Qubit** %67
+  call void @__quantum__qis__single_qubit_op_ctl(i64 20, i64 1, %Array* %ctls__4, %Qubit* %qb__30)
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__4, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %ctls__4, i64 -1)
   %ctls__5 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
@@ -1032,8 +238,8 @@ continue__3:                                      ; preds = %else__3, %then0__3
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__5, i64 1)
   %70 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %71 = bitcast i8* %70 to %Qubit**
-  %qb__27 = load %Qubit*, %Qubit** %71
-  call void @__quantum__qis__single_qubit_op_ctl(i64 22, i64 1, %Array* %ctls__5, %Qubit* %qb__27)
+  %qb__31 = load %Qubit*, %Qubit** %71
+  call void @__quantum__qis__single_qubit_op_ctl(i64 22, i64 1, %Array* %ctls__5, %Qubit* %qb__31)
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__5, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %ctls__5, i64 -1)
   %ctls__6 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
@@ -1043,8 +249,8 @@ continue__3:                                      ; preds = %else__3, %then0__3
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__6, i64 1)
   %74 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 2)
   %75 = bitcast i8* %74 to %Qubit**
-  %qb__28 = load %Qubit*, %Qubit** %75
-  call void @__quantum__qis__single_qubit_op_ctl(i64 25, i64 1, %Array* %ctls__6, %Qubit* %qb__28)
+  %qb__32 = load %Qubit*, %Qubit** %75
+  call void @__quantum__qis__single_qubit_op_ctl(i64 25, i64 1, %Array* %ctls__6, %Qubit* %qb__32)
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__6, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %ctls__6, i64 -1)
   %ctls__7 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
@@ -1054,9 +260,9 @@ continue__3:                                      ; preds = %else__3, %then0__3
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__7, i64 1)
   %78 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %79 = bitcast i8* %78 to %Qubit**
-  %qb__29 = load %Qubit*, %Qubit** %79
+  %qb__33 = load %Qubit*, %Qubit** %79
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__7, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls__7, %Qubit* %qb__29)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls__7, %Qubit* %qb__33)
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__7, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__7, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %ctls__7, i64 -1)
@@ -1067,9 +273,9 @@ continue__3:                                      ; preds = %else__3, %then0__3
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__9, i64 1)
   %82 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 2)
   %83 = bitcast i8* %82 to %Qubit**
-  %qb__31 = load %Qubit*, %Qubit** %83
+  %qb__35 = load %Qubit*, %Qubit** %83
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__9, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls__9, %Qubit* %qb__31)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls__9, %Qubit* %qb__35)
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__9, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %ctls__9, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %ctls__9, i64 -1)
@@ -1079,17 +285,17 @@ continue__3:                                      ; preds = %else__3, %then0__3
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %84 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %85 = bitcast i8* %84 to %Qubit**
-  %qb__33 = load %Qubit*, %Qubit** %85
+  %qb__37 = load %Qubit*, %Qubit** %85
   %86 = call i64 @__quantum__rt__array_get_size_1d(%Array* %cc)
   %87 = icmp eq i64 %86, 1
   br i1 %87, label %then0__4, label %else__4
 
 then0__4:                                         ; preds = %continue__3
-  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %cc, %Qubit* %qb__33)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %cc, %Qubit* %qb__37)
   br label %continue__4
 
 else__4:                                          ; preds = %continue__3
-  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %cc, %Qubit* %qb__33)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %cc, %Qubit* %qb__37)
   br label %continue__4
 
 continue__4:                                      ; preds = %else__4, %then0__4
@@ -1097,16 +303,16 @@ continue__4:                                      ; preds = %else__4, %then0__4
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %88 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %89 = bitcast i8* %88 to %Qubit**
-  %qb__34 = load %Qubit*, %Qubit** %89
+  %qb__38 = load %Qubit*, %Qubit** %89
   %90 = icmp eq i64 %86, 1
   br i1 %90, label %then0__5, label %else__5
 
 then0__5:                                         ; preds = %continue__4
-  call void @__quantum__qis__single_qubit_op_ctl(i64 4, i64 1, %Array* %cc, %Qubit* %qb__34)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 4, i64 1, %Array* %cc, %Qubit* %qb__38)
   br label %continue__5
 
 else__5:                                          ; preds = %continue__4
-  call void @__quantum__qis__single_qubit_op_ctl(i64 5, i64 1, %Array* %cc, %Qubit* %qb__34)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 5, i64 1, %Array* %cc, %Qubit* %qb__38)
   br label %continue__5
 
 continue__5:                                      ; preds = %else__5, %then0__5
@@ -1114,16 +320,16 @@ continue__5:                                      ; preds = %else__5, %then0__5
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %91 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %92 = bitcast i8* %91 to %Qubit**
-  %qb__35 = load %Qubit*, %Qubit** %92
+  %qb__39 = load %Qubit*, %Qubit** %92
   %93 = icmp eq i64 %86, 1
   br i1 %93, label %then0__6, label %else__6
 
 then0__6:                                         ; preds = %continue__5
-  call void @__quantum__qis__single_qubit_op_ctl(i64 7, i64 1, %Array* %cc, %Qubit* %qb__35)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 7, i64 1, %Array* %cc, %Qubit* %qb__39)
   br label %continue__6
 
 else__6:                                          ; preds = %continue__5
-  call void @__quantum__qis__single_qubit_op_ctl(i64 8, i64 1, %Array* %cc, %Qubit* %qb__35)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 8, i64 1, %Array* %cc, %Qubit* %qb__39)
   br label %continue__6
 
 continue__6:                                      ; preds = %else__6, %then0__6
@@ -1131,41 +337,41 @@ continue__6:                                      ; preds = %else__6, %then0__6
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %94 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %95 = bitcast i8* %94 to %Qubit**
-  %qb__36 = load %Qubit*, %Qubit** %95
-  call void @__quantum__qis__single_qubit_op_ctl(i64 10, i64 1, %Array* %cc, %Qubit* %qb__36)
+  %qb__40 = load %Qubit*, %Qubit** %95
+  call void @__quantum__qis__single_qubit_op_ctl(i64 10, i64 1, %Array* %cc, %Qubit* %qb__40)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %96 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 0)
   %97 = bitcast i8* %96 to %Qubit**
-  %qb__37 = load %Qubit*, %Qubit** %97
-  call void @__quantum__qis__single_qubit_op_ctl(i64 20, i64 1, %Array* %cc, %Qubit* %qb__37)
+  %qb__41 = load %Qubit*, %Qubit** %97
+  call void @__quantum__qis__single_qubit_op_ctl(i64 20, i64 1, %Array* %cc, %Qubit* %qb__41)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %98 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %99 = bitcast i8* %98 to %Qubit**
-  %qb__38 = load %Qubit*, %Qubit** %99
-  call void @__quantum__qis__single_qubit_op_ctl(i64 22, i64 1, %Array* %cc, %Qubit* %qb__38)
+  %qb__42 = load %Qubit*, %Qubit** %99
+  call void @__quantum__qis__single_qubit_op_ctl(i64 22, i64 1, %Array* %cc, %Qubit* %qb__42)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %100 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 2)
   %101 = bitcast i8* %100 to %Qubit**
-  %qb__39 = load %Qubit*, %Qubit** %101
-  call void @__quantum__qis__single_qubit_op_ctl(i64 25, i64 1, %Array* %cc, %Qubit* %qb__39)
+  %qb__43 = load %Qubit*, %Qubit** %101
+  call void @__quantum__qis__single_qubit_op_ctl(i64 25, i64 1, %Array* %cc, %Qubit* %qb__43)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %102 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 1)
   %103 = bitcast i8* %102 to %Qubit**
-  %qb__40 = load %Qubit*, %Qubit** %103
+  %qb__44 = load %Qubit*, %Qubit** %103
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %cc, %Qubit* %qb__40)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %cc, %Qubit* %qb__44)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
   %104 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qs, i64 2)
   %105 = bitcast i8* %104 to %Qubit**
-  %qb__42 = load %Qubit*, %Qubit** %105
+  %qb__46 = load %Qubit*, %Qubit** %105
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 1)
-  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %cc, %Qubit* %qb__42)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %cc, %Qubit* %qb__46)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 -1)
   call void @__quantum__rt__array_update_alias_count(%Array* %cc, i64 -1)
   call void @__quantum__rt__qubit_release_array(%Array* %cc)
@@ -1181,7 +387,42 @@ declare %Qubit* @__quantum__rt__qubit_allocate()
 
 declare %Array* @__quantum__rt__qubit_allocate_array(i64)
 
+define void @Microsoft__Quantum__Intrinsic__CNOT__body(%Qubit* %control, %Qubit* %target) {
+entry:
+  %ctls = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %ctls, i64 0)
+  %1 = bitcast i8* %0 to %Qubit**
+  store %Qubit* %control, %Qubit** %1
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  br i1 true, label %then0__1, label %else__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls, %Qubit* %target)
+  br label %continue__1
+
+else__1:                                          ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls, %Qubit* %target)
+  br label %continue__1
+
+continue__1:                                      ; preds = %else__1, %then0__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
 declare void @__quantum__qis__inject_barrier(i64, i64)
+
+define void @Microsoft__Quantum__Intrinsic__CNOT__adj(%Qubit* %control, %Qubit* %target) {
+entry:
+  call void @Microsoft__Quantum__Intrinsic__CNOT__body(%Qubit* %control, %Qubit* %target)
+  ret void
+}
+
+declare %Array* @__quantum__rt__array_create_1d(i32, i64)
+
+declare void @__quantum__qis__single_qubit_op_ctl(i64, i64, %Array*, %Qubit*)
+
+declare void @__quantum__rt__array_update_reference_count(%Array*, i64)
 
 declare void @__quantum__rt__qubit_release(%Qubit*)
 
@@ -1335,7 +576,9 @@ test3__1:                                         ; preds = %test2__1
   br i1 %59, label %then3__1, label %test4__1
 
 then3__1:                                         ; preds = %test3__1
-  %60 = call %Result* @__quantum__qis__joint_measure(i64 108, i64 1, %Array* %qs12)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qs12, i64 1)
+  %60 = call %Result* @__quantum__qis__joint_measure(i64 105, i64 1, %Array* %qs12)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qs12, i64 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %60, i64 1)
   %61 = load %Result*, %Result** %res
   store %Result* %60, %Result** %res
@@ -1358,7 +601,9 @@ test4__1:                                         ; preds = %test3__1
   br i1 %72, label %then4__1, label %test5__1
 
 then4__1:                                         ; preds = %test4__1
-  %73 = call %Result* @__quantum__qis__joint_measure(i64 109, i64 1, %Array* %qs12)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qs12, i64 1)
+  %73 = call %Result* @__quantum__qis__joint_measure(i64 103, i64 1, %Array* %qs12)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qs12, i64 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %73, i64 1)
   %74 = load %Result*, %Result** %res
   store %Result* %73, %Result** %res
@@ -1381,7 +626,9 @@ test5__1:                                         ; preds = %test4__1
   br i1 %85, label %then5__1, label %test6__1
 
 then5__1:                                         ; preds = %test5__1
-  %86 = call %Result* @__quantum__qis__joint_measure(i64 110, i64 1, %Array* %qs12)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qs12, i64 1)
+  %86 = call %Result* @__quantum__qis__joint_measure(i64 104, i64 1, %Array* %qs12)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qs12, i64 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %86, i64 1)
   %87 = load %Result*, %Result** %res
   store %Result* %86, %Result** %res
@@ -1404,7 +651,9 @@ test6__1:                                         ; preds = %test5__1
   br i1 %98, label %then6__1, label %continue__2
 
 then6__1:                                         ; preds = %test6__1
-  %99 = call %Result* @__quantum__qis__joint_measure(i64 111, i64 1, %Array* %qs12)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qs12, i64 1)
+  %99 = call %Result* @__quantum__qis__joint_measure(i64 102, i64 1, %Array* %qs12)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qs12, i64 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %99, i64 1)
   %100 = load %Result*, %Result** %res
   store %Result* %99, %Result** %res
@@ -1445,18 +694,836 @@ continue__4:                                      ; preds = %continue__5, %conti
   ret void
 }
 
+declare %Result* @__quantum__qis__single_qubit_measure(i64, i64, %Qubit*)
+
+declare void @__quantum__rt__result_update_reference_count(%Result*, i64)
+
+declare %Result* @__quantum__qis__joint_measure(i64, i64, %Array*)
+
 declare i1 @__quantum__rt__result_equal(%Result*, %Result*)
+
+define void @Microsoft__Quantum__Intrinsic__CNOT__ctl(%Array* %ctls, { %Qubit*, %Qubit* }* %0) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %1 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i32 0, i32 0
+  %control = load %Qubit*, %Qubit** %1
+  %2 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i32 0, i32 1
+  %target = load %Qubit*, %Qubit** %2
+  %3 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %3, i64 0)
+  %5 = bitcast i8* %4 to %Qubit**
+  store %Qubit* %control, %Qubit** %5
+  %ctls__1 = call %Array* @__quantum__rt__array_concatenate(%Array* %ctls, %Array* %3)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls__1, i64 1)
+  %6 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls__1)
+  %7 = icmp eq i64 %6, 1
+  br i1 %7, label %then0__1, label %else__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls__1, %Qubit* %target)
+  br label %continue__1
+
+else__1:                                          ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls__1, %Qubit* %target)
+  br label %continue__1
+
+continue__1:                                      ; preds = %else__1, %then0__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls__1, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %3, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %ctls__1, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+declare %Array* @__quantum__rt__array_concatenate(%Array*, %Array*)
+
+define void @Microsoft__Quantum__Intrinsic__CNOT__ctladj(%Array* %__controlQubits__, { %Qubit*, %Qubit* }* %0) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  %1 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i32 0, i32 0
+  %control = load %Qubit*, %Qubit** %1
+  %2 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i32 0, i32 1
+  %target = load %Qubit*, %Qubit** %2
+  %3 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %4 = bitcast %Tuple* %3 to { %Qubit*, %Qubit* }*
+  %5 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %4, i32 0, i32 0
+  %6 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %4, i32 0, i32 1
+  store %Qubit* %control, %Qubit** %5
+  store %Qubit* %target, %Qubit** %6
+  call void @Microsoft__Quantum__Intrinsic__CNOT__ctl(%Array* %__controlQubits__, { %Qubit*, %Qubit* }* %4)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %3, i64 -1)
+  ret void
+}
+
+declare %Tuple* @__quantum__rt__tuple_create(i64)
+
+declare void @__quantum__rt__tuple_update_reference_count(%Tuple*, i64)
+
+define void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 9, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__H__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 9, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__H__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 10, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__H__ctladj(%Array* %__controlQubits__, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 10, i64 1, %Array* %__controlQubits__, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  ret void
+}
+
+define %Result* @Microsoft__Quantum__Intrinsic__M__body(%Qubit* %qb) {
+entry:
+  %0 = call %Result* @__quantum__qis__single_qubit_measure(i64 100, i64 1, %Qubit* %qb)
+  ret %Result* %0
+}
+
+define %Result* @Microsoft__Quantum__Intrinsic__Measure__body(%Array* %paulis, %Array* %qubits) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %paulis, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %0 = load %Result*, %Result** @ResultOne
+  %res = alloca %Result*
+  store %Result* %0, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %0, i64 1)
+  %haveY = alloca i1
+  store i1 false, i1* %haveY
+  %1 = call i64 @__quantum__rt__array_get_size_1d(%Array* %paulis)
+  %2 = sub i64 %1, 1
+  br label %header__1
+
+header__1:                                        ; preds = %exiting__1, %entry
+  %i = phi i64 [ 0, %entry ], [ %15, %exiting__1 ]
+  %3 = icmp sle i64 %i, %2
+  br i1 %3, label %body__1, label %exit__1
+
+body__1:                                          ; preds = %header__1
+  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 %i)
+  %5 = bitcast i8* %4 to i2*
+  %6 = load i2, i2* %5
+  %7 = load i2, i2* @PauliY
+  %8 = icmp eq i2 %6, %7
+  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 %i)
+  %10 = bitcast i8* %9 to i2*
+  %11 = load i2, i2* %10
+  %12 = load i2, i2* @PauliI
+  %13 = icmp eq i2 %11, %12
+  %14 = or i1 %8, %13
+  br i1 %14, label %then0__1, label %continue__1
+
+then0__1:                                         ; preds = %body__1
+  store i1 true, i1* %haveY
+  br label %continue__1
+
+continue__1:                                      ; preds = %then0__1, %body__1
+  br label %exiting__1
+
+exiting__1:                                       ; preds = %continue__1
+  %15 = add i64 %i, 1
+  br label %header__1
+
+exit__1:                                          ; preds = %header__1
+  %16 = load i1, i1* %haveY
+  br i1 %16, label %then0__2, label %test1__1
+
+then0__2:                                         ; preds = %exit__1
+  %17 = call %Result* @__quantum__qis__joint_measure(i64 106, i64 1, %Array* %qubits)
+  call void @__quantum__rt__result_update_reference_count(%Result* %17, i64 1)
+  store %Result* %17, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %17, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %0, i64 -1)
+  br label %continue__2
+
+test1__1:                                         ; preds = %exit__1
+  %18 = icmp sgt i64 %1, 2
+  br i1 %18, label %then1__1, label %test2__1
+
+then1__1:                                         ; preds = %test1__1
+  %19 = call %Result* @__quantum__qis__joint_measure(i64 107, i64 1, %Array* %qubits)
+  call void @__quantum__rt__result_update_reference_count(%Result* %19, i64 1)
+  %20 = load %Result*, %Result** %res
+  store %Result* %19, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %19, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %20, i64 -1)
+  br label %continue__2
+
+test2__1:                                         ; preds = %test1__1
+  %21 = icmp eq i64 %1, 1
+  br i1 %21, label %then2__1, label %test3__1
+
+then2__1:                                         ; preds = %test2__1
+  %22 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
+  %23 = bitcast i8* %22 to i2*
+  %24 = load i2, i2* %23
+  %25 = load i2, i2* @PauliX
+  %26 = icmp eq i2 %24, %25
+  br i1 %26, label %then0__3, label %else__1
+
+then0__3:                                         ; preds = %then2__1
+  %27 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qubits, i64 0)
+  %28 = bitcast i8* %27 to %Qubit**
+  %qb = load %Qubit*, %Qubit** %28
+  %29 = call %Result* @__quantum__qis__single_qubit_measure(i64 101, i64 1, %Qubit* %qb)
+  call void @__quantum__rt__result_update_reference_count(%Result* %29, i64 1)
+  %30 = load %Result*, %Result** %res
+  store %Result* %29, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %29, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %30, i64 -1)
+  br label %continue__3
+
+else__1:                                          ; preds = %then2__1
+  %31 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %qubits, i64 0)
+  %32 = bitcast i8* %31 to %Qubit**
+  %qb__1 = load %Qubit*, %Qubit** %32
+  %33 = call %Result* @__quantum__qis__single_qubit_measure(i64 100, i64 1, %Qubit* %qb__1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %33, i64 1)
+  %34 = load %Result*, %Result** %res
+  store %Result* %33, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %33, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %34, i64 -1)
+  br label %continue__3
+
+continue__3:                                      ; preds = %else__1, %then0__3
+  br label %continue__2
+
+test3__1:                                         ; preds = %test2__1
+  %35 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
+  %36 = bitcast i8* %35 to i2*
+  %37 = load i2, i2* %36
+  %38 = load i2, i2* @PauliX
+  %39 = icmp eq i2 %37, %38
+  %40 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 1)
+  %41 = bitcast i8* %40 to i2*
+  %42 = load i2, i2* %41
+  %43 = load i2, i2* @PauliX
+  %44 = icmp eq i2 %42, %43
+  %45 = and i1 %39, %44
+  br i1 %45, label %then3__1, label %test4__1
+
+then3__1:                                         ; preds = %test3__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %46 = call %Result* @__quantum__qis__joint_measure(i64 105, i64 1, %Array* %qubits)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %46, i64 1)
+  %47 = load %Result*, %Result** %res
+  store %Result* %46, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %46, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %47, i64 -1)
+  br label %continue__2
+
+test4__1:                                         ; preds = %test3__1
+  %48 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
+  %49 = bitcast i8* %48 to i2*
+  %50 = load i2, i2* %49
+  %51 = load i2, i2* @PauliX
+  %52 = icmp eq i2 %50, %51
+  %53 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 1)
+  %54 = bitcast i8* %53 to i2*
+  %55 = load i2, i2* %54
+  %56 = load i2, i2* @PauliZ
+  %57 = icmp eq i2 %55, %56
+  %58 = and i1 %52, %57
+  br i1 %58, label %then4__1, label %test5__1
+
+then4__1:                                         ; preds = %test4__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %59 = call %Result* @__quantum__qis__joint_measure(i64 103, i64 1, %Array* %qubits)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %59, i64 1)
+  %60 = load %Result*, %Result** %res
+  store %Result* %59, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %59, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %60, i64 -1)
+  br label %continue__2
+
+test5__1:                                         ; preds = %test4__1
+  %61 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
+  %62 = bitcast i8* %61 to i2*
+  %63 = load i2, i2* %62
+  %64 = load i2, i2* @PauliZ
+  %65 = icmp eq i2 %63, %64
+  %66 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 1)
+  %67 = bitcast i8* %66 to i2*
+  %68 = load i2, i2* %67
+  %69 = load i2, i2* @PauliX
+  %70 = icmp eq i2 %68, %69
+  %71 = and i1 %65, %70
+  br i1 %71, label %then5__1, label %test6__1
+
+then5__1:                                         ; preds = %test5__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %72 = call %Result* @__quantum__qis__joint_measure(i64 104, i64 1, %Array* %qubits)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %72, i64 1)
+  %73 = load %Result*, %Result** %res
+  store %Result* %72, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %72, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %73, i64 -1)
+  br label %continue__2
+
+test6__1:                                         ; preds = %test5__1
+  %74 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 0)
+  %75 = bitcast i8* %74 to i2*
+  %76 = load i2, i2* %75
+  %77 = load i2, i2* @PauliZ
+  %78 = icmp eq i2 %76, %77
+  %79 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %paulis, i64 1)
+  %80 = bitcast i8* %79 to i2*
+  %81 = load i2, i2* %80
+  %82 = load i2, i2* @PauliZ
+  %83 = icmp eq i2 %81, %82
+  %84 = and i1 %78, %83
+  br i1 %84, label %then6__1, label %continue__2
+
+then6__1:                                         ; preds = %test6__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %85 = call %Result* @__quantum__qis__joint_measure(i64 102, i64 1, %Array* %qubits)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %85, i64 1)
+  %86 = load %Result*, %Result** %res
+  store %Result* %85, %Result** %res
+  call void @__quantum__rt__result_update_reference_count(%Result* %85, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %86, i64 -1)
+  br label %continue__2
+
+continue__2:                                      ; preds = %then6__1, %test6__1, %then5__1, %then4__1, %then3__1, %continue__3, %then1__1, %then0__2
+  %87 = load %Result*, %Result** %res
+  call void @__quantum__rt__array_update_alias_count(%Array* %paulis, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  ret %Result* %87
+}
+
+define void @Microsoft__Quantum__Intrinsic__Rx__body(double %theta, %Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 19, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Rx__adj(double %theta, %Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 19, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Rx__ctl(%Array* %ctls, { double, %Qubit* }* %0) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
+  %theta = load double, double* %1
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
+  %qb = load %Qubit*, %Qubit** %2
+  call void @__quantum__qis__single_qubit_op_ctl(i64 20, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Rx__ctladj(%Array* %ctls, { double, %Qubit* }* %0) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
+  %theta = load double, double* %1
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
+  %qb = load %Qubit*, %Qubit** %2
+  call void @__quantum__qis__single_qubit_op_ctl(i64 20, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Ry__body(double %theta, %Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 21, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Ry__adj(double %theta, %Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 21, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Ry__ctl(%Array* %ctls, { double, %Qubit* }* %0) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
+  %theta = load double, double* %1
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
+  %qb = load %Qubit*, %Qubit** %2
+  call void @__quantum__qis__single_qubit_op_ctl(i64 22, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Ry__ctladj(%Array* %ctls, { double, %Qubit* }* %0) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
+  %theta = load double, double* %1
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
+  %qb = load %Qubit*, %Qubit** %2
+  call void @__quantum__qis__single_qubit_op_ctl(i64 22, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Rz__body(double %theta, %Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 23, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Rz__adj(double %theta, %Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 24, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Rz__ctl(%Array* %ctls, { double, %Qubit* }* %0) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
+  %theta = load double, double* %1
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
+  %qb = load %Qubit*, %Qubit** %2
+  call void @__quantum__qis__single_qubit_op_ctl(i64 25, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Rz__ctladj(%Array* %ctls, { double, %Qubit* }* %0) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
+  %theta = load double, double* %1
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
+  %qb = load %Qubit*, %Qubit** %2
+  call void @__quantum__qis__single_qubit_op_ctl(i64 25, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__S__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__S__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__S__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__S__ctladj(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__T__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__T__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__T__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__T__ctladj(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__X__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 0, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__X__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 0, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__X__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
+  %1 = icmp eq i64 %0, 1
+  br i1 %1, label %then0__1, label %else__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %ctls, %Qubit* %qb)
+  br label %continue__1
+
+else__1:                                          ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %ctls, %Qubit* %qb)
+  br label %continue__1
+
+continue__1:                                      ; preds = %else__1, %then0__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__X__ctladj(%Array* %__controlQubits__, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %__controlQubits__)
+  %1 = icmp eq i64 %0, 1
+  br i1 %1, label %then0__1, label %else__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 1, i64 1, %Array* %__controlQubits__, %Qubit* %qb)
+  br label %continue__1
+
+else__1:                                          ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 2, i64 1, %Array* %__controlQubits__, %Qubit* %qb)
+  br label %continue__1
+
+continue__1:                                      ; preds = %else__1, %then0__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Y__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 3, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Y__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 3, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Y__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
+  %1 = icmp eq i64 %0, 1
+  br i1 %1, label %then0__1, label %else__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 4, i64 1, %Array* %ctls, %Qubit* %qb)
+  br label %continue__1
+
+else__1:                                          ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 5, i64 1, %Array* %ctls, %Qubit* %qb)
+  br label %continue__1
+
+continue__1:                                      ; preds = %else__1, %then0__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Y__ctladj(%Array* %__controlQubits__, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %__controlQubits__)
+  %1 = icmp eq i64 %0, 1
+  br i1 %1, label %then0__1, label %else__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 4, i64 1, %Array* %__controlQubits__, %Qubit* %qb)
+  br label %continue__1
+
+else__1:                                          ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 5, i64 1, %Array* %__controlQubits__, %Qubit* %qb)
+  br label %continue__1
+
+continue__1:                                      ; preds = %else__1, %then0__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Z__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 6, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Z__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 6, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Z__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %ctls)
+  %1 = icmp eq i64 %0, 1
+  br i1 %1, label %then0__1, label %else__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 7, i64 1, %Array* %ctls, %Qubit* %qb)
+  br label %continue__1
+
+else__1:                                          ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 8, i64 1, %Array* %ctls, %Qubit* %qb)
+  br label %continue__1
+
+continue__1:                                      ; preds = %else__1, %then0__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Intrinsic__Z__ctladj(%Array* %__controlQubits__, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
+  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %__controlQubits__)
+  %1 = icmp eq i64 %0, 1
+  br i1 %1, label %then0__1, label %else__1
+
+then0__1:                                         ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 7, i64 1, %Array* %__controlQubits__, %Qubit* %qb)
+  br label %continue__1
+
+else__1:                                          ; preds = %entry
+  call void @__quantum__qis__single_qubit_op_ctl(i64 8, i64 1, %Array* %__controlQubits__, %Qubit* %qb)
+  br label %continue__1
+
+continue__1:                                      ; preds = %else__1, %then0__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 -1)
+  ret void
+}
+
+define %Tuple* @Microsoft__Quantum__Core__Attribute__body() {
+entry:
+  ret %Tuple* null
+}
+
+define %Tuple* @Microsoft__Quantum__Core__EntryPoint__body() {
+entry:
+  ret %Tuple* null
+}
+
+define %Tuple* @Microsoft__Quantum__Core__Inline__body() {
+entry:
+  ret %Tuple* null
+}
+
+define %Result* @Microsoft__Quantum__Instructions__Mx__body(%Qubit* %qb) {
+entry:
+  %0 = call %Result* @__quantum__qis__single_qubit_measure(i64 101, i64 1, %Qubit* %qb)
+  ret %Result* %0
+}
+
+define %Result* @Microsoft__Quantum__Instructions__Mxx__body(%Array* %qubits) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %0 = call %Result* @__quantum__qis__joint_measure(i64 105, i64 1, %Array* %qubits)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  ret %Result* %0
+}
+
+define %Result* @Microsoft__Quantum__Instructions__Mxz__body(%Array* %qubits) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %0 = call %Result* @__quantum__qis__joint_measure(i64 103, i64 1, %Array* %qubits)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  ret %Result* %0
+}
+
+define %Result* @Microsoft__Quantum__Instructions__Mz__body(%Qubit* %qb) {
+entry:
+  %0 = call %Result* @__quantum__qis__single_qubit_measure(i64 100, i64 1, %Qubit* %qb)
+  ret %Result* %0
+}
+
+define %Result* @Microsoft__Quantum__Instructions__Mzx__body(%Array* %qubits) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %0 = call %Result* @__quantum__qis__joint_measure(i64 104, i64 1, %Array* %qubits)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  ret %Result* %0
+}
+
+define %Result* @Microsoft__Quantum__Instructions__Mzz__body(%Array* %qubits) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 1)
+  %0 = call %Result* @__quantum__qis__joint_measure(i64 102, i64 1, %Array* %qubits)
+  call void @__quantum__rt__array_update_alias_count(%Array* %qubits, i64 -1)
+  ret %Result* %0
+}
+
+define void @Microsoft__Quantum__Instructions__Sx__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 17, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Sx__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 17, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Sx__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 18, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Sx__ctladj(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 18, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Sz__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Sz__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 15, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Sz__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Sz__ctladj(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 16, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Tx__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 13, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Tx__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 13, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Tx__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 14, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Tx__ctladj(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 14, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Tz__body(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Tz__adj(%Qubit* %qb) {
+entry:
+  call void @__quantum__qis__single_qubit_op(i64 11, i64 1, %Qubit* %qb)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Tz__ctl(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
+
+define void @Microsoft__Quantum__Instructions__Tz__ctladj(%Array* %ctls, %Qubit* %qb) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 1)
+  call void @__quantum__qis__single_qubit_op_ctl(i64 12, i64 1, %Array* %ctls, %Qubit* %qb)
+  call void @__quantum__rt__array_update_alias_count(%Array* %ctls, i64 -1)
+  ret void
+}
 
 define { %String* }* @Microsoft__Quantum__Targeting__TargetInstruction__body(%String* %__Item1__) {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { %String* }*
-  %2 = getelementptr { %String* }, { %String* }* %1, i64 0, i32 0
+  %2 = getelementptr inbounds { %String* }, { %String* }* %1, i32 0, i32 0
   store %String* %__Item1__, %String** %2
   call void @__quantum__rt__string_update_reference_count(%String* %__Item1__, i64 1)
   ret { %String* }* %1
 }
-
-declare %Tuple* @__quantum__rt__tuple_create(i64)
 
 declare void @__quantum__rt__string_update_reference_count(%String*, i64)

--- a/src/QirRuntime/test/QIR-tracer/tracer-target.qs
+++ b/src/QirRuntime/test/QIR-tracer/tracer-target.qs
@@ -3,26 +3,35 @@
 
 namespace Microsoft.Quantum.Instructions {
 
+    // We'll use TargetInstruction attribute to suppress Q#'s compiler decoration of names for the generated callbacks.
+    open Microsoft.Quantum.Targeting;
+
+    @TargetInstruction("single_qubit_op")
     operation single_qubit_op(op_id: Int, duration: Int, qb : Qubit) : Unit {
         body intrinsic;
     }
 
+    @TargetInstruction("multi_qubit_op")
     operation multi_qubit_op(op_id: Int, duration: Int, qbs : Qubit[]) : Unit {
         body intrinsic;
     }
 
+    @TargetInstruction("single_qubit_op_ctl")
     operation single_qubit_op_ctl(op_id: Int, duration: Int, ctl : Qubit[], qb : Qubit) : Unit {
         body intrinsic;
     }
 
+    @TargetInstruction("multi_qubit_op_ctl")
     operation multi_qubit_op_ctl(op_id: Int, duration: Int, ctl : Qubit[], qbs : Qubit[]) : Unit {
         body intrinsic;
     }
 
+    @TargetInstruction("single_qubit_measure")
     operation single_qubit_measure(op_id: Int, duration: Int, qb : Qubit) : Result {
         body intrinsic;
     }
 
+    @TargetInstruction("joint_measure")
     operation joint_measure(op_id: Int, duration: Int, qbs : Qubit[]) : Result {
         body intrinsic;
     }
@@ -98,7 +107,9 @@ namespace Microsoft.Quantum.Instructions {
 
 namespace Microsoft.Quantum.Tracer {
 
-    @TargetInstruction("inject_global_barrier")
+    open Microsoft.Quantum.Targeting;
+
+    @TargetInstruction("inject_barrier")
     operation Barrier(id : Int, duration : Int) : Unit {
         body intrinsic;
     }
@@ -125,7 +136,7 @@ namespace Microsoft.Quantum.Intrinsic {
     is Adj + Ctl {
         body  (...) { Controlled X([control], target); }
         adjoint self;
-        controlled (ctls, ...) { Controlled X(ctls + control, target); }
+        controlled (ctls, ...) { Controlled X(ctls + [control], target); }
     }
 
     @Inline()
@@ -205,7 +216,7 @@ namespace Microsoft.Quantum.Intrinsic {
 
     @Inline()
     operation M(qb : Qubit) : Result {
-        body  (...) { return Phyz.Mz(qb); }
+        body  (...) { return Phys.Mz(qb); }
     }
 
     @Inline()
@@ -226,8 +237,8 @@ namespace Microsoft.Quantum.Intrinsic {
 
             // Single qubit measurement -- differentiate between Mx and Mz
             elif Length(paulis) == 1 {
-                if (paulis[0] == PauliX) { set res = Mx(qubits[0]); }
-                else { set res = Mz(qubits[0]); }
+                if (paulis[0] == PauliX) { set res = Phys.Mx(qubits[0]); }
+                else { set res = Phys.Mz(qubits[0]); }
             }
 
             // Specialize for two-qubit measurements: Mxx, Mxz, Mzx, Mzz


### PR DESCRIPTION
In response to PR comments I made some changes to target.qs but then forgot to regenerate it. This change fixes that and it also makes the Tracer to link in QIS bridge and support libs.