### PR TITLE
Explicitly disable docs generation in all test projects.

### DIFF
--- a/src/Qir/Tests/QIR-static/qsharp/qir-gen.csproj
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-gen.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <QirGeneration>True</QirGeneration>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
+    <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Qir/Tests/QIR-tracer/qsharp/tracer-qir.csproj
+++ b/src/Qir/Tests/QIR-tracer/qsharp/tracer-qir.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <QirGeneration>True</QirGeneration>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
+    <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>
 
 </Project>

--- a/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/IntrinsicTests/IntrinsicTests.csproj
@@ -6,6 +6,7 @@
     <!-- we will provide our own -->
     <CSharpGeneration>false</CSharpGeneration>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
+    <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/UnitTests/UnitTests.csproj
@@ -7,6 +7,7 @@
     <!-- we will provide our own -->
     <CSharpGeneration>false</CSharpGeneration>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
+    <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR explicitly disables Q# API documentation generation for unit test projects that do not depend on `Simulators.Test.props` (e.g.: QIR and trace simulation tests), so that test functions and operations are not incorrectly included in documentation.

(+@KittyYeungQ for broken links impact; the documentation that is incorrectly generated from unit tests contains broken links, since there's no corresponding package to document.) 