### PR TITLE
Removed Azure.Identity as package reference from the Azure client project

### DIFF
--- a/src/Azure/Azure.Quantum.Client/Microsoft.Azure.Quantum.Client.csproj
+++ b/src/Azure/Azure.Quantum.Client/Microsoft.Azure.Quantum.Client.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.2.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />


### PR DESCRIPTION
This change removed the Azure.Identity package from the Azure client project to unblock pipeline failures.