### PR TITLE
Add DelaySign.cs to AutoSubstitution project.

### DIFF
--- a/src/Simulation/AutoSubstitution/AutoSubstitution.csproj
+++ b/src/Simulation/AutoSubstitution/AutoSubstitution.csproj
@@ -15,4 +15,9 @@
     <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.16.2105140327-beta" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Common\DelaySign.cs" Link="Properties\DelaySign.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR should fix build failures in our release pipeline by allowing delay signing of the new Microsoft.Quantum.AutoSubstitution assembly.