### PR TITLE
Updated Version Numbers

### DIFF
--- a/Simulation.sln
+++ b/Simulation.sln
@@ -63,7 +63,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IonQExe", "src\Simulation\S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QCIExe", "src\Simulation\Simulators.Tests\TestProjects\QCIExe\QCIExe.csproj", "{C015FF41-9A51-4AF0-AEFC-2547D596B10A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TargetedExe", "src\Simulation\Simulators.Tests\TestProjects\TargetedExe\TargetedExe.csproj", "{D292BF18-3956-4827-820E-254C3F81EF09}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TargetedExe", "src\Simulation\Simulators.Tests\TestProjects\TargetedExe\TargetedExe.csproj", "{D292BF18-3956-4827-820E-254C3F81EF09}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Quantum.QSharp.Foundation", "src\Simulation\QSharpFoundation\Microsoft.Quantum.QSharp.Foundation.csproj", "{DB45AD73-4D91-43F3-85CC-C63614A96FB0}"
 EndProject
@@ -71,7 +71,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Quantum.Type2.Cor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.Microsoft.Quantum.Simulators.Type2", "src\Simulation\Simulators.Type2.Tests\Tests.Microsoft.Quantum.Simulators.Type2.csproj", "{ED3D7040-4B3F-4217-A75E-9DF63DD84707}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntrinsicTests", "src\Simulation\Simulators.Tests\TestProjects\IntrinsicTests\IntrinsicTests.csproj", "{4EF958CA-B4A6-4E5F-924A-100B5615BEC3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntrinsicTests", "src\Simulation\Simulators.Tests\TestProjects\IntrinsicTests\IntrinsicTests.csproj", "{4EF958CA-B4A6-4E5F-924A-100B5615BEC3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.Microsoft.Quantum.Simulators.Type1", "src\Simulation\Simulators.Type1.Tests\Tests.Microsoft.Quantum.Simulators.Type1.csproj", "{EB6E3DBD-C884-4241-9BC4-8281191D1F53}"
 EndProject

--- a/src/Simulation/CSharpGeneration/Microsoft.Quantum.CSharpGeneration.fsproj
+++ b/src/Simulation/CSharpGeneration/Microsoft.Quantum.CSharpGeneration.fsproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.15.2102129527-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.15.210223649-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator.Tests/Tests.Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\Simulators.Dev.props" />

--- a/src/Simulation/QSharpCore/Microsoft.Quantum.QSharp.Core.csproj
+++ b/src/Simulation/QSharpCore/Microsoft.Quantum.QSharp.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
   <Import Project="..\TargetDefinitions\TargetPackages\QSharpCore.Package.props" />
 
   <PropertyGroup>

--- a/src/Simulation/QSharpFoundation/Microsoft.Quantum.QSharp.Foundation.csproj
+++ b/src/Simulation/QSharpFoundation/Microsoft.Quantum.QSharp.Foundation.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/HoneywellExe/HoneywellExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IonQExe/IonQExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CSharpGeneration>false</CSharpGeneration>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/QSharpExe/QSharpExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QSharpExe/QSharpExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators.Tests/Tests.Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\Common\Simulators.Test.props" />
 

--- a/src/Simulation/Simulators.Type1.Tests/Tests.Microsoft.Quantum.Simulators.Type1.csproj
+++ b/src/Simulation/Simulators.Type1.Tests/Tests.Microsoft.Quantum.Simulators.Type1.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\Common\Simulators.Test.props" />
 

--- a/src/Simulation/Simulators.Type2.Tests/Tests.Microsoft.Quantum.Simulators.Type2.csproj
+++ b/src/Simulation/Simulators.Type2.Tests/Tests.Microsoft.Quantum.Simulators.Type2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\Common\Simulators.Test.props" />
 

--- a/src/Simulation/Simulators.Type3.Tests/Tests.Microsoft.Quantum.Simulators.Type3.csproj
+++ b/src/Simulation/Simulators.Type3.Tests/Tests.Microsoft.Quantum.Simulators.Type3.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\Common\Simulators.Test.props" />
 

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\Common\AssemblyCommon.props" />
   <Import Project="..\Common\DebugSymbols.props" />

--- a/src/Simulation/Type1Core/Microsoft.Quantum.Type1.Core.csproj
+++ b/src/Simulation/Type1Core/Microsoft.Quantum.Type1.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\TargetDefinitions\TargetPackages\Type1.Package.props" />
 

--- a/src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.csproj
+++ b/src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\TargetDefinitions\TargetPackages\Type2.Package.props" />
 

--- a/src/Simulation/Type3Core/Microsoft.Quantum.Type3.Core.csproj
+++ b/src/Simulation/Type3Core/Microsoft.Quantum.Type3.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102129527-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.210223649-alpha">
 
   <Import Project="..\TargetDefinitions\TargetPackages\Type3.Package.props" />
 


### PR DESCRIPTION
The old version number seemed to reference data types that are not available in the main branch of the compiler repo, but rather a not-yet merged in feature branch. The new version number references a package made from the main branch of the compiler repo.