### PR TITLE
Added the empty implementation of `AssertMeasurement[Probability]()`

### DIFF
--- a/src/Qir/Runtime/lib/QSharpFoundation/qsharp-foundation-qis.ll
+++ b/src/Qir/Runtime/lib/QSharpFoundation/qsharp-foundation-qis.ll
@@ -228,3 +228,67 @@ define dllexport void @__quantum__qis__applyconditionallyintrinsic__body(
     %struct.QirCallable* %clb_on_equal, %struct.QirCallable* %clb_on_different)
   ret void
 }
+
+;===============================================================================
+; quantum.qis AssertMeasurement functions/operations implementation
+;
+;    operation AssertMeasurementProbability(bases : Pauli[], qubits : Qubit[], result : Result, prob : Double, msg : String, tol : Double) : Unit
+;    is Adj + Ctl {
+;        body intrinsic;
+;    }
+;    operation AssertMeasurement(bases : Pauli[], qubits : Qubit[], result : Result, msg : String) : Unit
+;    is Adj + Ctl {
+;        body intrinsic;
+;    }
+define dllexport void @__quantum__qis__assertmeasurementprobability__body(
+  %Array* %.bases, %Array* %.qubits, %Result* %.result, double %prob, %String* %.msg, double %tol) {
+  ; Empty.
+  ret void
+}
+
+define dllexport void @__quantum__qis__assertmeasurementprobability__adj(
+  %Array* %.bases, %Array* %.qubits, %Result* %.result, double %prob, %String* %.msg, double %tol) {
+  ; Empty.
+  ret void
+}
+
+define dllexport void @__quantum__qis__assertmeasurementprobability__ctl(
+  %Array*,
+  %Array* %.bases, %Array* %.qubits, %Result* %.result, double %prob, %String* %.msg, double %tol) {
+  ; Empty.
+  ret void
+}
+
+define dllexport void @__quantum__qis__assertmeasurementprobability__ctladj(
+  %Array*,
+  %Array* %.bases, %Array* %.qubits, %Result* %.result, double %prob, %String* %.msg, double %tol) {
+  ; Empty.
+  ret void
+}
+
+
+define dllexport void @__quantum__qis__assertmeasurement__body(
+  %Array* %.bases, %Array* %.qubits, %Result* %.result, %String* %.msg) {
+  ; Empty.
+  ret void
+}
+
+define dllexport void @__quantum__qis__assertmeasurement__adj(
+  %Array* %.bases, %Array* %.qubits, %Result* %.result, %String* %.msg) {
+  ; Empty.
+  ret void
+}
+
+define dllexport void @__quantum__qis__assertmeasurement__ctl(
+  %Array*,
+  %Array* %.bases, %Array* %.qubits, %Result* %.result, %String* %.msg) {
+  ; Empty.
+  ret void
+}
+
+define dllexport void @__quantum__qis__assertmeasurement__ctladj(
+  %Array*,
+  %Array* %.bases, %Array* %.qubits, %Result* %.result, %String* %.msg) {
+  ; Empty.
+  ret void
+}

--- a/src/Qir/Tests/QIR-dynamic/qir-driver.cpp
+++ b/src/Qir/Tests/QIR-dynamic/qir-driver.cpp
@@ -20,6 +20,8 @@ extern "C" void Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__body(co
 extern "C" void Microsoft__Quantum__Testing__QIR__DumpRegisterTest__body(); // NOLINT
 extern "C" void Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__body(const void*); // NOLINT
 
+extern "C" void Microsoft__Quantum__Testing__QIR__AssertMeasurementTest__body(); // NOLINT
+
 using namespace Microsoft::Quantum;
 
 TEST_CASE("QIR: Generate a random number with full state simulator", "[qir]")
@@ -159,3 +161,11 @@ TEST_CASE("QIR: DumpRegister", "[qir][DumpRegister]")
     // Remove the file, ignore the failure:
     (void) remove(filePath);
 }
+
+
+TEST_CASE("QIR: AssertMeasurement", "[qir][AssertMeasurement]")
+{
+    QirExecutionContext::Scoped contextReleaser{CreateFullstateSimulator().release()};
+
+    Microsoft__Quantum__Testing__QIR__AssertMeasurementTest__body();
+} // TEST_CASE("QIR: AssertMeasurement", "[qir][AssertMeasurement]")

--- a/src/Qir/Tests/QIR-dynamic/qsharp/qir-test-assert.qs
+++ b/src/Qir/Tests/QIR-dynamic/qsharp/qir-test-assert.qs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Testing.QIR  {
+
+    open Microsoft.Quantum.Diagnostics;
+
+    @EntryPoint()
+    operation AssertMeasurementTest() : Unit {
+        use qubit = Qubit();
+        // Test that all the calls are resolved (linker is happy):
+        AssertMeasurement([PauliZ], [qubit], Zero, "Newly allocated qubit must be in the |0> state.");
+        AssertMeasurementProbability ([PauliZ], [qubit], Zero, 1.0, "Newly allocated qubit must be in the |0> state.", 1e-10);
+    }
+} // namespace Microsoft.Quantum.Testing.QIR


### PR DESCRIPTION
The [Algorithm Samples](https://github.com/microsoft/Quantum/tree/main/samples/algorithms), [Oracle Synthesis](https://github.com/microsoft/Quantum/blob/main/samples/algorithms/oracle-synthesis), relies on [`AssertMeasurement[Probability]()`](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.diagnostics.assertmeasurement). 
To unblock the PNNL I'm adding the empty implementation of the `AssertMeasurement[Probability]()`