### PR TITLE
Fix for dynamic type load when inheritance used

### DIFF
--- a/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulatorImpl.cs
+++ b/src/Simulation/Simulators/QCTraceSimulator/QCTraceSimulatorImpl.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.QCTraceSimulators.Implementati
             var intrinsicAssembly = coreAssembly;
             if (intrinsicAssembly == null)
             {
-                var currentName = this.GetType().Assembly.GetName();
+                var currentName = typeof(QCTraceSimulatorImpl).Assembly.GetName();
                 var coreName = currentName.FullName.Replace("Simulators", "QSharp.Core");
                 try
                 {


### PR DESCRIPTION
If inheritance is used, the `this` in QCTraceSimulatorImpl wont resolve to the right assembly. This uses the QCTraceSimulatorImpl type itself so that the assembly matching the QDK can be resolved.