### PR TITLE
Adding option to provider UserAgent when submitting jobs to Azure Quantum

### DIFF
--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -570,6 +570,7 @@ let ``Submit uses default values`` () =
                Location: myLocation
                Credential: Default
                AadToken:
+               UserAgent:
                Job Name:
                Shots: 500
                Output: FriendlyUri
@@ -593,6 +594,7 @@ let ``Submit uses default values with default target`` () =
                Location: myLocation
                Credential: Default
                AadToken:
+               UserAgent:
                Job Name:
                Shots: 500
                Output: FriendlyUri
@@ -616,6 +618,8 @@ let ``Submit allows overriding default values`` () =
         "myJobName"
         "--shots"
         "750"
+        "--user-agent"
+        "myUserAgent"
         "--credential"
         "cli"
     ])
@@ -628,6 +632,7 @@ let ``Submit allows overriding default values`` () =
                Location: myLocation
                Credential: CLI
                AadToken: myTok
+               UserAgent: myUserAgent
                Job Name: myJobName
                Shots: 750
                Output: FriendlyUri
@@ -653,6 +658,8 @@ let ``Submit extracts the location from a quantum endpoint`` () =
         "myJobName"
         "--credential"
         "VisualStudio"
+        "--user-agent"
+        "myUserAgent"
         "--shots"
         "750"
         "--target"
@@ -667,6 +674,7 @@ let ``Submit extracts the location from a quantum endpoint`` () =
                 Location: westus
                 Credential: VisualStudio
                 AadToken: myTok
+                UserAgent: myUserAgent
                 Job Name: myJobName
                 Shots: 750
                 Output: FriendlyUri
@@ -702,6 +710,7 @@ let ``Submit allows overriding default values with default target`` () =
                Location: myLocation
                Credential: Interactive
                AadToken: myTok
+               UserAgent:
                Job Name: myJobName
                Shots: 750
                Output: FriendlyUri
@@ -740,6 +749,7 @@ let ``Submit allows to include --base-uri option when --location is not present`
                Location: mybaseuri
                Credential: Default
                AadToken:
+               UserAgent:
                Job Name:
                Shots: 500
                Output: FriendlyUri
@@ -765,6 +775,7 @@ let ``Submit allows to include --location option when --base-uri is not present`
                Location: myLocation
                Credential: Default
                AadToken:
+               UserAgent:
                Job Name:
                Shots: 500
                Output: FriendlyUri
@@ -794,6 +805,7 @@ let ``Submit allows spaces for the --location option`` () =
                Location: My Location
                Credential: Default
                AadToken:
+               UserAgent:
                Job Name:
                Shots: 500
                Output: FriendlyUri
@@ -898,6 +910,7 @@ let ``Submit supports Q# submitters`` () =
          Location: myLocation
          Credential: Default
          AadToken:
+         UserAgent:
          Job Name:
          Shots: 500
          Output: FriendlyUri

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -969,6 +969,7 @@ let ``Shows help text for submit command`` () =
                       --credential <credential>                           The type of credential to use to authenticate with Azure.
                       --storage <storage>                                 The storage account connection string.
                       --aad-token <aad-token>                             The Azure Active Directory authentication token.
+                      --user-agent <user-agent>                           A label to identify this application when making requests to Azure Quantum.
                       --base-uri <base-uri>                               The base URI of the Azure Quantum endpoint.
                       --location <location>                               The location to use with the default endpoint.
                       --job-name <job-name>                               The name of the submitted job.
@@ -999,6 +1000,7 @@ let ``Shows help text for submit command with default target`` () =
                       --credential <credential>                           The type of credential to use to authenticate with Azure.
                       --storage <storage>                                 The storage account connection string.
                       --aad-token <aad-token>                             The Azure Active Directory authentication token.
+                      --user-agent <user-agent>                           A label to identify this application when making requests to Azure Quantum.
                       --base-uri <base-uri>                               The base URI of the Azure Quantum endpoint.
                       --location <location>                               The location to use with the default endpoint.
                       --job-name <job-name>                               The name of the submitted job.

--- a/src/Simulation/EntryPointDriver/Azure/AzureSettings.cs
+++ b/src/Simulation/EntryPointDriver/Azure/AzureSettings.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using Azure.Core;
+using Azure.Quantum;
+
 using Microsoft.Azure.Quantum;
 using Microsoft.Azure.Quantum.Authentication;
 using Microsoft.Quantum.Runtime.Submitters;
@@ -87,6 +89,11 @@ namespace Microsoft.Quantum.EntryPointDriver
         public string? Location { get; set; }
 
         /// <summary>
+        /// A string to identify this application when making requests to Azure Quantum.
+        /// </summary>
+        public string? UserAgent { get; set; }
+
+        /// <summary>
         /// The name of the submitted job.
         /// </summary>
         public string JobName { get; set; } = "";
@@ -123,6 +130,14 @@ namespace Microsoft.Quantum.EntryPointDriver
             }
         }
 
+        internal QuantumJobClientOptions CreateClientOptions()
+        {
+            var options = new QuantumJobClientOptions();
+            options.Diagnostics.ApplicationId = UserAgent ?? System.Environment.GetEnvironmentVariable("USER_AGENT");
+
+            return options;
+        }
+
         /// <summary>
         /// The submission options corresponding to these settings.
         /// </summary>
@@ -135,6 +150,7 @@ namespace Microsoft.Quantum.EntryPointDriver
         internal Workspace CreateWorkspace()
         {
             var credentials = CreateCredentials();
+            var clientOptions = CreateClientOptions();
             var location = NormalizeLocation(Location ?? ExtractLocation(BaseUri));
 
             return new Workspace(
@@ -142,7 +158,8 @@ namespace Microsoft.Quantum.EntryPointDriver
                 resourceGroupName: ResourceGroup,
                 workspaceName: Workspace,
                 location: location,
-                credential: credentials);
+                credential: credentials,
+                options: clientOptions);
         }
 
         public override string ToString() => string.Join(
@@ -156,6 +173,7 @@ namespace Microsoft.Quantum.EntryPointDriver
             $"Location: {Location ?? ExtractLocation(BaseUri)}",
             $"Credential: {Credential}",
             $"AadToken: {AadToken?.Substring(0, 5)}",
+            $"UserAgent: {UserAgent}",
             $"Job Name: {JobName}",
             $"Shots: {Shots}",
             $"Output: {Output}",

--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Quantum.EntryPointDriver
             ImmutableList.Create("--aad-token"), default, "The Azure Active Directory authentication token.");
 
         /// <summary>
+        /// The User-Agent option.
+        /// </summary>
+        private static readonly OptionInfo<string?> UserAgentOption = new OptionInfo<string?>(
+            ImmutableList.Create("--user-agent"), default, "A label to identify this application when making requests to Azure Quantum.");
+        /// <summary>
         /// The base URI option.
         /// </summary>
         private static readonly OptionInfo<Uri?> BaseUriOption = new OptionInfo<Uri?>(
@@ -432,6 +437,7 @@ namespace Microsoft.Quantum.EntryPointDriver
                 .Concat(AddOptionIfAvailable(command, CredentialOption))
                 .Concat(AddOptionIfAvailable(command, StorageOption))
                 .Concat(AddOptionIfAvailable(command, AadTokenOption))
+                .Concat(AddOptionIfAvailable(command, UserAgentOption))
                 .Concat(AddOptionIfAvailable(command, BaseUriOption))
                 .Concat(AddOptionIfAvailable(command, LocationOption))
                 .Concat(AddOptionIfAvailable(command, JobNameOption))
@@ -472,6 +478,7 @@ namespace Microsoft.Quantum.EntryPointDriver
                 Target = DefaultIfShadowed(entryPoint, TargetOption, azureSettings.Target),
                 Storage = DefaultIfShadowed(entryPoint, StorageOption, azureSettings.Storage),
                 AadToken = DefaultIfShadowed(entryPoint, AadTokenOption, azureSettings.AadToken),
+                UserAgent = DefaultIfShadowed(entryPoint, UserAgentOption, azureSettings.UserAgent),
                 BaseUri = DefaultIfShadowed(entryPoint, BaseUriOption, azureSettings.BaseUri),
                 Location = DefaultIfShadowed(entryPoint, LocationOption, azureSettings.Location),
                 Credential = DefaultIfShadowed(entryPoint, CredentialOption, azureSettings.Credential),

--- a/src/Simulation/Simulators.Tests/CoreTests.cs
+++ b/src/Simulation/Simulators.Tests/CoreTests.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
                     "Location: myLocation",
                     "Credential: Default",
                     "AadToken: ",
+                    "UserAgent: ",
                     "Job Name: ",
                     "Shots: 500",
                     "Output: FriendlyUri",


### PR DESCRIPTION
The user-agent can be provided either as an extra argument to the executable, or as an environment variable.