### PR TITLE
Remove reference to props

### DIFF
--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -26,6 +26,7 @@ $artifacts = @{
         "Microsoft.Quantum.Type1.Core",
         "Microsoft.Quantum.Type2.Core",
         "Microsoft.Quantum.Type3.Core",
+        "Microsoft.Quantum.Qir.Runtime",
         "Microsoft.Quantum.Qir.Tools",
         "Microsoft.Quantum.QSharp.Foundation"
         "Microsoft.Quantum.Runtime.Core",

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -163,13 +163,13 @@ Pack-Dotnet '../src/Simulation/QSharpCore/Microsoft.Quantum.QSharp.Core.csproj'
 Pack-Dotnet '../src/Simulation/Type1Core/Microsoft.Quantum.Type1.Core.csproj'
 Pack-Dotnet '../src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.csproj'
 Pack-Dotnet '../src/Simulation/Type3Core/Microsoft.Quantum.Type3.Core.csproj'
-Pack-Dotnet '../src/Qir/Execution/Tools/Microsoft.Quantum.Qir.Tools.csproj' -ForcePrerelease
-Pack-Dotnet '../src/Qir/Execution/CommandLineTool/Microsoft.Quantum.Qir.CommandLineTool.csproj' -ForcePrerelease
 Pack-One '../src/Simulation/Simulators/Microsoft.Quantum.Simulators.nuspec'
 Pack-One '../src/Xunit/Microsoft.Quantum.Xunit.csproj'
 Pack-Crate -PackageDirectory "../src/Simulation/qdk_sim_rs" -OutPath $Env:CRATE_OUTDIR;
 Pack-Wheel -PackageDirectory "../src/Simulation/qdk_sim_rs" -OutPath $Env:WHEEL_OUTDIR;
 Pack-One '../src/Qir/Runtime/Microsoft.Quantum.Qir.Runtime.nuspec' -ForcePrerelease
+Pack-Dotnet '../src/Qir/Execution/Tools/Microsoft.Quantum.Qir.Tools.csproj' -ForcePrerelease
+Pack-Dotnet '../src/Qir/Execution/CommandLineTool/Microsoft.Quantum.Qir.CommandLineTool.csproj' -ForcePrerelease
 
 Move-Item -Path (Join-Path $Env:NUGET_OUTDIR Microsoft.Quantum.Qir.CommandLineTool.*) -Destination $Env:INTERNAL_TOOLS_OUTDIR
 

--- a/src/Qir/Execution/Tools/Executable/ClangClient.cs
+++ b/src/Qir/Execution/Tools/Executable/ClangClient.cs
@@ -51,12 +51,12 @@ namespace Microsoft.Quantum.Qir.Tools.Executable
         private static void AddPathsToEnvironmentVariable(string variable, string[] values)
         {
             var newValue = string.Join(Path.PathSeparator, values);
-            var oldValue = Environment.GetEnvironmentVariable(variable);
+            var oldValue = System.Environment.GetEnvironmentVariable(variable);
             if (oldValue != null)
             {
                 newValue = oldValue + $"{Path.PathSeparator}{newValue}";
             }
-            Environment.SetEnvironmentVariable(variable, newValue);
+            System.Environment.SetEnvironmentVariable(variable, newValue);
         }
     }
 }

--- a/src/Qir/Execution/Tools/Microsoft.Quantum.Qir.Tools.csproj
+++ b/src/Qir/Execution/Tools/Microsoft.Quantum.Qir.Tools.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\..\Simulation\Common\Simulators.Dev.props" />
-
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/Qir/Execution/Tools/Microsoft.Quantum.Qir.Tools.csproj
+++ b/src/Qir/Execution/Tools/Microsoft.Quantum.Qir.Tools.csproj
@@ -12,7 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Quantum.Qir.Runtime" Version="0.18.2107150698-alpha" />
     <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.18.2107150698-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2107150698-alpha" />
   </ItemGroup>
   
   <ItemGroup>
@@ -49,47 +51,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>QirCppFullStateSimulatorInitializer.tt</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\..\..\Qir\drops\bin\**\*">
-      <Link>runtimes\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
-    <None Include="..\..\..\Qir\drops\include\**\*">
-      <Link>runtimes\any\native\include\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(QSimDll)">
-      <Link Condition="$([MSBuild]::IsOsPlatform('Windows'))">Libraries\win-x64\%(FileName)%(Extension)</Link>
-      <Link Condition="$([MSBuild]::IsOsPlatform('OSX'))">Libraries\osx-x64\%(FileName)%(Extension)</Link>
-      <Link Condition="$([MSBuild]::IsOsPlatform('Linux'))">Libraries\linux-x64\%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\..\..\Simulation\Native\win10\**\*">
-      <Link>Libraries\win-x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
-    <None Include="..\..\..\Simulation\Native\osx\**\*">
-      <Link>Libraries\osx-x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
-    <None Include="..\..\..\Simulation\Native\linux\**\*">
-      <Link>Libraries\linux-x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR removes a reference to `Simulators.Dev.props` which inadvertently caused the `Microsoft.Quantum.Qir.Tools` package to have reference on  a `Microsoft.Quantum.Simulation.Common` package that does not exist.