### PR TITLE
Enable Speculative Load Hardening and Retpoline

### DIFF
--- a/src/Qir/Runtime/CMakeLists.txt
+++ b/src/Qir/Runtime/CMakeLists.txt
@@ -11,6 +11,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
+# Always use available Spectre mitigations
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mspeculative-load-hardening -mretpoline")
+
 if (WIN32)
     add_link_options("LINKER:/guard:cf")
 endif()

--- a/src/Qir/Runtime/CMakeLists.txt
+++ b/src/Qir/Runtime/CMakeLists.txt
@@ -11,8 +11,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
-# Always use available Spectre mitigations
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mspeculative-load-hardening -mretpoline")
+# Always use available Spectre mitigations where available
+if (NOT APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mspeculative-load-hardening -mretpoline")
+endif()
 
 if (WIN32)
     add_link_options("LINKER:/guard:cf")

--- a/src/Qir/qir-utils.ps1
+++ b/src/Qir/qir-utils.ps1
@@ -35,7 +35,7 @@ function Build-CMakeProject {
     $oldCC = $env:CC
     $oldCXX = $env:CXX
     $oldRC = $env:RC
-    $oldCCFLAGS  = $env:CCFLAGS
+    $oldCFLAGS  = $env:CFLAGS
     $oldCXXFLAGS = $env:CXXFLAGS
 
     $clangTidy = ""
@@ -160,7 +160,7 @@ function Build-CMakeProject {
     Pop-Location
 
     $env:CXXFLAGS = $oldCXXFLAGS
-    $env:CCFLAGS  = $oldCCFLAGS
+    $env:CFLAGS  = $oldCFLAGS
 
     $env:CC = $oldCC
     $env:CXX = $oldCXX


### PR DESCRIPTION
These two flags correspond to the Speculative Execution Side-Channel attack (Spectre) mitigation used by Clang, as described in https://github.com/llvm/llvm-project/blob/d480f968ad8b56d3ee4a6b6df5532d485b0ad01e/llvm/docs/SpeculativeLoadHardening.md. The change also includes fixes to a build script use of environment variables for caching.