### PR TITLE
Update scripts to LLVM 11, add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/dotnet/sdk:3.1-focal
+RUN apt update \
+    && apt-get install -y cmake \
+    && apt-get install -y ninja-build \
+    && apt-get install -y clang-11 \
+    && apt-get install -y clang-tidy-11
+RUN apt-get install -y build-essential
+CMD [ "pwsh" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,61 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+*.sh text eol=lf
+
+###############################################################################
+# diff behavior for some non-binary formats
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+*.md   diff=astextplain
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/src/QirRuntime/README.md
+++ b/src/QirRuntime/README.md
@@ -11,7 +11,7 @@ This folder contains QIR runtime project, which includes implementation of the
 
 ## Build
 
-The QirRuntime project is using CMake (3.17) + Ninja(1.10.0) + Clang++(10.0.0). Other versions of the tools might work
+The QirRuntime project is using CMake (3.17) + Ninja(1.10.0) + Clang++(11.0.0). Other versions of the tools might work
  but haven't been tested. Only x64 architecture is supported.
 
 You can use CMake directly. For example, to produce a release build:
@@ -35,7 +35,7 @@ CI builds and tests are enabled for this project. The build has no external depe
 
 ### Windows pre-reqs
 
-1. Install Clang, Ninja and CMake from the public distros.
+1. Install Clang 11, Ninja and CMake from the public distros.
 1. Add all three to your/system `%PATH%`.
 1. Install VS 2019 and enable "Desktop development with C++" component (Clang uses MSVC's standard library on Windows).
 1. Install clang-tidy and clang-format if your Clang/LLVM packages didn't include the tools.
@@ -52,11 +52,11 @@ Running cmake from the editors will likely default to MSVC or clang-cl and fail.
 1. In the Ubuntu's terminal:
     1. `$ sudo apt install cmake` (`$ cmake --version` should return 3.16.3)
     1. `$ sudo apt-get install ninja-build` (`$ ninja --version` should return 1.10.0)
-    1. `$ sudo apt install clang` (`$ clang++ --version` should return 10.0.0)
+    1. `$ sudo apt install clang-11` (`$ clang++-11 --version` should return 11.0.0)
     1. Set Clang as the preferred C/C++ compiler:
-        - $ export CC=/usr/bin/clang
-        - $ export CXX=/usr/bin/clang++
-    1. `$ sudo apt install clang-tidy` (`$ clang-tidy --version` should return 'LLVM version 10.0.0')
+        - $ export CC=/usr/bin/clang-11
+        - $ export CXX=/usr/bin/clang++-11
+    1. `$ sudo apt install clang-tidy-11` (`$ clang-tidy-11 --version` should return 'LLVM version 11.0.0')
     1. Install the same version of dotnet as specified by qsharp-runtime [README](../../README.md)
     1. <_optional_> To use build/test scripts, check that you have python3 installed (it should be by default).
 

--- a/src/QirRuntime/build-qir-runtime.ps1
+++ b/src/QirRuntime/build-qir-runtime.ps1
@@ -18,6 +18,8 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
     $oldCXX = $env:CXX
     $oldRC = $env:RC
 
+    $clangTidy = ""
+
     if (($IsMacOS) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Darwin"))))
     {
         Write-Host "On MacOS build QIR Runtim using the default C/C++ compiler (should be AppleClang)"
@@ -25,9 +27,10 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
     elseif (($IsLinux) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Lin"))))
     {
         Write-Host "On Linux build QIR Runtime using Clang"
-        $env:CC = "/usr/bin/clang"
-        $env:CXX = "/usr/bin/clang++"
-        $env:RC = "/usr/bin/clang++"
+        $env:CC = "/usr/bin/clang-11"
+        $env:CXX = "/usr/bin/clang++-11"
+        $env:RC = "/usr/bin/clang++-11"
+        $clangTidy = "-DCMAKE_CXX_CLANG_TIDY=clang-tidy-11"
     }
     elseif (($IsWindows) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Win"))))
     {
@@ -48,7 +51,7 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
 
     Push-Location $qirRuntimeBuildFolder
 
-    cmake -G Ninja -D CMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ../..
+    cmake -G Ninja $clangTidy -D CMAKE_BUILD_TYPE="$Env:BUILD_CONFIGURATION" ../..
     cmake --build . --target install
 
     Pop-Location

--- a/src/QirRuntime/build.py
+++ b/src/QirRuntime/build.py
@@ -45,10 +45,14 @@ def do_build(root_dir, should_make, should_build, flavor):
 
   flavorWithDebInfo = flavor
   if flavor == "Release" :
-      flavorWithDebInfo = "RelWithDebInfo"
+    flavorWithDebInfo = "RelWithDebInfo"
+
+  clangTidy = "clang-tidy"
+  if platform.system() == "Linux" :
+    clangTidy = "clang-tidy-11"
 
   if should_make:
-    cmd = "cmake -G Ninja -DCMAKE_CXX_CLANG_TIDY=clang-tidy -DCMAKE_BUILD_TYPE=" + flavorWithDebInfo + " ../../.."
+    cmd = "cmake -G Ninja -DCMAKE_CXX_CLANG_TIDY=" + clangTidy + " -DCMAKE_BUILD_TYPE=" + flavorWithDebInfo + " ../../.."
     log("running: " + cmd)
     result = subprocess.run(cmd, shell = True)
     if result.returncode != 0:

--- a/src/QirRuntime/prerequisites.ps1
+++ b/src/QirRuntime/prerequisites.ps1
@@ -5,10 +5,13 @@ if ($Env:ENABLE_QIRRUNTIME -eq "true") {
     if (($IsWindows) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Win")))) {
         choco install llvm
         choco install ninja
-    } else {
-        #brew install llvm  # this seems to mess up native simulator build, probably because of STD libs
-                            # llvm should be already available on later Linux/Darwin systems
+    } elseif ($IsMacOS) {
         brew install ninja
+    } else {
+        sudo apt update
+        sudo apt-get install -y ninja-build
+        sudo apt-get install -y clang-11
+        sudo apt-get install -y clang-tidy-11
     }
 }
 


### PR DESCRIPTION
This updates the QirRuntime folder's readme and scripts to explicitly call out using LLVM 11 on Linux. It also adds a devcontainer for easier local Linux development with prerequisites for Q# development and QIR development already installed.