### PR TITLE
QIR Validation Script - Runtime

### DIFF
--- a/src/Qir/Execution/Tools/Executable/QirFullStateExecutable.cs
+++ b/src/Qir/Execution/Tools/Executable/QirFullStateExecutable.cs
@@ -51,7 +51,6 @@ namespace Microsoft.Quantum.Qir.Tools.Executable
 
             LibraryDirectories.Add(new DirectoryInfo(Path.Combine(thisModulePath, "runtimes", osID, "native")));
             LibraryDirectories.Add(new DirectoryInfo(Path.Combine(thisModulePath, "Libraries", osID)));
-            LibraryDirectories.Add(new DirectoryInfo(Path.Combine(thisModulePath, "Libraries")));
         }
     }
 }

--- a/src/Qir/Execution/Tools/Microsoft.Quantum.Qir.Tools.csproj
+++ b/src/Qir/Execution/Tools/Microsoft.Quantum.Qir.Tools.csproj
@@ -68,7 +68,9 @@
 
   <ItemGroup>
     <None Include="$(QSimDll)">
-      <Link>Libraries\%(FileName)%(Extension)</Link>
+      <Link Condition="$([MSBuild]::IsOsPlatform('Windows'))">Libraries\win-x64\%(FileName)%(Extension)</Link>
+      <Link Condition="$([MSBuild]::IsOsPlatform('OSX'))">Libraries\osx-x64\%(FileName)%(Extension)</Link>
+      <Link Condition="$([MSBuild]::IsOsPlatform('Linux'))">Libraries\linux-x64\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>


### PR DESCRIPTION
Changes the location the Simulator dll is copied to. This avoids an error on ADO builds that causes the Simulator dll that is appropriate for the given os platform from being overwritten by the dll that is for Windows.

See also: https://github.com/microsoft/Quantum/pull/519