### PR TITLE
Target both Net5.0 and 3.1 for core compiler and runtime assemblies.

### DIFF
--- a/AdvantageBenchmark/privateBuild/host.csproj
+++ b/AdvantageBenchmark/privateBuild/host.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages> <!-- otherwise the standard library is included by the Sdk -->
   </PropertyGroup>
 

--- a/AdvantageBenchmark/privateBuild/host.csproj
+++ b/AdvantageBenchmark/privateBuild/host.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages> <!-- otherwise the standard library is included by the Sdk -->
   </PropertyGroup>
 

--- a/AdvantageBenchmark/releasedBuild/host/host.csproj
+++ b/AdvantageBenchmark/releasedBuild/host/host.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/AdvantageBenchmark/releasedBuild/host/host.csproj
+++ b/AdvantageBenchmark/releasedBuild/host/host.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/Simulation/CSharpGeneration.App/Microsoft.Quantum.CSharpGeneration.App.fsproj
+++ b/src/Simulation/CSharpGeneration.App/Microsoft.Quantum.CSharpGeneration.App.fsproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <AssemblyName>Microsoft.Quantum.CSharpGeneration.App</AssemblyName>
-    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/Simulation/CSharpGeneration.App/Microsoft.Quantum.CSharpGeneration.App.fsproj
+++ b/src/Simulation/CSharpGeneration.App/Microsoft.Quantum.CSharpGeneration.App.fsproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <AssemblyName>Microsoft.Quantum.CSharpGeneration.App</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
Cross-repo change to add limited support for users that only have .Net5 installed.