### PR TITLE
Disable API docs generation in simulator tests.

### DIFF
--- a/src/Simulation/Common/Simulators.Test.props
+++ b/src/Simulation/Common/Simulators.Test.props
@@ -13,6 +13,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <CSharpGeneration>false</CSharpGeneration><!-- we will provide our own -->
+    <!-- Don't generate API docs for test cases. -->
+    <QSharpDocsGeneration>false</QSharpDocsGeneration>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR disables generating Q# API documentation from simulator test projects.