### PR TITLE
Update reference C++ entry-point driver to use the latest QIR emission

### DIFF
--- a/src/QirRuntime/samples/StandaloneInputReference/CMakeLists.txt
+++ b/src/QirRuntime/samples/StandaloneInputReference/CMakeLists.txt
@@ -32,7 +32,7 @@ install(TARGETS qir-input-reference-standalone RUNTIME DESTINATION "${CMAKE_BINA
 include(CTest)
 add_test(
   NAME qir-input-reference-standalone
-  COMMAND qir-input-reference-standalone --int-value 1 --integer-array 1 2 3 4 5 --double-value 0.5 --double-array 0.1 0.2 0.3 0.4 0.5 --bool-value true --bool-array true TRUE false fALSe 1 --pauli-value PauliX --pauli-array PauliI paulix PAULIY PAulIZ --range-value 1 2 10 --range-array 1 2 10 5 5 50 10 1 20 --string-value ASampleString --result-value one --result-array one ONE true TRUE 1 zero ZERO false FALSE 0
+  COMMAND qir-input-reference-standalone --int-value 1 --integer-array 1 2 3 4 5 --double-value 0.5 --double-array 0.1 0.2 0.3 0.4 0.5 --bool-value true --bool-array true TRUE false fALSe 1 --pauli-value PauliI --pauli-array PauliI paulix PAULIY PAulIZ --range-value 1 2 10 --range-array 1 2 10 5 5 50 10 1 20 --string-value ASampleString --result-value one --result-array one ONE 1 0 zero ZERO
 )
 
 # set the environment path for loading shared libs the tests are using

--- a/src/QirRuntime/samples/StandaloneInputReference/CMakeLists.txt
+++ b/src/QirRuntime/samples/StandaloneInputReference/CMakeLists.txt
@@ -32,7 +32,7 @@ install(TARGETS qir-input-reference-standalone RUNTIME DESTINATION "${CMAKE_BINA
 include(CTest)
 add_test(
   NAME qir-input-reference-standalone
-  COMMAND qir-input-reference-standalone --int-value 1 --integer-array 1 2 3 4 5 --double-value 0.5 --double-array 0.1 0.2 0.3 0.4 0.5 --bool-value true --bool-array true TRUE false fALSe 1 --pauli-value PauliI --pauli-array PauliI paulix PAULIY PAulIZ --range-value 1 2 10 --range-array 1 2 10 5 5 50 10 1 20 --string-value ASampleString --result-value one --result-array one ONE 1 0 zero ZERO
+  COMMAND qir-input-reference-standalone --int-value 1 --integer-array 1 2 3 4 5 --double-value 0.5 --double-array 0.1 0.2 0.3 0.4 0.5 --bool-value true --bool-array true TRUE false fALSe 1 --pauli-value PauliI --pauli-array PauliI paulix PAULIY PAulIZ --range-value 1 2 10 --range-array 1 2 10 5 5 50 10 1 20 --string-value ASampleString --result-value one --result-array one ONE 1 0 zero ZERO --string-array StringA StringB StringC
 )
 
 # set the environment path for loading shared libs the tests are using

--- a/src/QirRuntime/samples/StandaloneInputReference/qir-driver.cpp
+++ b/src/QirRuntime/samples/StandaloneInputReference/qir-driver.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include <cstring> // for memcpy
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -10,30 +9,47 @@
 
 #include "CLI11.hpp"
 
-#include "CoreTypes.hpp"
 #include "QirContext.hpp"
-#include "QirTypes.hpp"
-#include "QirRuntimeApi_I.hpp"
 #include "SimFactory.hpp"
-#include "QirRuntime.hpp"
 
 using namespace Microsoft::Quantum;
 using namespace std;
 
-// This is the function corresponding to the QIR entry-point.
-extern "C" int64_t Quantum__StandaloneSupportedInputs__ExerciseInputs__body( // NOLINT
-    int64_t intValue,
-    double doubleValue,
-    Result resultValue,
-    QirString* stringValue);
+struct InteropArray
+{
+    int64_t Size;
+    void* Data;
+};
 
-const char FalseAsChar = 0x0;
-const char TrueAsChar = 0x1;
+struct InteropRange
+{
+    int64_t Start;
+    int64_t Step;
+    int64_t End;
+};
+
+// This is the function corresponding to the QIR entry-point.
+extern "C" void Quantum__StandaloneSupportedInputs__ExerciseInputs( // NOLINT
+    int64_t intValue,
+    InteropArray* integerArray,
+    double doubleValue,
+    InteropArray* doubleArray,
+    char boolValue,
+    InteropArray* boolArray,
+    char pauliValue,
+    InteropArray* pauliArray,
+    InteropRange* rangeValue,
+    char resultValue,
+    InteropArray* resultArray,
+    const char* stringValue);
+
+const char InteropFalseAsChar = 0x0;
+const char InteropTrueAsChar = 0x1;
 map<string, bool> BoolAsCharMap{
-    {"0", FalseAsChar},
-    {"false", FalseAsChar},
-    {"1", TrueAsChar},
-    {"true", TrueAsChar}};
+    {"0", InteropFalseAsChar},
+    {"false", InteropFalseAsChar},
+    {"1", InteropTrueAsChar},
+    {"true", InteropTrueAsChar}};
 
 map<string, PauliId> PauliMap{
     {"PauliI", PauliId::PauliId_I},
@@ -41,59 +57,55 @@ map<string, PauliId> PauliMap{
     {"PauliY", PauliId::PauliId_Y},
     {"PauliZ", PauliId::PauliId_Z}};
 
+const char InteropResultZeroAsChar = 0x0;
+const char InteropResultOneAsChar = 0x1;
 map<string, char> ResultAsCharMap{
-    {"0", FalseAsChar},
-    {"Zero", FalseAsChar},
-    {"false", FalseAsChar},
-    {"1", TrueAsChar},
-    {"One", TrueAsChar},
-    {"true", TrueAsChar}};
+    {"0", InteropResultZeroAsChar},
+    {"Zero", InteropResultZeroAsChar},
+    {"1", InteropResultOneAsChar},
+    {"One", InteropResultOneAsChar}
+};
 
 template<typename T>
-QirArray* CreateQirArray(T* dataBuffer, int64_t itemCount)
+unique_ptr<InteropArray> CreateInteropArray(vector<T> v)
 {
-    int32_t typeSize = sizeof(T); // NOLINT
-    QirArray* qirArray = quantum__rt__array_create_1d(typeSize, itemCount);
-    memcpy(qirArray->buffer, dataBuffer, typeSize * itemCount);
-    return qirArray;
-}
-
-template<typename D, typename S>
-unique_ptr<D[]> TranslateVectorToBuffer(vector<S>sourceVector, function<D(S)> translationFunction)
-{
-    unique_ptr<D[]> buffer (new D[sourceVector.size()]);
-    for (int index = 0; index < sourceVector.size(); index++)
-    {
-        buffer[index] = translationFunction(sourceVector[index]);
-    }
-
-    return buffer;
+    unique_ptr<InteropArray> array(new InteropArray());
+    array->Size = v.size();
+    array->Data = v.data();
+    return array;
 }
 
 using RangeTuple = tuple<int64_t, int64_t, int64_t>;
-QirRange TranslateRangeTupleToQirRange(RangeTuple rangeTuple)
+unique_ptr<InteropRange> CreateInteropRange(RangeTuple rangeTuple)
 {
-    QirRange qirRange = {
+    unique_ptr<InteropRange> range(new InteropRange());
+    range->Start = get<0>(rangeTuple);
+    range->Step = get<1>(rangeTuple);
+    range->End = get<2>(rangeTuple);
+    return range;
+}
+
+char TranslatePauliToChar(PauliId pauli)
+{
+    return static_cast<char>(pauli);
+}
+
+template<typename S, typename D>
+void TranslateVector(vector<S>sourceVector, vector<D>& destinationVector, function<D(S)> translationFunction)
+{
+    destinationVector.resize(sourceVector.size());
+    transform(sourceVector.begin(), sourceVector.end(), destinationVector.begin(), translationFunction);
+}
+
+InteropRange TranslateRangeTupleToInteropRange(RangeTuple rangeTuple)
+{
+    InteropRange range = {
         get<0>(rangeTuple), // Start
         get<1>(rangeTuple), // Step
         get<2>(rangeTuple)  // End
     };
 
-    return qirRange;
-}
-
-bool TranslateCharToBool(char boolAsChar)
-{
-    return (boolAsChar != FalseAsChar);
-}
-
-// Result Zero and One are opaque types defined by the runtime. They are declared here and initialized before executing
-// the simulation.
-Result RuntimeResultZero = nullptr;
-Result RuntimeResultOne = nullptr;
-Result TranslateCharToResult(char resultAsChar)
-{
-    return resultAsChar == FalseAsChar ? RuntimeResultZero : RuntimeResultOne;
+    return range;
 }
 
 int main(int argc, char* argv[])
@@ -103,19 +115,13 @@ int main(int argc, char* argv[])
     // Initialize simulator.
     unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     QirContextScope qirctx(sim.get(), false /*trackAllocatedObjects*/);
-    RuntimeResultZero = sim->UseZero();
-    RuntimeResultOne = sim->UseOne();
 
-    // Add the --simulation-output and --operation-output options.
-    // N.B. These options should be present in all standalone drivers.
+    // Add the --simulation-output options.
+    // N.B. This option should be present in all standalone drivers.
     string simulationOutputFile;
     CLI::Option* simulationOutputFileOpt = app.add_option(
         "-s,--simulation-output", simulationOutputFile,
         "File where the output produced during the simulation is written");
-
-    string operationOutputFile;
-    CLI::Option* operationOutputFileOpt = app.add_option(
-        "-o,--operation-output", operationOutputFile, "File where the output of the Q# operation is written");
 
     // Add the options that correspond to the parameters that the QIR entry-point needs.
     // Option for a Q# Int type.
@@ -135,8 +141,10 @@ int main(int argc, char* argv[])
     app.add_option("--double-array", doubleVector, "A double array")->required();
 
     // Option for a Q# Bool type.
-    bool boolValue = false;
-    app.add_option("--bool-value", boolValue, "A bool value")->required();
+    char boolAsCharValue = InteropFalseAsChar;
+    app.add_option("--bool-value", boolAsCharValue, "A bool value")
+        ->required()
+        ->transform(CLI::CheckedTransformer(BoolAsCharMap, CLI::ignore_case));
 
     // Option for a Q# Array<Bool> type.
     // N.B. For command line parsing, a char vector is used because vector<bool> is a specialized version of vector not
@@ -161,8 +169,8 @@ int main(int argc, char* argv[])
     // Option for Q# Range type.
     // N.B. RangeTuple type is used here instead of QirRange because CLI11 supports tuple parsing which is leveraged and
     //      the tuple is later translated to QirRange.
-    RangeTuple rangeValue(0, 0, 0);
-    app.add_option("--range-value", rangeValue, "A Range value (start, step, end)")->required();
+    RangeTuple rangeTuple(0, 0, 0);
+    app.add_option("--range-value", rangeTuple, "A Range value (start, step, end)")->required();
 
     // Option for a Q# Array<Range> type.
     vector<RangeTuple> rangeTupleVector;
@@ -171,7 +179,7 @@ int main(int argc, char* argv[])
     // Option for Q# Result type.
     // N.B. This is implemented as a char rather than a boolean to be consistent with the way an array of results has to
     //      be implemented.
-    char resultAsCharValue = FalseAsChar;
+    char resultAsCharValue = InteropResultZeroAsChar;
     app.add_option("--result-value", resultAsCharValue, "A Result value")
         ->required()
         ->transform(CLI::CheckedTransformer(ResultAsCharMap, CLI::ignore_case));
@@ -192,37 +200,31 @@ int main(int argc, char* argv[])
     CLI11_PARSE(app, argc, argv);
 
     // Translate values to its final form after parsing.
-    // Create a QirArray of integer values.
-    QirArray* qirIntegerArray = CreateQirArray(integerVector.data(), integerVector.size());
+    // Create an interop array of integer values.
+    unique_ptr<InteropArray> integerArray = CreateInteropArray(integerVector);
 
-    // Create a QirArray of double values.
-    QirArray* qirDoubleArray = CreateQirArray(doubleVector.data(), doubleVector.size());
+    // Create an interop array of double values.
+    unique_ptr<InteropArray> doubleArray = CreateInteropArray(doubleVector);
 
-    // Create a QirArray of bool values.
-    unique_ptr<bool[]> boolArray = TranslateVectorToBuffer<bool, char>(boolAsCharVector, TranslateCharToBool);
-    QirArray* qirboolArray = CreateQirArray(boolArray.get(), boolAsCharVector.size());
+    // Create an interop array of bool values.
+    unique_ptr<InteropArray> boolArray = CreateInteropArray(boolAsCharVector);
 
-    // Create a QirArray of Pauli values.
-    QirArray* qirPauliArray = CreateQirArray(pauliVector.data(), pauliVector.size());
+    // Translate a PauliID value to its char representation.
+    char pauliAsCharValue = TranslatePauliToChar(pauliValue);
 
-    // Create a QirRange.
-    QirRange qirRange = TranslateRangeTupleToQirRange(rangeValue);
+    // Create an interop array of Pauli values represented as chars.
+    vector<char> pauliAsCharVector;
+    TranslateVector<PauliId, char>(pauliVector, pauliAsCharVector, TranslatePauliToChar);
+    unique_ptr<InteropArray> pauliArray = CreateInteropArray(pauliAsCharVector);
 
-    // Create a QirArray of Range values.
-    unique_ptr<QirRange[]> rangeArray = TranslateVectorToBuffer<QirRange, RangeTuple>(
-        rangeTupleVector, TranslateRangeTupleToQirRange);
+    // Create an interop range.
+    unique_ptr<InteropRange> rangeValue = CreateInteropRange(rangeTuple);
+    vector<InteropRange> rangeVector;
+    TranslateVector<RangeTuple, InteropRange>(rangeTupleVector, rangeVector, TranslateRangeTupleToInteropRange);
+    unique_ptr<InteropArray> rangeArray = CreateInteropArray(rangeVector);
 
-    QirArray* qirRangeArray = CreateQirArray(rangeArray.get(), rangeTupleVector.size());
-
-    // Create a Result.
-    Result result = TranslateCharToResult(resultAsCharValue);
-
-    // Create a QirArray of Result values.
-    unique_ptr<Result[]> resultArray = TranslateVectorToBuffer<Result, char>(resultAsCharVector, TranslateCharToResult);
-    QirArray* qirResultArray = CreateQirArray(resultArray.get(), resultAsCharVector.size());
-
-    // Create a QirString.
-    QirString* qirString = quantum__rt__string_create(stringValue.c_str());
+    // Create an interop array of Result values.
+    unique_ptr<InteropArray> resultArray = CreateInteropArray(resultAsCharVector);
 
     // Redirect the simulator output from std::cout if the --simulation-output option is present.
     ostream* simulatorOutputStream = &cout;
@@ -234,29 +236,22 @@ int main(int argc, char* argv[])
         simulatorOutputStream = &simulationOutputFileStream;
     }
 
-    // Redirect the Q# operation output from std::cout if the --operation-output option is present.
-    ostream* operationOutputStream = &cout;
-    ofstream operationOutputFileStream;
-    if (!operationOutputFileOpt->empty())
-    {
-        operationOutputFileStream.open(operationOutputFile);
-        operationOutputStream = &operationOutputFileStream;
-    }
-
     // Run simulation and write the output of the operation to the corresponding stream.
-    int64_t operationOutput = Quantum__StandaloneSupportedInputs__ExerciseInputs__body(
-        intValue, doubleValue, result, qirString);
+    Quantum__StandaloneSupportedInputs__ExerciseInputs(
+        intValue,
+        integerArray.get(),
+        doubleValue,
+        doubleArray.get(),
+        boolAsCharValue,
+        boolArray.get(),
+        pauliAsCharValue,
+        pauliArray.get(),
+        rangeValue.get(),
+        resultAsCharValue,
+        resultArray.get(),
+        stringValue.c_str());
 
     simulatorOutputStream->flush();
-    (*operationOutputStream) << operationOutput << endl;
-    operationOutputStream->flush();
-
-    // Close opened file buffers;
-    if (operationOutputFileStream.is_open())
-    {
-        operationOutputFileStream.close();
-    }
-
     if (simulationOutputFileStream.is_open())
     {
         simulationOutputFileStream.close();

--- a/src/QirRuntime/samples/StandaloneInputReference/qir-driver.cpp
+++ b/src/QirRuntime/samples/StandaloneInputReference/qir-driver.cpp
@@ -108,6 +108,11 @@ InteropRange TranslateRangeTupleToInteropRange(RangeTuple rangeTuple)
     return range;
 }
 
+const char* TranslateStringToCharBuffer(string s)
+{
+    return s.c_str();
+}
+
 int main(int argc, char* argv[])
 {
     CLI::App app("QIR Standalone Entry Point Inputs Reference");
@@ -196,6 +201,11 @@ int main(int argc, char* argv[])
     string stringValue;
     app.add_option("--string-value", stringValue, "A String value")->required();
 
+    // Option for a Q# Array<String> type.
+    vector<string> stringVector;
+    app.add_option("--string-array", stringVector, "A String array")->required();
+
+
     // With all the options added, parse arguments from the command line.
     CLI11_PARSE(app, argc, argv);
 
@@ -225,6 +235,11 @@ int main(int argc, char* argv[])
 
     // Create an interop array of Result values.
     unique_ptr<InteropArray> resultArray = CreateInteropArray(resultAsCharVector);
+
+    // Create an interop array of String values.
+    vector<const char *> stringBufferVector;
+    TranslateVector<string, const char*>(stringVector, stringBufferVector, TranslateStringToCharBuffer);
+    unique_ptr<InteropArray> stringArray = CreateInteropArray(stringBufferVector);
 
     // Redirect the simulator output from std::cout if the --simulation-output option is present.
     ostream* simulatorOutputStream = &cout;

--- a/src/QirRuntime/samples/StandaloneInputReference/qir-driver.cpp
+++ b/src/QirRuntime/samples/StandaloneInputReference/qir-driver.cpp
@@ -95,6 +95,15 @@ unique_ptr<InteropRange> CreateInteropRange(RangeTuple rangeTuple)
     return range;
 }
 
+template<typename T>
+void FreePointerVector(vector<T*>& v)
+{
+    for (auto p : v)
+    {
+        delete p;
+    }
+}
+
 char TranslatePauliToChar(PauliId& pauli)
 {
     return static_cast<char>(pauli);
@@ -271,6 +280,7 @@ int main(int argc, char* argv[])
         resultArray.get(),
         stringValue.c_str());
 
+    FreePointerVector(rangeVector);
     simulatorOutputStream->flush();
     if (simulationOutputFileStream.is_open())
     {

--- a/src/QirRuntime/samples/StandaloneInputReference/qir-driver.cpp
+++ b/src/QirRuntime/samples/StandaloneInputReference/qir-driver.cpp
@@ -107,9 +107,9 @@ void TranslateVector(vector<S>& sourceVector, vector<D>& destinationVector, func
     transform(sourceVector.begin(), sourceVector.end(), destinationVector.begin(), translationFunction);
 }
 
-InteropRange TranslateRangeTupleToInteropRange(RangeTuple& rangeTuple)
+InteropRange* TranslateRangeTupleToInteropRangePointer(RangeTuple& rangeTuple)
 {
-    InteropRange range(rangeTuple);
+    InteropRange* range = new InteropRange(rangeTuple);
     return range;
 }
 
@@ -234,8 +234,8 @@ int main(int argc, char* argv[])
 
     // Create an interop range.
     unique_ptr<InteropRange> rangeValue = CreateInteropRange(rangeTuple);
-    vector<InteropRange> rangeVector;
-    TranslateVector<RangeTuple, InteropRange>(rangeTupleVector, rangeVector, TranslateRangeTupleToInteropRange);
+    vector<InteropRange*> rangeVector;
+    TranslateVector<RangeTuple, InteropRange*>(rangeTupleVector, rangeVector, TranslateRangeTupleToInteropRangePointer);
     unique_ptr<InteropArray> rangeArray = CreateInteropArray(rangeVector);
 
     // Create an interop array of Result values.

--- a/src/QirRuntime/samples/StandaloneInputReference/qsharp/qir-standalone-input-reference.csproj
+++ b/src/QirRuntime/samples/StandaloneInputReference/qsharp/qir-standalone-input-reference.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210324341-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.15.210324451-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/QirRuntime/samples/StandaloneInputReference/qsharp/qir-standalone-input-reference.qs
+++ b/src/QirRuntime/samples/StandaloneInputReference/qsharp/qir-standalone-input-reference.qs
@@ -4,6 +4,28 @@
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Intrinsic;
 
+    function ArrayToString<'T> (array : 'T[]) : String
+    {
+        mutable first = true;
+        mutable itemsString = "[";
+        for item in array
+        {
+            if (first)
+            {
+                set itemsString = itemsString + $"{item}";
+            }
+            else
+            {
+                set itemsString = itemsString + $", {item}";
+            }
+
+            set first = false;
+        }
+
+        set itemsString = itemsString + $"]";
+        return itemsString;
+    }
+
     function TautologyPredicate<'T> (input : 'T) : Bool
     {
         return true;
@@ -13,16 +35,16 @@
     operation ExerciseInputs (intValue : Int, intArray : Int[], doubleValue : Double, doubleArray : Double[], boolValue : Bool, boolArray : Bool[], pauliValue : Pauli, pauliArray : Pauli[], rangeValue : Range, resultValue : Result, resultArray : Result[], stringValue : String) : Unit {
         Message("Exercise Supported Inputs Reference");
         Message($"intValue: {intValue}");
-        Message($"intArray: {intArray} ({Count(TautologyPredicate<Int>, intArray)})");
+        Message($"intArray: {ArrayToString<Int>(intArray)} ({Count(TautologyPredicate<Int>, intArray)})");
         Message($"doubleValue: {doubleValue}");
-        Message($"doubleArray: {doubleArray} ({Count(TautologyPredicate<Double>, doubleArray)})");
+        Message($"doubleArray: {ArrayToString<Double>(doubleArray)} ({Count(TautologyPredicate<Double>, doubleArray)})");
         Message($"boolValue: {boolValue}");
-        Message($"boolArray: {boolArray} ({Count(TautologyPredicate<Bool>, boolArray)})");
+        Message($"boolArray: {ArrayToString<Bool>(boolArray)} ({Count(TautologyPredicate<Bool>, boolArray)})");
         Message($"pauliValue: {pauliValue}");
-        Message($"pauliArray: {pauliArray} ({Count(TautologyPredicate<Pauli>, pauliArray)})");
+        Message($"pauliArray: {ArrayToString<Pauli>(pauliArray)} ({Count(TautologyPredicate<Pauli>, pauliArray)})");
         Message($"rangeValue: {rangeValue}");
         Message($"resultValue: {resultValue}");
-        Message($"resultArray: {resultArray} ({Count(TautologyPredicate<Result>, resultArray)})");
+        Message($"resultArray: {ArrayToString<Result>(resultArray)} ({Count(TautologyPredicate<Result>, resultArray)})");
         Message($"stringValue: {stringValue}");
     }
 }

--- a/src/QirRuntime/samples/StandaloneInputReference/qsharp/qir-standalone-input-reference.qs
+++ b/src/QirRuntime/samples/StandaloneInputReference/qsharp/qir-standalone-input-reference.qs
@@ -12,17 +12,16 @@
         {
             if (first)
             {
+                set first = false;
                 set itemsString = itemsString + $"{item}";
             }
             else
             {
                 set itemsString = itemsString + $", {item}";
             }
-
-            set first = false;
         }
 
-        set itemsString = itemsString + $"]";
+        set itemsString = itemsString + "]";
         return itemsString;
     }
 

--- a/src/QirRuntime/samples/StandaloneInputReference/qsharp/qir-standalone-input-reference.qs
+++ b/src/QirRuntime/samples/StandaloneInputReference/qsharp/qir-standalone-input-reference.qs
@@ -1,15 +1,28 @@
 ﻿namespace Quantum.StandaloneSupportedInputs {
 
+    open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Intrinsic;
 
+    function TautologyPredicate<'T> (input : 'T) : Bool
+    {
+        return true;
+    }
+
     @EntryPoint()
-    operation ExerciseInputs (intValue : Int, doubleValue : Double, resultValue : Result, stringValue : String) : Int {
-        Message("Exercise Supported Inputs");
+    operation ExerciseInputs (intValue : Int, intArray : Int[], doubleValue : Double, doubleArray : Double[], boolValue : Bool, boolArray : Bool[], pauliValue : Pauli, pauliArray : Pauli[], rangeValue : Range, resultValue : Result, resultArray : Result[], stringValue : String) : Unit {
+        Message("Exercise Supported Inputs Reference");
         Message($"intValue: {intValue}");
+        Message($"intArray: {intArray} ({Count(TautologyPredicate<Int>, intArray)})");
         Message($"doubleValue: {doubleValue}");
+        Message($"doubleArray: {doubleArray} ({Count(TautologyPredicate<Double>, doubleArray)})");
+        Message($"boolValue: {boolValue}");
+        Message($"boolArray: {boolArray} ({Count(TautologyPredicate<Bool>, boolArray)})");
+        Message($"pauliValue: {pauliValue}");
+        Message($"pauliArray: {pauliArray} ({Count(TautologyPredicate<Pauli>, pauliArray)})");
+        Message($"rangeValue: {rangeValue}");
         Message($"resultValue: {resultValue}");
+        Message($"resultArray: {resultArray} ({Count(TautologyPredicate<Result>, resultArray)})");
         Message($"stringValue: {stringValue}");
-        return 0;
     }
 }

--- a/src/QirRuntime/test.py
+++ b/src/QirRuntime/test.py
@@ -114,6 +114,6 @@ if __name__ == '__main__':
     " --range-array 1 2 10 5 5 50 10 1 20" +\
     " --string-value ASampleString" +\
     " --result-value one" +\
-    " --result-array one ONE true TRUE 1 zero ZERO false FALSE 0")
+    " --result-array one ONE 1 zero ZERO 0")
 
   print("\n")

--- a/src/QirRuntime/test.py
+++ b/src/QirRuntime/test.py
@@ -100,8 +100,10 @@ if __name__ == '__main__':
     subprocess.run(test_binary + " ~[skip]", shell = True)
 
   log("========= Running samples =========")
+  sample_binary = os.path.join(install_dir, "qir-input-reference-standalone" + exe_ext)
+  log(sample_binary)
   subprocess.run(
-    "qir-input-reference-standalone" +\
+    sample_binary +\
     " --int-value 1" +\
     " --integer-array 1 2 3 4 5" +\
     " --double-value 0.5" +\
@@ -114,6 +116,7 @@ if __name__ == '__main__':
     " --range-array 1 2 10 5 5 50 10 1 20" +\
     " --string-value ASampleString" +\
     " --result-value one" +\
-    " --result-array one ONE 1 zero ZERO 0")
+    " --result-array one ONE 1 zero ZERO 0" +\
+    " --string-array StringA StringB StringC")
 
   print("\n")


### PR DESCRIPTION
This change updates the reference C++ entry-point driver to be compatible with the latest QIR emission.

One of the important changes is that it is now assumed that interop QIR functions are always `void`. 