### PR TITLE
Include QIR Runtime binaries and headers in drops

### DIFF
--- a/src/Qir/Runtime/build-qir-runtime.ps1
+++ b/src/Qir/Runtime/build-qir-runtime.ps1
@@ -6,3 +6,18 @@
 if (-not (Build-CMakeProject $PSScriptRoot "QIR Runtime")) {
     throw "At least one project failed to compile. Check the logs."
 }
+
+# Copy the results of runtime compilation and the corresponding headers to the drops folder so
+# they can be included in pipeline artifacts.
+$qirDropsFolder = (Join-Path $Env:DROPS_DIR QIR)
+$qirDropsBin = (Join-Path $qirDropsFolder bin)
+$qirDropsInclude = (Join-Path $qirDropsFolder include)
+if (-not (Test-Path $qirDropsFolder)) {
+    New-Item -Path $qirDropsFolder -ItemType "directory"
+    New-Item -Path $qirDropsBin -ItemType "directory"
+    New-Item -Path $qirDropsInclude -ItemType "directory"
+}
+$qirBinaries = (Join-Path $PSScriptRoot build $Env:BUILD_CONFIGURATION bin *)
+$qirIncludes = (Join-Path $PSScriptRoot public *)
+Copy-Item $qirBinaries $qirDropsBin
+Copy-Item $qirIncludes $qirDropsInclude


### PR DESCRIPTION
This updates the build script to copy the QIR Runtime binaries and headers into the drops folder. This will ensure that during PR builds (non-e2e) the corresponding cross-platform binaries are still produced as build artifacts.