### PR TITLE
Fix QIR Simulator dll load

### DIFF
--- a/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
@@ -29,12 +29,11 @@ typedef void* QUANTUM_SIMULATOR;
 
 namespace
 {
-#ifdef _WIN32
 const char* FULLSTATESIMULATORLIB = "Microsoft.Quantum.Simulator.Runtime.dll";
-#elif __APPLE__
-const char* FULLSTATESIMULATORLIB = "libMicrosoft.Quantum.Simulator.Runtime.dylib";
+#if defined(__APPLE__)
+const char* XPLATFULLSTATESIMULATORLIB = "libMicrosoft.Quantum.Simulator.Runtime.dylib";
 #else
-const char* FULLSTATESIMULATORLIB = "libMicrosoft.Quantum.Simulator.Runtime.so";
+const char* XPLATFULLSTATESIMULATORLIB = "libMicrosoft.Quantum.Simulator.Runtime.so";
 #endif
 
 QUANTUM_SIMULATOR LoadQuantumSimulator()
@@ -52,8 +51,12 @@ QUANTUM_SIMULATOR LoadQuantumSimulator()
     handle = ::dlopen(FULLSTATESIMULATORLIB, RTLD_LAZY);
     if (handle == nullptr)
     {
-        throw std::runtime_error(
-            std::string("Failed to load ") + FULLSTATESIMULATORLIB + " (" + ::dlerror() + ")");
+        handle = ::dlopen(XPLATFULLSTATESIMULATORLIB, RTLD_LAZY);
+        if (handle == nullptr)
+        {
+            throw std::runtime_error(
+                std::string("Failed to load ") + XPLATFULLSTATESIMULATORLIB + " (" + ::dlerror() + ")");
+        }
     }
 #endif
     return handle;

--- a/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
@@ -32,7 +32,7 @@ namespace
 const char* FULLSTATESIMULATORLIB = "Microsoft.Quantum.Simulator.Runtime.dll";
 #if defined(__APPLE__)
 const char* XPLATFULLSTATESIMULATORLIB = "libMicrosoft.Quantum.Simulator.Runtime.dylib";
-#else
+#elif !defined(_WIN32)
 const char* XPLATFULLSTATESIMULATORLIB = "libMicrosoft.Quantum.Simulator.Runtime.so";
 #endif
 


### PR DESCRIPTION
Since the packaged Fullstate Simulator always uses the Windows style dll name and local development (or xplat pipelines) need to handle the platform specific library name, we will imitate the loading patterns from .NET and try both when not on Windows.