### PR TITLE
Create QIR Runtime nuget package

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -74,6 +74,11 @@ Pack-Dotnet '../src/Simulation/Type3Core/Microsoft.Quantum.Type3.Core.csproj'
 Pack-One '../src/Simulation/Simulators/Microsoft.Quantum.Simulators.nuspec'
 Pack-One '../src/Quantum.Development.Kit/Microsoft.Quantum.Development.Kit.nuspec'
 Pack-One '../src/Xunit/Microsoft.Quantum.Xunit.csproj'
+Pack-One '../src/Qir/Runtime/Microsoft.Quantum.Qir.Runtime.nuspec'
+
+# Workaround to suppress publishing of QIR Runtime nuget package. Remove this line when we are
+# ready to support it as a full result instead of just a pipeline artifact.
+Move-Item (Join-Path $Env:NUGET_OUTDIR Microsoft.Quantum.Qir.Runtime.*) $env:DROPS_DIR -Force
 
 if (-not $all_ok) {
     throw "At least one project failed to pack. Check the logs."

--- a/build/set-env.ps1
+++ b/build/set-env.ps1
@@ -15,6 +15,10 @@ If (($Env:ENABLE_NATIVE -ne "false") -and ($Env:NATIVE_SIMULATOR -eq $null) ) {
     $Env:NATIVE_SIMULATOR = (Join-Path $PSScriptRoot "..\src\Simulation\Native\build\drop")
 }
 
+if ($Env:ENABLE_QIRRUNTIME -ne "false" -and $Env:QIR_DROPS -eq $null) {
+    $Env:QIR_DROPS = (Join-Path $PSScriptRoot "../src/Qir/drops")
+}
+
 If ($Env:DROPS_DIR -eq $null) { $Env:DROPS_DIR =  [IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\drops")) }
 
 If ($Env:NUGET_OUTDIR -eq $null) { $Env:NUGET_OUTDIR =  (Join-Path $Env:DROPS_DIR "nugets") }

--- a/src/Qir/Runtime/Microsoft.Quantum.Qir.Runtime.nuspec
+++ b/src/Qir/Runtime/Microsoft.Quantum.Qir.Runtime.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Quantum.Qir.Runtime</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>Microsoft</authors>
+    <owners>QuantumEngineering, Microsoft</owners>
+    <license type="expression">MIT</license>
+    <projectUrl>https://docs.microsoft.com/azure/quantum</projectUrl>
+    <icon>images\qdk-nuget-icon.png</icon>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Native libraries for linking and executing Quantum Intermediate Representation.</description>
+    <releaseNotes>See: https://docs.microsoft.com/azure/quantum/qdk-relnotes/</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>Quantum Q# QSharp QIR native</tags>
+  </metadata>
+  <files>
+    <file src="..\drops\bin\**\*" target="runtimes" />
+    <file src="..\drops\include\*" target="runtimes/any/native/include" />
+    <file src="..\..\..\build\assets\qdk-nuget-icon.png" target="images" />
+  </files>
+</package>

--- a/src/Qir/Runtime/build-qir-runtime.ps1
+++ b/src/Qir/Runtime/build-qir-runtime.ps1
@@ -7,17 +7,22 @@ if (-not (Build-CMakeProject $PSScriptRoot "QIR Runtime")) {
     throw "At least one project failed to compile. Check the logs."
 }
 
-# Copy the results of runtime compilation and the corresponding headers to the drops folder so
+# Copy the results of runtime compilation and the corresponding headers to the QIR drops folder so
 # they can be included in pipeline artifacts.
-$qirDropsFolder = (Join-Path $Env:DROPS_DIR QIR)
-$qirDropsBin = (Join-Path $qirDropsFolder bin)
-$qirDropsInclude = (Join-Path $qirDropsFolder include)
-if (-not (Test-Path $qirDropsFolder)) {
-    New-Item -Path $qirDropsFolder -ItemType "directory"
+$osDir = "win-x64"
+if ($IsLinux) {
+    $osDir = "linux-x64"
+} elseif ($IsMacOS) {
+    $osDir = "osx-x64"
+}
+$qirDropsBin = (Join-Path $Env:QIR_DROPS bin $osDir native)
+$qirDropsInclude = (Join-Path $Env:QIR_DROPS include)
+if (-not (Test-Path $Env:QIR_DROPS)) {
+    New-Item -Path $Env:QIR_DROPS -ItemType "directory"
     New-Item -Path $qirDropsBin -ItemType "directory"
     New-Item -Path $qirDropsInclude -ItemType "directory"
 }
 $qirBinaries = (Join-Path $PSScriptRoot build $Env:BUILD_CONFIGURATION bin *)
 $qirIncludes = (Join-Path $PSScriptRoot public *)
-Copy-Item $qirBinaries $qirDropsBin
-Copy-Item $qirIncludes $qirDropsInclude
+Copy-Item $qirBinaries $qirDropsBin -Exclude "*unittests*","*.Tracer.*"
+Copy-Item $qirIncludes $qirDropsInclude -Exclude "*.md","Tracer*"


### PR DESCRIPTION
Adds the infrastructure for creating the QIR Runtime package with native dependencies (libraries and headers) needed for compiling and executing QIR with the runtime. Note that this package is not ready for publish yet, so upload to the nuget feed is suppressed.