### PR TITLE
Truncate user-agent

### DIFF
--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -671,7 +671,7 @@ let ``Submit allows a long user-agent`` () =
                Location: myLocation
                Credential: CLI
                AadToken: myTok
-               UserAgent: a-very-long-user-agent-
+               UserAgent: a-very-long-user-agent-(
                Job Name: myJobName
                Shots: 750
                Output: FriendlyUri

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -642,6 +642,45 @@ let ``Submit allows overriding default values`` () =
                Submitting Q# entry point using a quantum machine.
 
                https://www.example.com/00000000-0000-0000-0000-0000000000000"
+
+               
+[<Fact>]
+let ``Submit allows a long user-agent`` () =
+    let given = test "Returns Unit"
+    given (submitWithNoOpTarget @ [
+        "--verbose"
+        "--storage"
+        "myStorage"
+        "--aad-token"
+        "myToken"
+        "--job-name"
+        "myJobName"
+        "--shots"
+        "750"
+        "--user-agent"
+        "a-very-long-user-agent-(it-will-be-truncated)"
+        "--credential"
+        "cli"
+    ])
+    |> yields "Subscription: mySubscription
+               Resource Group: myResourceGroup
+               Workspace: myWorkspace
+               Target: test.machine.noop
+               Storage: myStorage
+               Base URI:
+               Location: myLocation
+               Credential: CLI
+               AadToken: myTok
+               UserAgent: a-very-long-user-agent-
+               Job Name: myJobName
+               Shots: 750
+               Output: FriendlyUri
+               Dry Run: False
+               Verbose: True
+
+               Submitting Q# entry point using a quantum machine.
+
+               https://www.example.com/00000000-0000-0000-0000-0000000000000"
                
 [<Fact>]
 let ``Submit extracts the location from a quantum endpoint`` () =

--- a/src/Simulation/EntryPointDriver/Azure/AzureSettings.cs
+++ b/src/Simulation/EntryPointDriver/Azure/AzureSettings.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Quantum.EntryPointDriver
         }
 
         internal string? TrimmedUserAgent() {
-            var userAgent = (UserAgent ?? System.Environment.GetEnvironmentVariable("USER_AGENT")).Trim();
+            var userAgent = (UserAgent ?? System.Environment.GetEnvironmentVariable("USER_AGENT"))?.Trim();
 
             return (userAgent == null || userAgent.Length < 25)
                 ? userAgent
@@ -181,7 +181,7 @@ namespace Microsoft.Quantum.EntryPointDriver
             $"Location: {Location ?? ExtractLocation(BaseUri)}",
             $"Credential: {Credential}",
             $"AadToken: {AadToken?.Substring(0, 5)}",
-            $"UserAgent: {UserAgent}",
+            $"UserAgent: {TrimmedUserAgent()}",
             $"Job Name: {JobName}",
             $"Shots: {Shots}",
             $"Output: {Output}",

--- a/src/Simulation/EntryPointDriver/Azure/AzureSettings.cs
+++ b/src/Simulation/EntryPointDriver/Azure/AzureSettings.cs
@@ -130,11 +130,19 @@ namespace Microsoft.Quantum.EntryPointDriver
             }
         }
 
+        internal string? TrimmedUserAgent() {
+            var userAgent = (UserAgent ?? System.Environment.GetEnvironmentVariable("USER_AGENT")).Trim();
+
+            return (userAgent == null || userAgent.Length < 25)
+                ? userAgent
+                : userAgent.Substring(0, 24);
+            }
+
+
         internal QuantumJobClientOptions CreateClientOptions()
         {
             var options = new QuantumJobClientOptions();
-            options.Diagnostics.ApplicationId = UserAgent ?? System.Environment.GetEnvironmentVariable("USER_AGENT");
-
+            options.Diagnostics.ApplicationId = TrimmedUserAgent();
             return options;
         }
 


### PR DESCRIPTION
When user-agent is longer than 24 characters, we get a runtime exception. This prevents the error by truncating the user-agent