### PR TITLE
Update QIR tests for latest calling conventions

### DIFF
--- a/src/Qir/Samples/StandaloneInputReference/CMakeLists.txt
+++ b/src/Qir/Samples/StandaloneInputReference/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(qir-input-reference-standalone
 )
 
 # This is where the generated QIR file is specified.
-target_source_from_qir(qir-input-reference-standalone qsharp/qir/qir-standalone-input-reference.ll)
+target_source_from_qir(qir-input-reference-standalone qsharp/obj/qsharp/qir-standalone-input-reference.bc)
 
 target_link_libraries(qir-input-reference-standalone PUBLIC
   "-L${runtime_lib_path}"

--- a/src/Qir/Tests/FullstateSimulator/CMakeLists.txt
+++ b/src/Qir/Tests/FullstateSimulator/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(fullstate-simulator-tests
   FullstateSimulatorTests.cpp)
 
-target_source_from_qir(fullstate-simulator-tests qsharp/qir/qir-test-simulator.ll)
+target_source_from_qir(fullstate-simulator-tests qsharp/obj/qsharp/qir-test-simulator.bc)
 
 target_link_libraries(fullstate-simulator-tests PUBLIC
   "-L${runtime_lib_path}"

--- a/src/Qir/Tests/FullstateSimulator/FullstateSimulatorTests.cpp
+++ b/src/Qir/Tests/FullstateSimulator/FullstateSimulatorTests.cpp
@@ -353,11 +353,11 @@ TEST_CASE("Fullstate simulator: get qubit state of Bell state", "[fullstate_simu
     }
 }
 
-extern "C" int Microsoft__Quantum__Testing__QIR__Test_Simulator_QIS__body(); // NOLINT
+extern "C" int Microsoft__Quantum__Testing__QIR__Test_Simulator_QIS__Interop(); // NOLINT
 TEST_CASE("QIR: invoke all standard Q# gates against the fullstate simulator", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     QirExecutionContext::Scoped qirctx(sim.get(), true /*trackAllocatedObjects*/);
 
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Test_Simulator_QIS__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Test_Simulator_QIS__Interop());
 }

--- a/src/Qir/Tests/QIR-dynamic/CMakeLists.txt
+++ b/src/Qir/Tests/QIR-dynamic/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(TEST_FILES
-  qsharp/qir/qir-test-random.ll
+  qsharp/obj/qsharp/qir-test-random.bc
 )
 
 #==============================================================================

--- a/src/Qir/Tests/QIR-dynamic/qir-driver.cpp
+++ b/src/Qir/Tests/QIR-dynamic/qir-driver.cpp
@@ -8,19 +8,18 @@
 #define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
 #include "catch.hpp"
 
-#include "QirTypes.hpp"
 #include "SimFactory.hpp"
 #include "QirContext.hpp"
 #include "OutputStream.hpp"
 
-extern "C" int64_t Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__body(); // NOLINT
+extern "C" int64_t Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__Interop(); // NOLINT
 
-extern "C" void Microsoft__Quantum__Testing__QIR__DumpMachineTest__body(); // NOLINT
-extern "C" void Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__body(const void*); // NOLINT
-extern "C" void Microsoft__Quantum__Testing__QIR__DumpRegisterTest__body(); // NOLINT
-extern "C" void Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__body(const void*); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__DumpMachineTest__Interop(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__Interop(const char[]); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__DumpRegisterTest__Interop(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__Interop(const char[]); // NOLINT
 
-extern "C" void Microsoft__Quantum__Testing__QIR__AssertMeasurementTest__body(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__AssertMeasurementTest__Interop(); // NOLINT
 
 using namespace Microsoft::Quantum;
 
@@ -28,9 +27,9 @@ TEST_CASE("QIR: Generate a random number with full state simulator", "[qir]")
 {
     QirExecutionContext::Scoped contextReleaser{CreateFullstateSimulator().release()};
 
-    const int ret1 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__body();
-    const int ret2 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__body();
-    const int ret3 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__body();
+    const int ret1 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__Interop();
+    const int ret2 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__Interop();
+    const int ret3 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__Interop();
     INFO(
         std::string("Three random numbers: ") + std::to_string(ret1) + ", " + std::to_string(ret2) + ", " +
         std::to_string(ret3));
@@ -58,7 +57,7 @@ TEST_CASE("QIR: DumpMachine", "[qir][DumpMachine]")
             // Redirect the output from std::cout to outStrStream:
             OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
 
-            Microsoft__Quantum__Testing__QIR__DumpMachineTest__body();
+            Microsoft__Quantum__Testing__QIR__DumpMachineTest__Interop();
         } // qOStreamRedirector goes out of scope.
 
         REQUIRE(outStrStream.str().size() != 0);
@@ -68,12 +67,11 @@ TEST_CASE("QIR: DumpMachine", "[qir][DumpMachine]")
     // Dump to empty string location (std::cout):
     {
         std::ostringstream      outStrStream;
-        const QirString         qstrEmpty{std::string("")};
         {
             // Redirect the output from std::cout to outStrStream:
             OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
 
-            Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__body(&qstrEmpty);
+            Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__Interop("");
         } // qOStreamRedirector goes out of scope.
 
         REQUIRE(outStrStream.str().size() != 0);
@@ -92,8 +90,7 @@ TEST_CASE("QIR: DumpMachine", "[qir][DumpMachine]")
     REQUIRE(!FileExists(filePath));
 
     // Dump the machine state to that `filePath`:
-    const QirString qstr{std::string(filePath)};
-    Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__body(&qstr);
+    Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__Interop(filePath);
 
     // Make sure the file has been created.
     REQUIRE(FileExists(filePath));
@@ -116,7 +113,7 @@ TEST_CASE("QIR: DumpRegister", "[qir][DumpRegister]")
             // Redirect the output from std::cout to outStrStream:
             OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
 
-            Microsoft__Quantum__Testing__QIR__DumpRegisterTest__body();
+            Microsoft__Quantum__Testing__QIR__DumpRegisterTest__Interop();
         } // qOStreamRedirector goes out of scope.
 
         REQUIRE(outStrStream.str().size() != 0);
@@ -126,12 +123,11 @@ TEST_CASE("QIR: DumpRegister", "[qir][DumpRegister]")
     // Dump to empty string location (std::cout):
     {
         std::ostringstream      outStrStream;
-        const QirString         qstrEmpty{""};
         {
             // Redirect the output from std::cout to outStrStream:
             OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
 
-            Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__body(&qstrEmpty);
+            Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__Interop("");
         } // qOStreamRedirector goes out of scope.
 
         REQUIRE(outStrStream.str().size() != 0);
@@ -150,8 +146,7 @@ TEST_CASE("QIR: DumpRegister", "[qir][DumpRegister]")
     REQUIRE(!FileExists(filePath));
 
     // Dump to that `filePath`:
-    const QirString qstr{filePath};
-    Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__body(&qstr);
+    Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__Interop(filePath);
 
     // Make sure the file has been created.
     REQUIRE(FileExists(filePath));
@@ -167,5 +162,5 @@ TEST_CASE("QIR: AssertMeasurement", "[qir][AssertMeasurement]")
 {
     QirExecutionContext::Scoped contextReleaser{CreateFullstateSimulator().release()};
 
-    Microsoft__Quantum__Testing__QIR__AssertMeasurementTest__body();
+    Microsoft__Quantum__Testing__QIR__AssertMeasurementTest__Interop();
 } // TEST_CASE("QIR: AssertMeasurement", "[qir][AssertMeasurement]")

--- a/src/Qir/Tests/QIR-dynamic/qsharp/qir-test-random.qs
+++ b/src/Qir/Tests/QIR-dynamic/qsharp/qir-test-random.qs
@@ -9,16 +9,13 @@ namespace Microsoft.Quantum.Testing.QIR
     operation QuantumRandomNumberGenerator() : Int {
        mutable randomNumber = 0;
 
-       for (i in 1 .. 64)
-       {
-           using(q = Qubit())
-           {
-               H(q);
-               set randomNumber = randomNumber <<< 1;
-               if (M(q) == One) {
-                   set randomNumber += 1;
-               }
-           }
+       for i in 1 .. 64 {
+            use q = Qubit();
+            H(q);
+            set randomNumber = randomNumber <<< 1;
+            if M(q) == One {
+                set randomNumber += 1;
+            }
        }
        return randomNumber;
    } 

--- a/src/Qir/Tests/QIR-static/CMakeLists.txt
+++ b/src/Qir/Tests/QIR-static/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TEST_FILES
   qir-test-noqsharp.ll
-  qsharp/qir/qir-gen.ll
+  qsharp/obj/qsharp/qir-gen.bc
 )
 
 #==============================================================================

--- a/src/Qir/Tests/QIR-static/qir-driver.cpp
+++ b/src/Qir/Tests/QIR-static/qir-driver.cpp
@@ -50,8 +50,7 @@ struct Array {
 extern "C" int64_t Microsoft__Quantum__Testing__QIR__Test_Arrays__Interop( // NOLINT
     Array* array,
     int64_t index,
-    int64_t val,
-    bool compilerDecoy);
+    int64_t val);
 TEST_CASE("QIR: Using 1D arrays", "[qir][qir.arr1d]")
 {
     QirExecutionContext::Scoped qirctx(nullptr, true /*trackAllocatedObjects*/);
@@ -60,11 +59,11 @@ TEST_CASE("QIR: Using 1D arrays", "[qir][qir.arr1d]")
     int64_t values[n] = {0, 1, 2, 3, 4};
     auto array = Array{5, values};
 
-    int64_t res = Microsoft__Quantum__Testing__QIR__Test_Arrays__Interop(&array, 2, 42, false);
+    int64_t res = Microsoft__Quantum__Testing__QIR__Test_Arrays__Interop(&array, 2, 42);
     REQUIRE(res == (0 + 42) + (42 + 3 + 4));
 }
 
-extern "C" void Microsoft__Quantum__Testing__QIR__TestQubitResultManagement__body(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__TestQubitResultManagement__Interop(); // NOLINT
 struct QubitsResultsTestSimulator : public Microsoft::Quantum::SimulatorStub
 {
     // no intelligent reuse, we just want to check that QIR releases all qubits
@@ -151,7 +150,7 @@ TEST_CASE("QIR: allocating and releasing qubits and results", "[qir][qir.qubit][
     unique_ptr<QubitsResultsTestSimulator> sim = make_unique<QubitsResultsTestSimulator>();
     QirExecutionContext::Scoped qirctx(sim.get(), true /*trackAllocatedObjects*/);
 
-    REQUIRE_NOTHROW(Microsoft__Quantum__Testing__QIR__TestQubitResultManagement__body());
+    REQUIRE_NOTHROW(Microsoft__Quantum__Testing__QIR__TestQubitResultManagement__Interop());
 
     // check that all qubits have been released
     for (size_t id = 0; id < sim->qubits.size(); id++)
@@ -205,19 +204,17 @@ TEST_CASE("QIR: Report range in a failure message", "[qir][qir.range]")
     REQUIRE(failed);
 }
 
-#if 0 // TODO: Q# compiler crashes generating QIR for TestPartials
 // TestPartials subtracts the second argument from the first and returns the result.
-extern "C" int64_t Microsoft__Quantum__Testing__QIR__TestPartials__body(int64_t, int64_t); // NOLINT
+extern "C" int64_t Microsoft__Quantum__Testing__QIR__TestPartials__Interop(int64_t, int64_t); // NOLINT
 TEST_CASE("QIR: Partial application of a callable", "[qir][qir.partCallable]")
 {
     QirExecutionContext::Scoped qirctx(nullptr, true /*trackAllocatedObjects*/);
 
-    const int64_t res = Microsoft__Quantum__Testing__QIR__TestPartials__body(42, 17);
+    const int64_t res = Microsoft__Quantum__Testing__QIR__TestPartials__Interop(42, 17);
     REQUIRE(res == 42 - 17);
 }
-#endif
 
-// The Microsoft__Quantum__Testing__QIR__TestFunctors__body tests needs proper semantics of X and M, and nothing else.
+// The Microsoft__Quantum__Testing__QIR__TestFunctors__Interop tests needs proper semantics of X and M, and nothing else.
 // The validation is done inside the test and it would throw in case of failure.
 struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
 {
@@ -295,8 +292,8 @@ struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
 FunctorsTestSimulator* g_ctrqapi = nullptr;
 static int g_cKCalls = 0;
 static int g_cKCallsControlled = 0;
-extern "C" void Microsoft__Quantum__Testing__QIR__TestFunctors__body();       // NOLINT
-extern "C" void Microsoft__Quantum__Testing__QIR__TestFunctorsNoArgs__body(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__TestFunctors__Interop();       // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__TestFunctorsNoArgs__Interop(); // NOLINT
 extern "C" void __quantum__qis__k__body(Qubit q)                              // NOLINT
 {
     g_cKCalls++;
@@ -313,11 +310,11 @@ TEST_CASE("QIR: application of nested controlled functor", "[qir][qir.functor]")
     QirExecutionContext::Scoped qirctx(qapi.get(), true /*trackAllocatedObjects*/);
     g_ctrqapi = qapi.get();
 
-    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestFunctors__body());
+    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestFunctors__Interop());
 
     const int cKCalls = g_cKCalls;
     const int cKCallsControlled = g_cKCallsControlled;
-    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestFunctorsNoArgs__body());
+    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestFunctorsNoArgs__Interop());
     CHECK(g_cKCalls - cKCalls == 3);
     CHECK(g_cKCallsControlled - cKCallsControlled == 5);
 

--- a/src/Qir/Tests/QIR-static/qir-test-conditionals.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-conditionals.cpp
@@ -114,14 +114,14 @@ struct ConditionalsTestSimulator : public Microsoft::Quantum::SimulatorStub
     }
 };
 
-extern "C" void Microsoft__Quantum__Testing__QIR__TestApplyIf__body(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__TestApplyIf__Interop(); // NOLINT
 TEST_CASE("QIR: ApplyIf", "[qir][qir.conditionals]")
 {
     unique_ptr<ConditionalsTestSimulator> qapi =
         make_unique<ConditionalsTestSimulator>(vector<ResultValue>{Result_Zero, Result_One});
     QirExecutionContext::Scoped qirctx(qapi.get(), true /*trackAllocatedObjects*/);
 
-    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestApplyIf__body());
+    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestApplyIf__Interop());
 
     INFO(qapi->GetHistory());
     CHECK(qapi->xCallbacks.size() == 8);
@@ -129,14 +129,14 @@ TEST_CASE("QIR: ApplyIf", "[qir][qir.conditionals]")
     CHECK(qapi->otherCallbacks.size() == 0);
 }
 
-extern "C" void Microsoft__Quantum__Testing__QIR__TestApplyIfWithFunctors__body(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__TestApplyIfWithFunctors__Interop(); // NOLINT
 TEST_CASE("QIR: ApplyIf with functors", "[qir][qir.conditionals]")
 {
     unique_ptr<ConditionalsTestSimulator> qapi =
         make_unique<ConditionalsTestSimulator>(vector<ResultValue>{Result_Zero, Result_One});
     QirExecutionContext::Scoped qirctx(qapi.get(), true /*trackAllocatedObjects*/);
 
-    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestApplyIfWithFunctors__body());
+    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestApplyIfWithFunctors__Interop());
 
     INFO(qapi->GetHistory());
     CHECK(qapi->xCallbacks.size() == 5);
@@ -144,14 +144,14 @@ TEST_CASE("QIR: ApplyIf with functors", "[qir][qir.conditionals]")
     CHECK(qapi->otherCallbacks.size() == 0);
 }
 
-extern "C" void Microsoft__Quantum__Testing__QIR__TestApplyConditionally__body(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__TestApplyConditionally__Interop(); // NOLINT
 TEST_CASE("QIR: ApplyConditionally", "[qir][qir.conditionals]")
 {
     unique_ptr<ConditionalsTestSimulator> qapi =
         make_unique<ConditionalsTestSimulator>(vector<ResultValue>{Result_Zero, Result_One});
     QirExecutionContext::Scoped qirctx(qapi.get(), true /*trackAllocatedObjects*/);
 
-    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestApplyConditionally__body());
+    CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestApplyConditionally__Interop());
 
     INFO(qapi->GetHistory());
     CHECK(qapi->xCallbacks.size() == 4);

--- a/src/Qir/Tests/QIR-static/qir-test-math.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-math.cpp
@@ -8,85 +8,85 @@
 
 #include "qsharp__foundation_internal.hpp"
 
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SqrtTest__body();                                  // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__LogTest__body();                                   // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcTan2Test__body();                               // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SinTest__body();                                   // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__CosTest__body();                                   // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TanTest__body();                                   // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcSinTest__body();                                // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcCosTest__body();                                // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcTanTest__body();                                // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SinhTest__body();                                  // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__CoshTest__body();                                  // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TanhTest__body();                                  // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__IeeeRemainderTest__body();                         // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__body(int64_t min, int64_t max); // NOLINT
-extern "C" double Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__body(double min, double max);  // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SqrtTest__Interop();                                  // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__LogTest__Interop();                                   // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcTan2Test__Interop();                               // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SinTest__Interop();                                   // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__CosTest__Interop();                                   // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TanTest__Interop();                                   // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcSinTest__Interop();                                // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcCosTest__Interop();                                // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcTanTest__Interop();                                // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SinhTest__Interop();                                  // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__CoshTest__Interop();                                  // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TanhTest__Interop();                                  // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__IeeeRemainderTest__Interop();                         // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(int64_t min, int64_t max); // NOLINT
+extern "C" double Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(double min, double max);  // NOLINT
 
 TEST_CASE("QIR: Math.Sqrt", "[qir.math][qir.Math.Sqrt]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__SqrtTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__SqrtTest__Interop());
 }
 
 TEST_CASE("QIR: Math.Log", "[qir.math][qir.Math.Log]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__LogTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__LogTest__Interop());
 }
 
 TEST_CASE("QIR: Math.ArcTan2", "[qir.math][qir.Math.ArcTan2]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__ArcTan2Test__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__ArcTan2Test__Interop());
 }
 
 TEST_CASE("QIR: Math.Sin", "[qir.math][qir.Math.Sin]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__SinTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__SinTest__Interop());
 }
 
 TEST_CASE("QIR: Math.Cos", "[qir.math][qir.Math.Cos]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__CosTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__CosTest__Interop());
 }
 
 TEST_CASE("QIR: Math.Tan", "[qir.math][qir.Math.Tan]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__TanTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__TanTest__Interop());
 }
 
 TEST_CASE("QIR: Math.ArcSin", "[qir.math][qir.Math.ArcSin]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__ArcSinTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__ArcSinTest__Interop());
 }
 
 TEST_CASE("QIR: Math.ArcCos", "[qir.math][qir.Math.ArcCos]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__ArcCosTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__ArcCosTest__Interop());
 }
 
 TEST_CASE("QIR: Math.ArcTan", "[qir.math][qir.Math.ArcTan]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__ArcTanTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__ArcTanTest__Interop());
 }
 
 TEST_CASE("QIR: Math.Sinh", "[qir.math][qir.Math.Sinh]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__SinhTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__SinhTest__Interop());
 }
 
 TEST_CASE("QIR: Math.Cosh", "[qir.math][qir.Math.Cosh]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__CoshTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__CoshTest__Interop());
 }
 
 TEST_CASE("QIR: Math.Tanh", "[qir.math][qir.Math.Tanh]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__TanhTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__TanhTest__Interop());
 }
 
 TEST_CASE("QIR: Math.IeeeRemainder", "[qir.math][qir.Math.IeeeRemainder]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__IeeeRemainderTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Math__IeeeRemainderTest__Interop());
 }
 
 TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
@@ -96,20 +96,20 @@ TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
     while(--times)
     {
         const uint64_t qsRndNum = 
-            Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__body(std::numeric_limits<int64_t>::min(),
+            Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(std::numeric_limits<int64_t>::min(),
                                                                             std::numeric_limits<int64_t>::max());
         const uint64_t cppRndNum = Quantum::Qis::Internal::GetLastGeneratedRandomI64();  // This call must be done 
-            // _after_ the  Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__body().
+            // _after_ the  Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop().
         REQUIRE(qsRndNum == cppRndNum);
     }
 
     // Make sure the correct exception is thrown if min > max:
-    REQUIRE_THROWS_AS(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__body(10, 5), std::runtime_error);
+    REQUIRE_THROWS_AS(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(10, 5), std::runtime_error);
 
     // Check the exception string:
     try
     {
-        (void)Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__body(10, 5);
+        (void)Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(10, 5);
     }
     catch (std::runtime_error const& exc)
     {
@@ -119,7 +119,7 @@ TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
     // Test equal minimum and maximum:
     for(uint64_t num: { -5, 0, 3 } )
     {
-        REQUIRE(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__body(num, num) == num);
+        REQUIRE(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(num, num) == num);
     }
 
     // There is a strong difference in the opinions about how the random number generator must be tested.
@@ -180,7 +180,7 @@ TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
     //     actualNumbers.reserve(times);
     //     while (times--)
     //     {
-    //         actualNumbers.emplace_back(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__body(-10, 10));
+    //         actualNumbers.emplace_back(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(-10, 10));
     //     }
 
     //     // Compare the actual numbers with the expected ones:
@@ -197,7 +197,7 @@ TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
     //     while (times--)
     //     {
     //         actualNumbers.emplace_back(
-    //             Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__body(std::numeric_limits<int64_t>::min(),
+    //             Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(std::numeric_limits<int64_t>::min(),
     //                                                                             std::numeric_limits<int64_t>::max()));
     //     }
 
@@ -216,20 +216,20 @@ TEST_CASE("QIR: Math.DrawRandomDouble", "[qir.math][qir.Math.DrawRandomDouble]")
     while(--times)
     {
         const double qsRndNum = 
-            Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__body(std::numeric_limits<double>::min(),
+            Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(std::numeric_limits<double>::min(),
                                                                                std::numeric_limits<double>::max());
         const double cppRndNum = Quantum::Qis::Internal::GetLastGeneratedRandomDouble();  // This call must be done 
-            // _after_ the  Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__body().
+            // _after_ the  Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop().
         REQUIRE(qsRndNum == cppRndNum);
     }
 
     // Make sure the correct exception is thrown if min > max:
-    REQUIRE_THROWS_AS(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__body(10.0, 5.0), std::runtime_error);
+    REQUIRE_THROWS_AS(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(10.0, 5.0), std::runtime_error);
 
     // Check the exception string:
     try
     {
-        (void)Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__body(10.0, 5.0);
+        (void)Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(10.0, 5.0);
     }
     catch (std::runtime_error const& exc)
     {

--- a/src/Qir/Tests/QIR-static/qir-test-other.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-other.cpp
@@ -3,22 +3,22 @@
 
 #include "catch.hpp"
 
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__ParityTest__body();                // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntTest__body();       // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntFailTest__body();   // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__ParityTest__Interop();                // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntTest__Interop();       // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntFailTest__Interop();   // NOLINT
 
 TEST_CASE("QIR: Other.PauliArrayAsIntFail", "[qir.Other][qir.Other.PauliArrayAsIntFail]")
 {
-    REQUIRE_THROWS(Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntFailTest__body());
+    REQUIRE_THROWS(Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntFailTest__Interop());
 }
 
 TEST_CASE("QIR: Other.PauliArrayAsInt", "[qir.Other][qir.Other.PauliArrayAsInt]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntTest__Interop());
 }
 
 
 TEST_CASE("QIR: Other.Parity", "[qir.Other][qir.Other.Parity]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Other__ParityTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Other__ParityTest__Interop());
 }

--- a/src/Qir/Tests/QIR-static/qir-test-ouput.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-ouput.cpp
@@ -4,11 +4,10 @@
 
 #include "catch.hpp"
 
-#include "QirTypes.hpp"
 #include "QirRuntime.hpp"
 #include "OutputStream.hpp"
 
-extern "C" void Microsoft__Quantum__Testing__QIR__Out__MessageTest__body(void*); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__QIR__Out__MessageTest__Interop(const char[]); // NOLINT
 
 TEST_CASE("QIR: Out.Message", "[qir.Out][qir.Out.Message]")
 {
@@ -22,10 +21,8 @@ TEST_CASE("QIR: Out.Message", "[qir.Out][qir.Out.Message]")
         Microsoft::Quantum::OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
 
         // Log something (to the redirected output):
-        QirString qstr{std::string(testStr1)};
-        Microsoft__Quantum__Testing__QIR__Out__MessageTest__body(&qstr);
-        qstr.str = testStr2;
-        Microsoft__Quantum__Testing__QIR__Out__MessageTest__body(&qstr);
+        Microsoft__Quantum__Testing__QIR__Out__MessageTest__Interop(testStr1.c_str());
+        Microsoft__Quantum__Testing__QIR__Out__MessageTest__Interop(testStr2.c_str());
 
     } // Recover the output stream.
 

--- a/src/Qir/Tests/QIR-static/qir-test-strings.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-strings.cpp
@@ -5,11 +5,11 @@
 #include "catch.hpp"
 
 
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Str__PauliToStringTest__body();   // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Str__PauliToStringTest__Interop();   // NOLINT
 
 
 TEST_CASE("QIR: Strings", "[qir.Str][qir.Str.PauliToString]")
 {
-    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Str__PauliToStringTest__body());
+    REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Str__PauliToStringTest__Interop());
 }
 

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-arrays.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-arrays.qs
@@ -8,7 +8,7 @@ namespace Microsoft.Quantum.Testing.QIR {
     open Microsoft.Quantum.Testing.QIR.Out;
 
     @EntryPoint()
-    operation Test_Arrays(array : Int[], index : Int, val : Int, compilerDecoy : Bool) : Int {
+    operation Test_Arrays(array : Int[], index : Int, val : Int) : Int {
         // exercise __quantum__rt__array_copy
         mutable local = array;
 
@@ -31,40 +31,6 @@ namespace Microsoft.Quantum.Testing.QIR {
             set sum += result[i];
         }
 
-        // The purpose of this block is to keep the Q# compiler from optimizing away other tests when generating QIR
-        if (compilerDecoy) {
-            let res1_1 = TestFunctors();
-            let res1_2 = TestFunctorsNoArgs();
-            let res2 = TestPartials(17, 42);
-            TestQubitResultManagement();
-
-            // Math tests:
-            let res4 = SqrtTest();
-            let res5 = LogTest();
-            let res6 = ArcTan2Test();
-            let res7 = PauliToStringTest();
-            let res8 = TestDrawRandomInt(0, 1);
-            let res9 = SinTest();
-            let res10 = CosTest();
-            let res11 = TanTest();
-            let res12 = SinhTest();
-            let res13 = CoshTest();
-            let res14 = TanhTest();
-            let res15 = IeeeRemainderTest();
-            let res16 = ArcSinTest();
-            let res17 = ArcCosTest();
-            let res18 = ArcTanTest();
-            let res19 = ParityTest();
-            let res20 = PauliArrayAsIntTest();
-            let res21 = PauliArrayAsIntFailTest();
-            let res22 = TestDrawRandomDouble(0.0, 1.0);
-            MessageTest("Test");
-
-            // Conditionals:
-            TestApplyIf();
-            TestApplyIfWithFunctors();
-            TestApplyConditionally();
-        }
         return sum;
     }
 }

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-conditionals.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-conditionals.qs
@@ -4,6 +4,7 @@ namespace Microsoft.Quantum.Testing.QIR {
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Simulation.QuantumProcessor.Extensions;
 
+    @EntryPoint()
     operation TestApplyIf() : Unit {
         use q1 = Qubit();
         use q2 = Qubit();
@@ -23,6 +24,7 @@ namespace Microsoft.Quantum.Testing.QIR {
         ApplyIfZero(r1, (X, q1));
     }
 
+    @EntryPoint()
     operation TestApplyIfWithFunctors() : Unit {
         use q1 = Qubit();
         use q2 = Qubit();
@@ -44,6 +46,7 @@ namespace Microsoft.Quantum.Testing.QIR {
         Adjoint Controlled ApplyIfZeroCA([q2], (r1, (X, q1)));
     }
 
+    @EntryPoint()
     operation TestApplyConditionally() : Unit {
         use q1 = Qubit();
         use q2 = Qubit();

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-functors.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-functors.qs
@@ -32,6 +32,7 @@ namespace Microsoft.Quantum.Testing.QIR {
     // BasicMeasurementFeedback, which in turn doesn't allow updating mutables inside measurement conditionals.
     // this means, we cannot easily get detailed failure information back from Q#, but the test driver can mock
     // the simulator to track the point of failure.
+    @EntryPoint()
     operation TestFunctors() : Unit {
         let qop = Qop(_, 1);
         let adj_qop = Adjoint qop;
@@ -80,6 +81,7 @@ namespace Microsoft.Quantum.Testing.QIR {
         }
     }
 
+    @EntryPoint()
     operation TestFunctorsNoArgs() : Unit {
         NoArgs();
         let qop = NoArgs;

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-math.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-math.qs
@@ -8,6 +8,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
     open Microsoft.Quantum.Random;
     open Microsoft.Quantum.Convert;     // DoubleAsString()
 
+    @EntryPoint()
     function SqrtTest() : Int {
         if  2.0 != Sqrt(  4.0)          { return 1; }           // The return value indicates which test case has failed.
         if  3.0 != Sqrt(  9.0)          { return 2; }     
@@ -20,6 +21,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function LogTest() : Int {
         if 1.0 != Log(E())                          { return 1; }       // ln(e)   -> 1     // The return value indicates which test case has failed.
         if 2.0 != Log(E() * E())                    { return 2; }       // ln(e^2) -> 2
@@ -32,6 +34,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function ArcTan2Test() : Int {
 
         // function ArcTan2(y : Double, x : Double) : Double 
@@ -62,14 +65,17 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     operation TestDrawRandomInt(min : Int, max : Int) : Int {
         return DrawRandomInt(min, max);
     }
 
+    @EntryPoint()
     operation TestDrawRandomDouble(min : Double, max : Double) : Double {
         return DrawRandomDouble(min, max);
     }
 
+    @EntryPoint()
     function Close(expected : Double, actual : Double) : Bool {
         let neighbourhood = 0.0000001;  // On x86-64 + Win the error is in 16th digit after the decimal point. 
                                         // E.g. enstead of 0.0 there can be 0.00000000000000012.
@@ -78,6 +84,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return ((expected - neighbourhood) < actual) and (actual < (expected + neighbourhood));
     }
 
+    @EntryPoint()
     function SinTest() : Int {
 
         // function Sin (theta : Double) : Double
@@ -101,6 +108,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function CosTest() : Int {
 
         // function Cos (theta : Double) : Double
@@ -124,6 +132,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function TanTest() : Int {
         // function Tan (theta : Double) : Double
         if not Close( 0.0, Tan(0.0))                            { return  1; }    // The return value indicates which test case has failed.
@@ -148,6 +157,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function ArcSinTest() : Int {
 
         // function ArcSin (theta : Double) : Double
@@ -175,6 +185,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function ArcCosTest() : Int {
 
         // function ArcCos (theta : Double) : Double
@@ -200,6 +211,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function ArcTanTest() : Int {
 
         // function ArcTan (theta : Double) : Double
@@ -226,6 +238,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function SinhTest() : Int {
 
         // function Sinh (theta : Double) : Double
@@ -243,6 +256,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function CoshTest() : Int {
 
         // function Cosh (theta : Double) : Double
@@ -260,6 +274,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function TanhTest() : Int {
 
         // function Tanh (theta : Double) : Double
@@ -277,6 +292,7 @@ namespace Microsoft.Quantum.Testing.QIR.Math {
         return 0;
     }
 
+    @EntryPoint()
     function IeeeRemainderTest() : Int {
 
         // function IeeeRemainder(x : Double, y : Double) : Double

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-other.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-other.qs
@@ -6,6 +6,7 @@ namespace Microsoft.Quantum.Testing.QIR.Other {
     open Microsoft.Quantum.Bitwise;
     open Microsoft.Quantum.Convert;
 
+    @EntryPoint()
     function PauliArrayAsIntTest() : Int {
         if 0 != PauliArrayAsInt([PauliI]) { return  1; }   // The return value indicates which test case has failed.
         if 1 != PauliArrayAsInt([PauliX]) { return  2; }
@@ -23,10 +24,12 @@ namespace Microsoft.Quantum.Testing.QIR.Other {
         return 0;
     }
 
+    @EntryPoint()
     function PauliArrayAsIntFailTest() : Int {
         return PauliArrayAsInt(new Pauli[32]);   // Must fail/throw.
     }
 
+    @EntryPoint()
     function ParityTest() : Int {
         //function Parity (a : Int) : Int
         if 0 != Parity(0)                       { return  1; }  // The return value indicates which test case has failed.

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-output.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-output.qs
@@ -5,6 +5,7 @@ namespace Microsoft.Quantum.Testing.QIR.Out {
 
     open Microsoft.Quantum.Intrinsic;
 
+    @EntryPoint()
     function MessageTest(msg: String) : Unit {
         Message(msg);
     }

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-partials.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-partials.qs
@@ -6,6 +6,7 @@ namespace Microsoft.Quantum.Testing.QIR {
         return from - what;
     }
 
+    @EntryPoint()
     function TestPartials(x : Int, y : Int) : Int {
         let subtractor = Subtract(x, _);
         return subtractor(y);

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-qubits-results.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-qubits-results.qs
@@ -3,6 +3,7 @@
 namespace Microsoft.Quantum.Testing.QIR {
     open Microsoft.Quantum.Intrinsic;
 
+    @EntryPoint()
     operation TestQubitResultManagement() : Unit {
         // exercise __quantum__rt__qubit_allocate_array
         use qs = Qubit[2] {

--- a/src/Qir/Tests/QIR-static/qsharp/qir-test-strings.qs
+++ b/src/Qir/Tests/QIR-static/qsharp/qir-test-strings.qs
@@ -5,6 +5,7 @@ namespace Microsoft.Quantum.Testing.QIR.Str {
 
     open Microsoft.Quantum.Intrinsic;
 
+    @EntryPoint()
     function PauliToStringTest() : Int {
 
         if "Pauli value: PauliI" != 

--- a/src/Qir/Tests/QIR-tracer/CMakeLists.txt
+++ b/src/Qir/Tests/QIR-tracer/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(TEST_FILES
-  qsharp/qir/tracer-qir.ll
+  qsharp/obj/qsharp/tracer-qir.bc
 )
 
 #==============================================================================

--- a/src/Qir/Tests/QIR-tracer/qir-tracer-driver.cpp
+++ b/src/Qir/Tests/QIR-tracer/qir-tracer-driver.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Invoke each intrinsic from Q# core once", "[qir-tracer]")
     shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/, g_operationNames);
     QirExecutionContext::Scoped qirctx(tr.get(), true /*trackAllocatedObjects*/);
 
-    REQUIRE_NOTHROW(Microsoft__Quantum__Testing__Tracer__TestCoreIntrinsics__body());
+    REQUIRE_NOTHROW(Microsoft__Quantum__Testing__Tracer__TestCoreIntrinsics__Interop());
     const vector<Layer>& layers = tr->UseLayers();
 
     std::stringstream out;
@@ -39,7 +39,7 @@ TEST_CASE("Conditional execution on measurement result", "[qir-tracer]")
     shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/, g_operationNames);
     QirExecutionContext::Scoped qirctx(tr.get(), true /*trackAllocatedObjects*/);
 
-    REQUIRE_NOTHROW(Microsoft__Quantum__Testing__Tracer__TestMeasurements__body());
+    REQUIRE_NOTHROW(Microsoft__Quantum__Testing__Tracer__TestMeasurements__Interop());
 
     std::stringstream out;
     tr->PrintLayerMetrics(out, ",", true /*printZeroMetrics*/);

--- a/src/Qir/Tests/QIR-tracer/qsharp/tracer-conditionals.qs
+++ b/src/Qir/Tests/QIR-tracer/qsharp/tracer-conditionals.qs
@@ -9,6 +9,7 @@ namespace Microsoft.Quantum.Testing.Tracer {
         op(arg);
     }
 
+    @EntryPoint()
     operation TestMeasurements() : Unit {
         use qs = Qubit[6];
         T(qs[0]); // layer 0

--- a/src/Qir/Tests/QIR-tracer/qsharp/tracer-intrinsics.qs
+++ b/src/Qir/Tests/QIR-tracer/qsharp/tracer-intrinsics.qs
@@ -5,6 +5,7 @@ namespace Microsoft.Quantum.Testing.Tracer {
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Tracer;
 
+    @EntryPoint()
     operation TestCoreIntrinsics() : Unit {
         use qs = Qubit[3];
 

--- a/src/Qir/Tests/QIR-tracer/tracer-config.hpp
+++ b/src/Qir/Tests/QIR-tracer/tracer-config.hpp
@@ -16,5 +16,5 @@ extern const std::unordered_map<Microsoft::Quantum::OpId, std::string> g_operati
 } // namespace TracerUser
 
 // Available function in generated QIR
-extern "C" void Microsoft__Quantum__Testing__Tracer__TestCoreIntrinsics__body(); // NOLINT
-extern "C" void Microsoft__Quantum__Testing__Tracer__TestMeasurements__body(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__Tracer__TestCoreIntrinsics__Interop(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__Tracer__TestMeasurements__Interop(); // NOLINT


### PR DESCRIPTION
This change updates the calling conventions used in the QIR Runtime tests to use `__Interop` wrappers for calling functions. This also required updating some older tests to the multiple entry point strategy for testing so that each test function is considered an externally callable operation/function. In addition, this updates the CMakeLists.txt to consume the bitcode files instead of the human readable .ll files wherever possible.