### PR TITLE
Fix Linux Clang build by including cstddef.h header explicitly

### DIFF
--- a/src/Qir/Runtime/public/QirTypes.hpp
+++ b/src/Qir/Runtime/public/QirTypes.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <vector>
+#include <cstddef>
 
 #include "CoreTypes.hpp"
 


### PR DESCRIPTION
Include cstddef.h header explicitly to ensure a deterministic behavior across platforms.