### PR TITLE
Call cbindgen manually

### DIFF
--- a/src/Simulation/qdk_sim_rs/Cargo.toml.template
+++ b/src/Simulation/qdk_sim_rs/Cargo.toml.template
@@ -4,16 +4,19 @@
 [package]
 name = "qdk_sim_experimental"
 version = "0.1.0"
-authors = ["Christopher Granade <cgranade@cgranade.com>"]
+authors = ["Microsoft"]
 edition = "2018"
 license = "MIT"
 description = "Experimental simulators for use with the Quantum Development Kit."
 homepage = "https://github.com/microsoft/qsharp-runtime"
 repository = "https://github.com/microsoft/qsharp-runtime"
+readme = "README.md"
 
 exclude = [
     # Exclude files specific to QDK build pipelines.
     "*.template", "*.csx", "*.ps1", "NuGet.Config", "drop",
+    # Don't include cbindgen configs and outputs.
+    "include", "cbindgen.toml",
     # Don't include Python sources or build artifacts.
     "*.egg-info", "qdk_sim_experimental", "setup.py", "*.whl", "pyproject.toml"
 ]

--- a/src/Simulation/qdk_sim_rs/Cargo.toml.template
+++ b/src/Simulation/qdk_sim_rs/Cargo.toml.template
@@ -11,9 +11,11 @@ description = "Experimental simulators for use with the Quantum Development Kit.
 homepage = "https://github.com/microsoft/qsharp-runtime"
 repository = "https://github.com/microsoft/qsharp-runtime"
 
-# Exclude files specific to QDK build pipelines.
 exclude = [
-    "*.template", "*.csx", "*.ps1", "NuGet.Config", "drops"
+    # Exclude files specific to QDK build pipelines.
+    "*.template", "*.csx", "*.ps1", "NuGet.Config", "drop",
+    # Don't include Python sources or build artifacts.
+    "*.egg-info", "qdk_sim_experimental", "setup.py", "*.whl", "pyproject.toml"
 ]
 
 [lib]
@@ -72,7 +74,6 @@ built = "0.5.0"
 
 [build-dependencies]
 built = "0.5.0"
-cbindgen = "0.19.0"
 
 
 [dev-dependencies]

--- a/src/Simulation/qdk_sim_rs/build.rs
+++ b/src/Simulation/qdk_sim_rs/build.rs
@@ -1,33 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-extern crate cbindgen;
-
 use std::env;
+use std::path::Path;
 
 fn main() -> Result<(), String> {
     built::write_built_file().expect("Failed to acquire build-time information");
-
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    cbindgen::generate_with_config(
-        &crate_dir,
-        cbindgen::Config {
-            language: cbindgen::Language::C,
-            ..Default::default()
-        },
-    )
-    .map_err(|e| e.to_string())?
-    .write_to_file("include/qdk_sim.h");
-
-    cbindgen::generate_with_config(
-        &crate_dir,
-        cbindgen::Config {
-            ..Default::default()
-        },
-    )
-    .map_err(|e| e.to_string())?
-    .write_to_file("include/qdk_sim.hpp");
 
     Ok(())
 }

--- a/src/Simulation/qdk_sim_rs/docs/c-api.md
+++ b/src/Simulation/qdk_sim_rs/docs/c-api.md
@@ -17,10 +17,12 @@ API.
 The [`qdk_sim`](..) crate has enabled the use of [`cbindgen`](https://crates.io/crates/cbindgen), such that C-language header files are generated automatically as part of the build for this crate.
 
 ```bash
-cargo build
+cargo install --force cbindgen
+cbindgen --language C --output include/qdk_sim.h
+cbindgen --language C++ --output include/qdk_sim.hpp
 ```
 
-This will generate `include/qdk_sim.h`, which can then be used from C callers:
+This will generate `include/qdk_sim.h` and `include/qdk_sim.hpp, which can then be used from C and C++ callers, respectively. For example, to call from C:
 
 ```c
 #include <stdio.h>
@@ -45,7 +47,7 @@ int main() {
 To build and run the above example using Clang on Windows:
 
 ```bash
-$ clang docs/example.c -Iinclude -Ltarget/debug -lqdk_sim -lws2_32 -lAdvapi32 -lUserenv
+$ clang example.c -Iinclude -Ltarget/debug -lqdk_sim -lws2_32 -lAdvapi32 -lUserenv
 got 1 1
 ```
 


### PR DESCRIPTION
This PR moves generation of C API headers for `qdk_sim_experimental` from build.rs to a manual step. This avoids https://github.com/eqrion/cbindgen/issues/560, allowing for `cargo package` to proceed and fully verify the `qdk_sim_experimental` crate.