### PR TITLE
Fixing install script to explicitly use LLVM 11

### DIFF
--- a/src/Qir/Runtime/prerequisites.ps1
+++ b/src/Qir/Runtime/prerequisites.ps1
@@ -4,7 +4,7 @@
 if ($Env:ENABLE_QIRRUNTIME -ne "false") {
     if (($IsWindows) -or ((Test-Path Env:AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Win")))) {
         if (!(Get-Command clang -ErrorAction SilentlyContinue)) {
-            choco install llvm
+            choco install llvm --version=11.1.0
             choco install ninja
         }
     } elseif ($IsMacOS) {


### PR DESCRIPTION
Chocolatey just updated the default version of LLVM to 12.0, but we use LLVM 11 to generate our IR. We should stick to the same version for the tools to ensure compatibility.