### PR TITLE
Update Simulator default random seed

### DIFF
--- a/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
@@ -10,7 +10,6 @@
 #include <vector>
 #include <fstream>
 #include <climits>
-#include <chrono>
 
 #pragma clang diagnostic push
     // Ignore warnings for reserved macro names `_In_`, `_In_reads_(n)`:
@@ -168,10 +167,6 @@ namespace Quantum
 
             qubitManager = std::make_unique<CQubitManager>();
             this->simulatorId = initSimulatorInstance();
-
-            typedef void (*TSeed)(unsigned, unsigned);
-            static TSeed setSimulatorSeed = reinterpret_cast<TSeed>(this->GetProc("seed"));
-            setSimulatorSeed(this->simulatorId, (unsigned)std::chrono::system_clock::now().time_since_epoch().count());
         }
         ~CFullstateSimulator() override
         {

--- a/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <fstream>
 #include <climits>
+#include <chrono>
 
 #pragma clang diagnostic push
     // Ignore warnings for reserved macro names `_In_`, `_In_reads_(n)`:
@@ -167,6 +168,10 @@ namespace Quantum
 
             qubitManager = std::make_unique<CQubitManager>();
             this->simulatorId = initSimulatorInstance();
+
+            typedef void (*TSeed)(unsigned, unsigned);
+            static TSeed setSimulatorSeed = reinterpret_cast<TSeed>(this->GetProc("seed"));
+            setSimulatorSeed(this->simulatorId, (unsigned)std::chrono::system_clock::now().time_since_epoch().count());
         }
         ~CFullstateSimulator() override
         {

--- a/src/Simulation/Native/src/simulator/wavefunction.hpp
+++ b/src/Simulation/Native/src/simulator/wavefunction.hpp
@@ -13,6 +13,7 @@
 #include <random>
 #include <string.h>
 #include <vector>
+#include <chrono>
 
 #include "gates.hpp"
 #include "types.hpp"
@@ -382,13 +383,13 @@ class Wavefunction
         : num_qubits_(0)
         , wfn_(1, 1.)
     {
-        rng_.seed(std::clock());
+        rng_.seed((unsigned)std::chrono::system_clock::now().time_since_epoch().count());
     }
 
     void reset()
     {
         fused_.reset();
-        rng_.seed(std::clock());
+        rng_.seed((unsigned)std::chrono::system_clock::now().time_since_epoch().count());
         num_qubits_ = 0;
         wfn_.resize(1);
         wfn_[0] = 1.;


### PR DESCRIPTION
This updates the default seed used by the simulator when initializing the random number generator used within the wave function. Previously it used `std::clock()` which is time since process start, but that is implementation and platform dependent (see https://en.cppreference.com/w/cpp/chrono/c/clock). This is changed to instead use current time, and was tested to show sufficient randomness even with rapid repeated invocation.