### PR TITLE
Better reuse of qubits within block

### DIFF
--- a/src/Simulation/Simulators.Tests/Circuits/ResourcesEstimator.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/ResourcesEstimator.qs
@@ -107,4 +107,33 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         }
     }
 
+    operation ReuseInBlockOrdered() : Unit {
+        body (...) {
+            use a = Qubit[8] {
+                CNOT(a[0], a[1]);
+                CNOT(a[0], a[2]);
+                CNOT(a[0], a[3]);
+                CNOT(a[0], a[4]);
+                CNOT(a[0], a[5]);
+                CNOT(a[0], a[6]);
+                CNOT(a[0], a[7]);
+            }
+        }
+    }
+
+    operation ReuseInBlockMixed() : Unit {
+        body (...) {
+            use a = Qubit[8] {
+                CNOT(a[0], a[1]);
+                CNOT(a[0], a[3]);
+                CNOT(a[0], a[5]);
+                CNOT(a[0], a[7]);
+                CNOT(a[0], a[6]);
+                CNOT(a[0], a[4]);
+                CNOT(a[0], a[2]);
+            }
+        }
+    }
+
+
 }

--- a/src/Simulation/Simulators.Tests/ResourcesEstimatorTests.cs
+++ b/src/Simulation/Simulators.Tests/ResourcesEstimatorTests.cs
@@ -232,5 +232,34 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.Equal(2.0 + 3.0 + 3.0, data3.Rows.Find("QubitCount")["Sum"]);
             Assert.Equal(3.0, data3.Rows.Find("QubitCount")["Max"]);
         }
+
+
+        [Fact]
+        public void ReuseInBlockOrderedTest() {
+            QCTraceSimulators.QCTraceSimulatorConfiguration config = ResourcesEstimator.RecommendedConfig();
+            config.OptimizeDepth = true;
+            var sim = new ResourcesEstimator(config);
+
+            ReuseInBlockOrdered.Run(sim).Wait();
+
+            Assert.Equal(8.0, sim.Data.Rows.Find("QubitCount")["Sum"]);
+            Assert.Equal(2.0, sim.Data.Rows.Find("Width")["Sum"]);
+            Assert.Equal(0.0, sim.Data.Rows.Find("Depth")["Sum"]);
+        }
+
+        [Fact]
+        public void ReuseInBlockMixedTest() {
+            QCTraceSimulators.QCTraceSimulatorConfiguration config = ResourcesEstimator.RecommendedConfig();
+            config.OptimizeDepth = true;
+            var sim = new ResourcesEstimator(config);
+
+            ReuseInBlockMixed.Run(sim).Wait();
+
+            Assert.Equal(8.0, sim.Data.Rows.Find("QubitCount")["Sum"]);
+            Assert.Equal(2.0, sim.Data.Rows.Find("Width")["Sum"]);
+            Assert.Equal(0.0, sim.Data.Rows.Find("Depth")["Sum"]);
+        }
+
+
     }
 }


### PR DESCRIPTION
Better reuse of qubits within one block.
When multiple qubits are released at the same time, they are sorted on the start of their busy time. This heuristic should result in a better reuse of qubits within one block.