### PR TITLE
Increasing the CMAKE required version for QIR

### DIFF
--- a/src/Qir/Runtime/CMakeLists.txt
+++ b/src/Qir/Runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 message(INFO "*** build config: ${CMAKE_BUILD_TYPE}")
 

--- a/src/Qir/Samples/CMakeLists.txt
+++ b/src/Qir/Samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 message(INFO "*** build config: ${CMAKE_BUILD_TYPE}")
 

--- a/src/Qir/Tests/CMakeLists.txt
+++ b/src/Qir/Tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 message(INFO "*** build config: ${CMAKE_BUILD_TYPE}")
 


### PR DESCRIPTION
This updates the required version for CMAKE in the CMakeLists.txt files for QIR, since we are now using features not correctly supported on older versions.