### PR TITLE
Remove llvm-ar depenency

### DIFF
--- a/src/QirRuntime/build-qir-runtime.ps1
+++ b/src/QirRuntime/build-qir-runtime.ps1
@@ -38,8 +38,6 @@ elseif (($IsWindows) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWit
     $env:CC = "clang.exe"
     $env:CXX = "clang++.exe"
     $env:RC = "clang++.exe"
-    $llvmExtras = Join-Path $PSScriptRoot externals LLVM
-    $env:PATH += ";$llvmExtras"
 
     if (!(Get-Command clang -ErrorAction SilentlyContinue) -and (choco find --idonly -l llvm) -contains "llvm") {
         # LLVM was installed by Chocolatey, so add the install location to the path.

--- a/src/QirRuntime/externals/readme.md
+++ b/src/QirRuntime/externals/readme.md
@@ -1,11 +1,5 @@
 # External components
 
-## LLVM tools
-
-We are relying on llvm-ar.exe 10.0.0 when building directly from IR. The tool is part of the official LLVM release package and can be installed from https://releases.llvm.org. However, it's not included into the Chocolatey package we are using to deply LLVM on Windows cloud build machines.
-
-While we are looking into a proper solution for this dependency, we are providing the tools as part of the repository.
-
 ## Catch2
 
 We are using v2.12.1 single-header distribution of catch2 native framework from https://github.com/catchorg/Catch2 (2e61d38c7c3078e600c331257b5bebfb81aaa685).


### PR DESCRIPTION
We shouldn't need llvm-ar.exe anymore, so we can remove that cached external component.

Fixes #554