### PR TITLE
Warn when qdk_sim is missing instead of failing outright.

### DIFF
--- a/src/Simulation/Common/Simulators.Dev.props
+++ b/src/Simulation/Common/Simulators.Dev.props
@@ -42,12 +42,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(ExperimentalSimDll)" >
+    <None Include="$(ExperimentalSimDll)" Condition="Exists('$(ExperimentalSimDll)')">
       <Link>Microsoft.Quantum.Experimental.Simulators.Runtime.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>
   </ItemGroup>
+
+  <Target Name="ValidateExperimentalSimDll" BeforeTargets="GetCopyToOutputDirectoryItems">
+    <Warning
+      Text="The experimental simulator DLL was not found at '$(ExperimentalSimDll)'; not including in simulators package."
+      Condition="!Exists('$(ExperimentalSimDll)')"
+    />
+  </Target>
 
   <Target Name="BeforeCSharpCompile">
     <ItemGroup>


### PR DESCRIPTION
This PR allows for building the simulators package to proceed even when `qdk_sim_rs` has not yet been built, as per feedback from @anpaz. Simulator packages built this way will fail in unit and integration testing, but can still be useful for local development of other simulation features on machines without `rustup` / `cargo`.