### PR TITLE
Add IQSharpSubmitter and mark IQuantumMachine and related types as obsolete

### DIFF
--- a/src/Simulation/Core/Microsoft.Quantum.Runtime.Core.csproj
+++ b/src/Simulation/Core/Microsoft.Quantum.Runtime.Core.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
+    <RootNamespace>Microsoft.Quantum.Runtime</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Simulation/Core/Submitters/IAzureSubmitter.cs
+++ b/src/Simulation/Core/Submitters/IAzureSubmitter.cs
@@ -3,7 +3,7 @@
 
 #nullable enable
 
-namespace Microsoft.Quantum.Runtime
+namespace Microsoft.Quantum.Runtime.Submitters
 {
     /// <summary>
     /// An interface for submitting quantum programs to Azure.

--- a/src/Simulation/Core/Submitters/IQSharpSubmitter.cs
+++ b/src/Simulation/Core/Submitters/IQSharpSubmitter.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using Microsoft.Quantum.Simulation.Core;
+using System.Threading.Tasks;
+
+namespace Microsoft.Quantum.Runtime.Submitters
+{
+    /// <summary>
+    /// An interface for submitting Q# programs to Azure.
+    /// </summary>
+    public interface IQSharpSubmitter : IAzureSubmitter
+    {
+        /// <summary>
+        /// Submits a job to execute a Q# program without waiting for execution to complete.
+        /// </summary>
+        /// <typeparam name="TIn">The entry point argument type.</typeparam>
+        /// <typeparam name="TOut">The entry point return type.</typeparam>
+        /// <param name="entryPoint">The entry point information for the submitted program.</param>
+        /// <param name="argument">The argument to the entry point.</param>
+        /// <param name="options">Additional options for the submission.</param>
+        /// <returns>The submitted job.</returns>
+        Task<IQuantumMachineJob> SubmitAsync<TIn, TOut>(
+            EntryPointInfo<TIn, TOut> entryPoint, TIn argument, SubmissionOptions options);
+
+        /// <summary>
+        /// Validates a Q# program for execution on Azure Quantum.
+        /// </summary>
+        /// <typeparam name="TIn">The entry point argument type.</typeparam>
+        /// <typeparam name="TOut">The entry point return type.</typeparam>
+        /// <param name="entryPoint">The entry point information for the submitted program.</param>
+        /// <param name="argument">The argument to the entry point.</param>
+        /// <returns><c>null</c> if the program is valid, or an error message otherwise.</returns>
+        string? Validate<TIn, TOut>(EntryPointInfo<TIn, TOut> entryPoint, TIn argument);
+    }
+}

--- a/src/Simulation/Core/Submitters/IQirSubmitter.cs
+++ b/src/Simulation/Core/Submitters/IQirSubmitter.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Microsoft.Quantum.Runtime
+namespace Microsoft.Quantum.Runtime.Submitters
 {
     /// <summary>
     /// An interface for submitting QIR programs to Azure.

--- a/src/Simulation/Core/Submitters/IQirSubmitter.cs
+++ b/src/Simulation/Core/Submitters/IQirSubmitter.cs
@@ -20,7 +20,9 @@ namespace Microsoft.Quantum.Runtime
         /// <param name="qir">The QIR program as a byte stream.</param>
         /// <param name="entryPoint">The fully-qualified name of the entry point to execute.</param>
         /// <param name="arguments">The arguments to the entry point in the order in which they are declared.</param>
+        /// <param name="options">Additional options for the submission.</param>
         /// <returns>The submitted job.</returns>
-        Task<IQuantumMachineJob> SubmitAsync(Stream qir, string entryPoint, IReadOnlyList<Argument> arguments);
+        Task<IQuantumMachineJob> SubmitAsync(
+            Stream qir, string entryPoint, IReadOnlyList<Argument> arguments, SubmissionOptions options);
     }
 }

--- a/src/Simulation/Core/Submitters/IQuantumMachine.cs
+++ b/src/Simulation/Core/Submitters/IQuantumMachine.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
+using Microsoft.Quantum.Runtime.Submitters;
 using Microsoft.Quantum.Simulation.Core;
+using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Quantum.Runtime
 {
     /// <summary>
     /// An interface for submitting Q# programs to Azure.
     /// </summary>
+    [Obsolete("Replaced by IQSharpSubmitter.")]
     public interface IQuantumMachine : IAzureSubmitter
     {
         /// <summary>

--- a/src/Simulation/Core/Submitters/IQuantumMachineExecutionContext.cs
+++ b/src/Simulation/Core/Submitters/IQuantumMachineExecutionContext.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Quantum.Runtime
 {
     /// <summary>
     /// Interface to provide configuration details to manage execution.
     /// </summary>
+    [Obsolete("No longer used.")]
     public interface IQuantumMachineExecutionContext
     {
         /// <summary>

--- a/src/Simulation/Core/Submitters/IQuantumMachineOutput.cs
+++ b/src/Simulation/Core/Submitters/IQuantumMachineOutput.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Quantum.Runtime
@@ -9,6 +10,7 @@ namespace Microsoft.Quantum.Runtime
     /// Interface to access the results of a program executed in a quantum machine.
     /// <typeparam name="TOutput">Type of output the quantum program returns.</typeparam>
     /// </summary>
+    [Obsolete("No longer used.")]
     public interface IQuantumMachineOutput<TOutput>
     {
         /// <summary>

--- a/src/Simulation/Core/Submitters/IQuantumMachineSubmissionContext.cs
+++ b/src/Simulation/Core/Submitters/IQuantumMachineSubmissionContext.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Quantum.Runtime
 {
     /// <summary>
     /// Interface to provide configuration details to submit a job.
     /// </summary>
+    [Obsolete("Replaced by SubmissionOptions.")]
     public interface IQuantumMachineSubmissionContext
     {
         /// <summary>

--- a/src/Simulation/Core/Submitters/SubmissionOptions.cs
+++ b/src/Simulation/Core/Submitters/SubmissionOptions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+namespace Microsoft.Quantum.Runtime
+{
+    /// <summary>
+    /// Options for a job submitted to Azure Quantum.
+    /// </summary>
+    public class SubmissionOptions
+    {
+        /// <summary>
+        /// A name describing the job.
+        /// </summary>
+        public string FriendlyName { get; }
+
+        /// <summary>
+        /// The number of times the program will be executed.
+        /// </summary>
+        public int Shots { get; }
+
+        /// <summary>
+        /// Creates a new set of submission options.
+        /// </summary>
+        /// <param name="friendlyName">A name describing the job.</param>
+        /// <param name="shots">The number of times the program will be executed.</param>
+        public SubmissionOptions(string friendlyName, int shots) =>
+            (this.FriendlyName, this.Shots) = (friendlyName, shots);
+    }
+}

--- a/src/Simulation/Core/Submitters/SubmissionOptions.cs
+++ b/src/Simulation/Core/Submitters/SubmissionOptions.cs
@@ -3,7 +3,7 @@
 
 #nullable enable
 
-namespace Microsoft.Quantum.Runtime
+namespace Microsoft.Quantum.Runtime.Submitters
 {
     /// <summary>
     /// Options for a job submitted to Azure Quantum.


### PR DESCRIPTION
* No factory for IQSharpSubmitter (or IQirSubmitter) yet since there are no concrete implementations.
* Naming oddity: IQuantumMachineJob is used by the new submitters. Not sure if it's worth renaming this, or what to rename it to. AzureJob? AzureQuantumJob?