### PR TITLE
Update brew to latest version as temporary workaround for Bintray sunset

### DIFF
--- a/src/Qir/Runtime/prerequisites.ps1
+++ b/src/Qir/Runtime/prerequisites.ps1
@@ -8,6 +8,9 @@ if ($Env:ENABLE_QIRRUNTIME -ne "false") {
             choco install ninja
         }
     } elseif ($IsMacOS) {
+        # temporary workaround for Bintray sunset
+        # remove this after Homebrew is updated to 3.1.1 on MacOS image, see:
+        # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
         brew update
         brew install ninja
     } else {

--- a/src/Qir/Runtime/prerequisites.ps1
+++ b/src/Qir/Runtime/prerequisites.ps1
@@ -8,6 +8,7 @@ if ($Env:ENABLE_QIRRUNTIME -ne "false") {
             choco install ninja
         }
     } elseif ($IsMacOS) {
+        brew update
         brew install ninja
     } else {
         sudo apt update

--- a/src/Simulation/Native/prerequisites.ps1
+++ b/src/Simulation/Native/prerequisites.ps1
@@ -4,6 +4,7 @@
 if (($IsMacOS) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Darwin")))) {
     # building with gcc-9 succeeds but some of the unit tests fail
     Write-Host "Install gcc-7 as pre-req for building native simulator on MacOS"
+    brew update
     brew install gcc@7
 } else {
     Write-Host "No pre-reqs for building native simulator on platforms other than MacOS"

--- a/src/Simulation/Native/prerequisites.ps1
+++ b/src/Simulation/Native/prerequisites.ps1
@@ -4,6 +4,9 @@
 if (($IsMacOS) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Darwin")))) {
     # building with gcc-9 succeeds but some of the unit tests fail
     Write-Host "Install gcc-7 as pre-req for building native simulator on MacOS"
+    # temporary workaround for Bintray sunset
+    # remove this after Homebrew is updated to 3.1.1 on MacOS image, see:
+    # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
     brew update
     brew install gcc@7
 } else {


### PR DESCRIPTION
Update homebrew to the latest version so it picks up on the new package hosting.

For details see: [Service End for Bintray, JCenter, GoCenter, and ChartCenter | JFrog](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)