### PR TITLE
Reformatted the C++ sources according to clang-format rules.

### DIFF
--- a/src/Qir/.clang-format
+++ b/src/Qir/.clang-format
@@ -67,7 +67,7 @@ SpacesInContainerLiterals: false
 #       int b) // With this comment does not fit under `int a`.
 AllowAllParametersOfDeclarationOnNextLine: false
 #BinPackParameters: true
-AllowShortFunctionsOnASingleLine: None #None #Empty     # Allow `void f() {}`, `virtual ~IRuntimeDriver() {}`.
+AllowShortFunctionsOnASingleLine: None
 
 # Class/Struct Declaration and Definition:
 #   class C
@@ -96,8 +96,8 @@ BreakInheritanceList: BeforeComma   # LineBreak before `:` and before `,`.
 #}
 BreakConstructorInitializers: BeforeComma       # LineBreak before `:` and before `,`.
                                                 # But if the member init list fits in the line after `)` 
-                                                # then makes the list horizontal and places after `)` :-(. 
-                                                # Failed to disable. https://stackoverflow.com/a/59574671/6362941
+                                                # then makes the list horizontal and places after `)`. 
+                                                # Failed to disable. Problem known for years. https://stackoverflow.com/a/59574671/6362941
 ConstructorInitializerAllOnOneLineOrOnePerLine: true    # Horizontal list (`: A(), B(), C()`) or vertical, like in the example above.
 AllowAllConstructorInitializersOnNextLine: false        # Disable horizontal list (`: A(), B(), C()`).
 # SpaceBeforeCtorInitializerColon is expected to be ignored.

--- a/src/Qir/.clang-format
+++ b/src/Qir/.clang-format
@@ -22,7 +22,7 @@ BasedOnStyle: Microsoft
 # Commented-out options correspond to the base Style (see `BasedOnStyle`).
 
 # Page Width:
-#ColumnLimit: 120
+#ColumnLimit: 120       # VSCode Show Ruler: https://stackoverflow.com/a/64004251/6362941
 #ReflowComments: true   # Comments are broken up into multiple lines.
 
 # Include Directives:
@@ -37,6 +37,7 @@ NamespaceIndentation: Inner
 
 # Templates:
 SpaceAfterTemplateKeyword: false    # Do not insert space after `template`.
+AlwaysBreakTemplateDeclarations: Yes
 
 # Line and Statements Layout:
 BreakBeforeBraces: Allman
@@ -45,6 +46,8 @@ BreakBeforeBraces: Allman
 #AllowAllArgumentsOnNextLine: true
 #BreakBeforeTernaryOperators: true
 AllowShortLambdasOnASingleLine: None    # Never merge lambdas into a single line (leave as is).
+AllowShortBlocksOnASingleLine: Empty    # Allow `while (true) {}`.
+AlignConsecutiveAssignments: true
 
 # Misc:
 #Cpp11BracedListStyle: true
@@ -64,7 +67,7 @@ SpacesInContainerLiterals: false
 #       int b) // With this comment does not fit under `int a`.
 AllowAllParametersOfDeclarationOnNextLine: false
 #BinPackParameters: true
-#AllowShortFunctionsOnASingleLine: None     # Never merge functions into a single line (leave as is).
+AllowShortFunctionsOnASingleLine: None #None #Empty     # Allow `void f() {}`, `virtual ~IRuntimeDriver() {}`.
 
 # Class/Struct Declaration and Definition:
 #   class C
@@ -75,8 +78,9 @@ AllowAllParametersOfDeclarationOnNextLine: false
 #       // Body.
 #   };
 #
-# TODO(rokuzmin): What if short line? E.g. `class C : B1`. Is still broken into multiple lines? If yes then how to disable?
 BreakInheritanceList: BeforeComma   # LineBreak before `:` and before `,`.
+                                    # However the line with one base class, e.g. `class C : B1`, is formatted to one line,
+                                    # even if already is broken up into multiple lines.
 #SpaceBeforeInheritanceColon : true     # Do not remove space before inheritance colon `:` in short lines like `class C : B1`.
 #AccessModifierOffset: -2
 
@@ -91,6 +95,9 @@ BreakInheritanceList: BeforeComma   # LineBreak before `:` and before `,`.
 #    // Body.
 #}
 BreakConstructorInitializers: BeforeComma       # LineBreak before `:` and before `,`.
+                                                # But if the member init list fits in the line after `)` 
+                                                # then makes the list horizontal and places after `)` :-(. 
+                                                # Failed to disable. https://stackoverflow.com/a/59574671/6362941
 ConstructorInitializerAllOnOneLineOrOnePerLine: true    # Horizontal list (`: A(), B(), C()`) or vertical, like in the example above.
 AllowAllConstructorInitializersOnNextLine: false        # Disable horizontal list (`: A(), B(), C()`).
 # SpaceBeforeCtorInitializerColon is expected to be ignored.

--- a/src/Qir/Runtime/lib/QIR/Output.cpp
+++ b/src/Qir/Runtime/lib/QIR/Output.cpp
@@ -1,13 +1,13 @@
-#include <ostream>                  // std::endl
+#include <ostream> // std::endl
 #include "QirTypes.hpp"
-#include "QirRuntime.hpp"           // QIR_SHARED_API for quantum__rt__message.
+#include "QirRuntime.hpp" // QIR_SHARED_API for quantum__rt__message.
 #include "OutputStream.hpp"
 
 // Public API:
 extern "C"
 {
-    void quantum__rt__message(QirString* qstr)   // NOLINT
+    void quantum__rt__message(QirString* qstr) // NOLINT
     {
         Microsoft::Quantum::OutputStream::Get() << qstr->str << std::endl;
     }
-}   // extern "C"
+} // extern "C"

--- a/src/Qir/Runtime/lib/QIR/OutputStream.cpp
+++ b/src/Qir/Runtime/lib/QIR/OutputStream.cpp
@@ -3,14 +3,14 @@
 
 // https://stackoverflow.com/a/5419388/6362941  redirect std::cout to a string
 // Discussion/history and some more info about the output redirection:
-//  https://github.com/microsoft/qsharp-runtime/pull/511#discussion_r574170031 
+//  https://github.com/microsoft/qsharp-runtime/pull/511#discussion_r574170031
 //  https://github.com/microsoft/qsharp-runtime/pull/511#discussion_r574194191
 
 #include <iostream>
 #include "QirRuntime.hpp"
 #include "OutputStream.hpp"
 
-namespace Microsoft           // Replace with `namespace Microsoft::Quantum` after migration to C++17.
+namespace Microsoft // Replace with `namespace Microsoft::Quantum` after migration to C++17.
 {
 namespace Quantum
 {
@@ -24,20 +24,20 @@ namespace Quantum
     std::ostream& OutputStream::Set(std::ostream& newOStream)
     {
         std::ostream& oldOStream = *currentOutputStream;
-        currentOutputStream = &newOStream;
+        currentOutputStream      = &newOStream;
         return oldOStream;
     }
 
-    OutputStream::ScopedRedirector::ScopedRedirector(std::ostream& newOstream)
-        : old(OutputStream::Set(newOstream))
-    {}
+    OutputStream::ScopedRedirector::ScopedRedirector(std::ostream& newOstream) : old(OutputStream::Set(newOstream))
+    {
+    }
 
     OutputStream::ScopedRedirector::~ScopedRedirector()
     {
         OutputStream::Set(old);
     }
 
-    std::ostream& SetOutputStream(std::ostream & newOStream)
+    std::ostream& SetOutputStream(std::ostream& newOStream)
     {
         return OutputStream::Set(newOStream);
     }

--- a/src/Qir/Runtime/lib/QIR/QirRange.cpp
+++ b/src/Qir/Runtime/lib/QIR/QirRange.cpp
@@ -6,13 +6,15 @@
 #include "QirRuntime.hpp"
 
 QirRange::QirRange(int64_t st, int64_t sp, int64_t en)
+    // clang-format off
     : start(st)
     , step(sp)
     , end(en)
+// clang-format on
 {
     // An attempt to create a %Range with a zero step should cause a runtime failure.
     // https://github.com/microsoft/qsharp-language/blob/main/Specifications/QIR/Data-Types.md#simple-types
-    if(sp == 0)
+    if (sp == 0)
     {
         quantum__rt__fail_cstr("Attempt to create a range with 0 step");
     }

--- a/src/Qir/Runtime/lib/QIR/QubitManager.cpp
+++ b/src/Qir/Runtime/lib/QIR/QubitManager.cpp
@@ -3,506 +3,515 @@
 
 #include "QubitManager.hpp"
 #include "QirRuntime.hpp" // For quantum__rt__fail_cstr
-#include <cstring> // For memcpy
+#include <cstring>        // For memcpy
 
 namespace Microsoft
 {
 namespace Quantum
 {
 
-//
-// Failing in case of errors
-//
+    //
+    // Failing in case of errors
+    //
 
-[[noreturn]] static void FailNow(const char* message)
-{
-     quantum__rt__fail_cstr(message);
-}
-
-static void FailIf(bool condition, const char* message)
-{
-    if (condition)
+    [[noreturn]] static void FailNow(const char* message)
     {
         quantum__rt__fail_cstr(message);
     }
-}
 
-//
-// QubitListInSharedArray
-//
-
-CQubitManager::QubitListInSharedArray::QubitListInSharedArray(
-    QubitIdType startId,
-    QubitIdType endId,
-    QubitIdType* sharedQbitStatusArray):
-        firstElement(startId),
-        lastElement(endId)
-{
-    FailIf(startId > endId || startId < 0 || endId == MaximumQubitCapacity,
-        "Incorrect boundaries in the linked list initialization.");
-    FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
-
-    for (QubitIdType i = startId; i < endId; i++) {
-        sharedQbitStatusArray[i] = i + 1; // Current element points to the next element.
-    }
-    sharedQbitStatusArray[endId] = NoneMarker; // Last element ends the chain.
-}
-
-bool CQubitManager::QubitListInSharedArray::IsEmpty() const
-{
-    return firstElement == NoneMarker;
-}
-
-void CQubitManager::QubitListInSharedArray::AddQubit(QubitIdType id, QubitIdType* sharedQbitStatusArray)
-{
-    FailIf(id == NoneMarker, "Incorrect qubit id, cannot add it to the list.");
-    FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
-
-    // If the list is empty, we initialize it with the new element.
-    if (IsEmpty())
+    static void FailIf(bool condition, const char* message)
     {
-        firstElement = id;
-        lastElement = id;
-        sharedQbitStatusArray[id] = NoneMarker; // List with a single elemenet in the chain.
-        return;
+        if (condition)
+        {
+            quantum__rt__fail_cstr(message);
+        }
     }
 
-    sharedQbitStatusArray[id] = firstElement; // The new element will point to the former first element.
-    firstElement = id; // The new element is now the first in the chain.
-}
+    //
+    // QubitListInSharedArray
+    //
 
-CQubitManager::QubitIdType CQubitManager::QubitListInSharedArray::TakeQubitFromFront(QubitIdType* sharedQbitStatusArray)
-{
-    FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
-
-    // First element will be returned. It is 'NoneMarker' if the list is empty.
-    QubitIdType result = firstElement;
-
-    // Advance list start to the next element if list is not empty.
-    if (!IsEmpty())
+    CQubitManager::QubitListInSharedArray::QubitListInSharedArray(QubitIdType startId, QubitIdType endId,
+                                                                  QubitIdType* sharedQbitStatusArray)
+        : firstElement(startId)
+        , lastElement(endId)
     {
-        firstElement = sharedQbitStatusArray[firstElement]; // The second element will be the first.
+        FailIf(startId > endId || startId < 0 || endId == MaximumQubitCapacity,
+               "Incorrect boundaries in the linked list initialization.");
+        FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
+
+        for (QubitIdType i = startId; i < endId; i++)
+        {
+            sharedQbitStatusArray[i] = i + 1; // Current element points to the next element.
+        }
+        sharedQbitStatusArray[endId] = NoneMarker; // Last element ends the chain.
     }
 
-    // Drop pointer to the last element if list becomes empty.
-    if (IsEmpty())
+    bool CQubitManager::QubitListInSharedArray::IsEmpty() const
     {
-        lastElement = NoneMarker;
+        return firstElement == NoneMarker;
     }
 
-    if (result != NoneMarker)
+    void CQubitManager::QubitListInSharedArray::AddQubit(QubitIdType id, QubitIdType* sharedQbitStatusArray)
     {
-        sharedQbitStatusArray[result] = AllocatedMarker;
+        FailIf(id == NoneMarker, "Incorrect qubit id, cannot add it to the list.");
+        FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
+
+        // If the list is empty, we initialize it with the new element.
+        if (IsEmpty())
+        {
+            firstElement              = id;
+            lastElement               = id;
+            sharedQbitStatusArray[id] = NoneMarker; // List with a single elemenet in the chain.
+            return;
+        }
+
+        sharedQbitStatusArray[id] = firstElement; // The new element will point to the former first element.
+        firstElement              = id;           // The new element is now the first in the chain.
     }
 
-    return result;
-}
-
-void CQubitManager::QubitListInSharedArray::MoveAllQubitsFrom(QubitListInSharedArray& source, QubitIdType* sharedQbitStatusArray)
-{
-    FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
-
-    // No need to do anthing if source is empty.
-    if (source.IsEmpty())
+    CQubitManager::QubitIdType CQubitManager::QubitListInSharedArray::TakeQubitFromFront(
+        QubitIdType* sharedQbitStatusArray)
     {
-        return;
+        FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
+
+        // First element will be returned. It is 'NoneMarker' if the list is empty.
+        QubitIdType result = firstElement;
+
+        // Advance list start to the next element if list is not empty.
+        if (!IsEmpty())
+        {
+            firstElement = sharedQbitStatusArray[firstElement]; // The second element will be the first.
+        }
+
+        // Drop pointer to the last element if list becomes empty.
+        if (IsEmpty())
+        {
+            lastElement = NoneMarker;
+        }
+
+        if (result != NoneMarker)
+        {
+            sharedQbitStatusArray[result] = AllocatedMarker;
+        }
+
+        return result;
     }
 
-    if (this->IsEmpty())
+    void CQubitManager::QubitListInSharedArray::MoveAllQubitsFrom(QubitListInSharedArray& source,
+                                                                  QubitIdType* sharedQbitStatusArray)
     {
-        // If this list is empty, we'll just set it to the source list.
-        lastElement = source.lastElement;
-    } else
-    {
-        // Attach source at the beginning of the list if both lists aren't empty.
-        sharedQbitStatusArray[source.lastElement] = firstElement; // The last element of the source chain will point to the first element of this chain.
+        FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
+
+        // No need to do anthing if source is empty.
+        if (source.IsEmpty())
+        {
+            return;
+        }
+
+        if (this->IsEmpty())
+        {
+            // If this list is empty, we'll just set it to the source list.
+            lastElement = source.lastElement;
+        }
+        else
+        {
+            // Attach source at the beginning of the list if both lists aren't empty.
+            sharedQbitStatusArray[source.lastElement] = firstElement; // The last element of the source chain will point
+                                                                      // to the first element of this chain.
+        }
+        firstElement = source.firstElement; // The first element from the source chain will be
+                                            // the first element of this chain.
+
+        // Remove all elements from source.
+        source.firstElement = NoneMarker;
+        source.lastElement  = NoneMarker;
     }
-    firstElement = source.firstElement; // The first element from the source chain will be the first element of this chain.
-
-    // Remove all elements from source.
-    source.firstElement = NoneMarker;
-    source.lastElement = NoneMarker;
-}
 
 
-//
-// RestrictedReuseArea
-//
+    //
+    // RestrictedReuseArea
+    //
 
-CQubitManager::RestrictedReuseArea::RestrictedReuseArea(
-    QubitListInSharedArray freeQubits):
-        FreeQubitsReuseProhibited(), // Default costructor
-        FreeQubitsReuseAllowed(freeQubits) // Default shallow copy.
-{
-}
-
-
-//
-// CRestrictedReuseAreaStack
-//
-
-void CQubitManager::CRestrictedReuseAreaStack::PushToBack(RestrictedReuseArea area)
-{
-    FailIf(Count() >= std::numeric_limits<int32_t>::max(), "Too many nested restricted reuse areas.");
-    this->insert(this->end(), area);
-}
-
-CQubitManager::RestrictedReuseArea CQubitManager::CRestrictedReuseAreaStack::PopFromBack()
-{
-    FailIf(this->empty(), "Cannot remove restricted reuse area from an empty set.");
-    RestrictedReuseArea result = this->back();
-    this->pop_back();
-    return result;
-}
-
-CQubitManager::RestrictedReuseArea& CQubitManager::CRestrictedReuseAreaStack::PeekBack()
-{
-    return this->back();
-}
-
-int32_t CQubitManager::CRestrictedReuseAreaStack::Count() const
-{
-    // The size should never exceed int32_t.
-    return static_cast<int32_t>(this->size());
-}
-
-//
-// CQubitManager
-//
-
-CQubitManager::CQubitManager(
-    QubitIdType initialQubitCapacity,
-    bool mayExtendCap):
-        mayExtendCapacity(mayExtendCap),
-        qubitCapacity(initialQubitCapacity)
-{
-    FailIf(qubitCapacity <= 0, "Qubit capacity must be positive.");
-    sharedQubitStatusArray = new QubitIdType[(size_t)qubitCapacity];
-
-    // These objects are passed by value (copies are created)
-    QubitListInSharedArray FreeQubitsFresh(0, qubitCapacity - 1, sharedQubitStatusArray);
-    RestrictedReuseArea outermostArea(FreeQubitsFresh);
-    freeQubitsInAreas.PushToBack(outermostArea);
-
-    freeQubitCount = qubitCapacity;
-}
-
-CQubitManager::~CQubitManager()
-{
-    if (sharedQubitStatusArray != nullptr)
+    CQubitManager::RestrictedReuseArea::RestrictedReuseArea(QubitListInSharedArray freeQubits)
+        : FreeQubitsReuseProhibited()        // Default costructor
+        , FreeQubitsReuseAllowed(freeQubits) // Default shallow copy.
     {
-        delete[] sharedQubitStatusArray;
-        sharedQubitStatusArray = nullptr;
     }
-    // freeQubitsInAreas - direct member of the class, no need to delete.
-}
 
-// Although it is not necessary to pass area IDs to these functions, such support may be added for extra checks.
-void CQubitManager::StartRestrictedReuseArea()
-{
-    FailIf(freeQubitsInAreas.Count() <= 0, "Internal error! No reuse areas.");
-    RestrictedReuseArea areaAboutToBegin;
-    RestrictedReuseArea& currentArea = freeQubitsInAreas.PeekBack();
-    if (currentArea.FreeQubitsReuseAllowed.IsEmpty())
+
+    //
+    // CRestrictedReuseAreaStack
+    //
+
+    void CQubitManager::CRestrictedReuseAreaStack::PushToBack(RestrictedReuseArea area)
     {
-        areaAboutToBegin.prevAreaWithFreeQubits = currentArea.prevAreaWithFreeQubits;
-    } else
+        FailIf(Count() >= std::numeric_limits<int32_t>::max(), "Too many nested restricted reuse areas.");
+        this->insert(this->end(), area);
+    }
+
+    CQubitManager::RestrictedReuseArea CQubitManager::CRestrictedReuseAreaStack::PopFromBack()
     {
-        areaAboutToBegin.prevAreaWithFreeQubits = freeQubitsInAreas.Count() - 1;
+        FailIf(this->empty(), "Cannot remove restricted reuse area from an empty set.");
+        RestrictedReuseArea result = this->back();
+        this->pop_back();
+        return result;
     }
-    freeQubitsInAreas.PushToBack(areaAboutToBegin);
-}
 
-void CQubitManager::NextRestrictedReuseSegment()
-{
-    FailIf(freeQubitsInAreas.Count() <= 0, "Internal error! No reuse areas.");
-    FailIf(freeQubitsInAreas.Count() == 1, "NextRestrictedReuseSegment() without an active area.");
-    RestrictedReuseArea& currentArea = freeQubitsInAreas.PeekBack();
-    // When new segment starts, reuse of all free qubits in the current area becomes prohibited.
-    currentArea.FreeQubitsReuseProhibited.MoveAllQubitsFrom(currentArea.FreeQubitsReuseAllowed, sharedQubitStatusArray);
-}
-
-void CQubitManager::EndRestrictedReuseArea()
-{
-    FailIf(freeQubitsInAreas.Count() < 2, "EndRestrictedReuseArea() without an active area.");
-    RestrictedReuseArea areaAboutToEnd = freeQubitsInAreas.PopFromBack();
-    RestrictedReuseArea& containingArea = freeQubitsInAreas.PeekBack();
-    if (areaAboutToEnd.prevAreaWithFreeQubits < containingArea.prevAreaWithFreeQubits) {
-        containingArea.prevAreaWithFreeQubits = areaAboutToEnd.prevAreaWithFreeQubits;
-    }
-    // When area ends, reuse of all free qubits from this area becomes allowed.
-    containingArea.FreeQubitsReuseAllowed.MoveAllQubitsFrom(areaAboutToEnd.FreeQubitsReuseProhibited, sharedQubitStatusArray);
-    containingArea.FreeQubitsReuseAllowed.MoveAllQubitsFrom(areaAboutToEnd.FreeQubitsReuseAllowed, sharedQubitStatusArray);
-}
-
-Qubit CQubitManager::Allocate()
-{
-    QubitIdType newQubitId = AllocateQubitId();
-    FailIf(newQubitId == NoneMarker, "Not enough qubits.");
-    return CreateQubitObject(newQubitId);
-}
-
-void CQubitManager::Allocate(Qubit* qubitsToAllocate, int32_t qubitCountToAllocate)
-{
-    if (qubitCountToAllocate == 0)
+    CQubitManager::RestrictedReuseArea& CQubitManager::CRestrictedReuseAreaStack::PeekBack()
     {
-        return;
+        return this->back();
     }
-    FailIf(qubitCountToAllocate < 0, "Cannot allocate negative number of qubits.");
-    FailIf(qubitsToAllocate == nullptr, "No array provided for qubits to be allocated.");
 
-    // Consider optimization for initial allocation of a large array at once
-    for (int32_t i = 0; i < qubitCountToAllocate; i++)
+    int32_t CQubitManager::CRestrictedReuseAreaStack::Count() const
+    {
+        // The size should never exceed int32_t.
+        return static_cast<int32_t>(this->size());
+    }
+
+    //
+    // CQubitManager
+    //
+
+    CQubitManager::CQubitManager(QubitIdType initialQubitCapacity, bool mayExtendCap)
+        : mayExtendCapacity(mayExtendCap)
+        , qubitCapacity(initialQubitCapacity)
+    {
+        FailIf(qubitCapacity <= 0, "Qubit capacity must be positive.");
+        sharedQubitStatusArray = new QubitIdType[(size_t)qubitCapacity];
+
+        // These objects are passed by value (copies are created)
+        QubitListInSharedArray FreeQubitsFresh(0, qubitCapacity - 1, sharedQubitStatusArray);
+        RestrictedReuseArea outermostArea(FreeQubitsFresh);
+        freeQubitsInAreas.PushToBack(outermostArea);
+
+        freeQubitCount = qubitCapacity;
+    }
+
+    CQubitManager::~CQubitManager()
+    {
+        if (sharedQubitStatusArray != nullptr)
+        {
+            delete[] sharedQubitStatusArray;
+            sharedQubitStatusArray = nullptr;
+        }
+        // freeQubitsInAreas - direct member of the class, no need to delete.
+    }
+
+    // Although it is not necessary to pass area IDs to these functions, such support may be added for extra checks.
+    void CQubitManager::StartRestrictedReuseArea()
+    {
+        FailIf(freeQubitsInAreas.Count() <= 0, "Internal error! No reuse areas.");
+        RestrictedReuseArea areaAboutToBegin;
+        RestrictedReuseArea& currentArea = freeQubitsInAreas.PeekBack();
+        if (currentArea.FreeQubitsReuseAllowed.IsEmpty())
+        {
+            areaAboutToBegin.prevAreaWithFreeQubits = currentArea.prevAreaWithFreeQubits;
+        }
+        else
+        {
+            areaAboutToBegin.prevAreaWithFreeQubits = freeQubitsInAreas.Count() - 1;
+        }
+        freeQubitsInAreas.PushToBack(areaAboutToBegin);
+    }
+
+    void CQubitManager::NextRestrictedReuseSegment()
+    {
+        FailIf(freeQubitsInAreas.Count() <= 0, "Internal error! No reuse areas.");
+        FailIf(freeQubitsInAreas.Count() == 1, "NextRestrictedReuseSegment() without an active area.");
+        RestrictedReuseArea& currentArea = freeQubitsInAreas.PeekBack();
+        // When new segment starts, reuse of all free qubits in the current area becomes prohibited.
+        currentArea.FreeQubitsReuseProhibited.MoveAllQubitsFrom(currentArea.FreeQubitsReuseAllowed,
+                                                                sharedQubitStatusArray);
+    }
+
+    void CQubitManager::EndRestrictedReuseArea()
+    {
+        FailIf(freeQubitsInAreas.Count() < 2, "EndRestrictedReuseArea() without an active area.");
+        RestrictedReuseArea areaAboutToEnd  = freeQubitsInAreas.PopFromBack();
+        RestrictedReuseArea& containingArea = freeQubitsInAreas.PeekBack();
+        if (areaAboutToEnd.prevAreaWithFreeQubits < containingArea.prevAreaWithFreeQubits)
+        {
+            containingArea.prevAreaWithFreeQubits = areaAboutToEnd.prevAreaWithFreeQubits;
+        }
+        // When area ends, reuse of all free qubits from this area becomes allowed.
+        containingArea.FreeQubitsReuseAllowed.MoveAllQubitsFrom(areaAboutToEnd.FreeQubitsReuseProhibited,
+                                                                sharedQubitStatusArray);
+        containingArea.FreeQubitsReuseAllowed.MoveAllQubitsFrom(areaAboutToEnd.FreeQubitsReuseAllowed,
+                                                                sharedQubitStatusArray);
+    }
+
+    Qubit CQubitManager::Allocate()
     {
         QubitIdType newQubitId = AllocateQubitId();
-        if (newQubitId == NoneMarker)
+        FailIf(newQubitId == NoneMarker, "Not enough qubits.");
+        return CreateQubitObject(newQubitId);
+    }
+
+    void CQubitManager::Allocate(Qubit* qubitsToAllocate, int32_t qubitCountToAllocate)
+    {
+        if (qubitCountToAllocate == 0)
         {
-            for (int32_t k = 0; k < i; k++)
-            {
-                Release(qubitsToAllocate[k]);
-            }
-            FailNow("Not enough qubits.");
+            return;
         }
-        qubitsToAllocate[i] = CreateQubitObject(newQubitId);
-    }
-}
+        FailIf(qubitCountToAllocate < 0, "Cannot allocate negative number of qubits.");
+        FailIf(qubitsToAllocate == nullptr, "No array provided for qubits to be allocated.");
 
-void CQubitManager::Release(Qubit qubit)
-{
-    FailIf(!IsValidQubit(qubit), "Qubit is not valid.");
-    ReleaseQubitId(QubitToId(qubit));
-    DeleteQubitObject(qubit);
-}
-
-void CQubitManager::Release(Qubit* qubitsToRelease, int32_t qubitCountToRelease) {
-    if (qubitCountToRelease == 0)
-    {
-        return;
-    }
-    FailIf(qubitCountToRelease < 0, "Cannot release negative number of qubits.");
-    FailIf(qubitsToRelease == nullptr, "No array provided with qubits to be released.");
-
-    for (int32_t i = 0; i < qubitCountToRelease; i++)
-    {
-        Release(qubitsToRelease[i]);
-        qubitsToRelease[i] = nullptr;
-    }
-}
-
-Qubit CQubitManager::Borrow()
-{
-    // We don't support true borrowing/returning at the moment.
-    return Allocate();
-}
-
-void CQubitManager::Borrow(Qubit* qubitsToBorrow, int32_t qubitCountToBorrow)
-{
-    // We don't support true borrowing/returning at the moment.
-    return Allocate(qubitsToBorrow, qubitCountToBorrow);
-}
-
-void CQubitManager::Return(Qubit qubit)
-{
-    // We don't support true borrowing/returning at the moment.
-    Release(qubit);
-}
-
-void CQubitManager::Return(Qubit* qubitsToReturn, int32_t qubitCountToReturn)
-{
-    // We don't support true borrowing/returning at the moment.
-    Release(qubitsToReturn, qubitCountToReturn);
-}
-
-void CQubitManager::Disable(Qubit qubit)
-{
-    FailIf(!IsValidQubit(qubit), "Qubit is not valid.");
-    QubitIdType id = QubitToId(qubit);
-
-    // We can only disable explicitly allocated qubits that were not borrowed.
-    FailIf(!IsExplicitlyAllocatedId(id), "Cannot disable qubit that is not explicitly allocated.");
-    sharedQubitStatusArray[id] = DisabledMarker;
-
-    disabledQubitCount++;
-    FailIf(disabledQubitCount <= 0, "Incorrect disabled qubit count.");
-    allocatedQubitCount--;
-    FailIf(allocatedQubitCount < 0, "Incorrect allocated qubit count.");
-}
-
-void CQubitManager::Disable(Qubit* qubitsToDisable, int32_t qubitCountToDisable)
-{
-    if (qubitCountToDisable == 0)
-    {
-        return;
-    }
-    FailIf(qubitCountToDisable < 0, "Cannot disable negative number of qubits.");
-    FailIf(qubitsToDisable == nullptr, "No array provided with qubits to be disabled.");
-
-    for (int32_t i = 0; i < qubitCountToDisable; i++)
-    {
-        Disable(qubitsToDisable[i]);
-    }
-}
-
-bool CQubitManager::IsValidId(QubitIdType id) const
-{
-    return (id >= 0) && (id < qubitCapacity);
-}
-
-bool CQubitManager::IsDisabledId(QubitIdType id) const
-{
-    return sharedQubitStatusArray[id] == DisabledMarker;
-}
-
-bool CQubitManager::IsExplicitlyAllocatedId(QubitIdType id) const
-{
-    return sharedQubitStatusArray[id] == AllocatedMarker;
-}
-
-bool CQubitManager::IsFreeId(QubitIdType id) const
-{
-    return sharedQubitStatusArray[id] >= 0;
-}
-
-
-bool CQubitManager::IsValidQubit(Qubit qubit) const
-{
-    return IsValidId(QubitToId(qubit));
-}
-
-bool CQubitManager::IsDisabledQubit(Qubit qubit) const
-{
-    return IsValidQubit(qubit) && IsDisabledId(QubitToId(qubit));
-}
-
-bool CQubitManager::IsExplicitlyAllocatedQubit(Qubit qubit) const
-{
-    return IsValidQubit(qubit) && IsExplicitlyAllocatedId(QubitToId(qubit));
-}
-
-bool CQubitManager::IsFreeQubitId(QubitIdType id) const
-{
-    return IsValidId(id) && IsFreeId(id);
-}
-
-CQubitManager::QubitIdType CQubitManager::GetQubitId(Qubit qubit) const
-{
-    FailIf(!IsValidQubit(qubit), "Not a valid qubit.");
-    return QubitToId(qubit);
-}
-
-
-Qubit CQubitManager::CreateQubitObject(QubitIdType id)
-{
-    // Make sure the static_cast won't overflow:
-    FailIf(id < 0 || id >= MaximumQubitCapacity, "Qubit id is out of range.");
-    intptr_t pointerSizedId = static_cast<intptr_t>(id);
-    return reinterpret_cast<Qubit>(pointerSizedId);
-}
-
-void CQubitManager::DeleteQubitObject(Qubit /*qubit*/)
-{
-    // Do nothing. By default we store qubit Id in place of a pointer to a qubit.
-}
-
-CQubitManager::QubitIdType CQubitManager::QubitToId(Qubit qubit) const
-{
-    intptr_t pointerSizedId = reinterpret_cast<intptr_t>(qubit);
-    // Make sure the static_cast won't overflow:
-    FailIf(pointerSizedId < 0 || pointerSizedId > std::numeric_limits<QubitIdType>::max(), "Qubit id is out of range.");
-    return static_cast<QubitIdType>(pointerSizedId);
-}
-
-void CQubitManager::EnsureCapacity(QubitIdType requestedCapacity)
-{
-    FailIf(requestedCapacity <= 0, "Requested qubit capacity must be positive.");
-    if (requestedCapacity <= qubitCapacity)
-    {
-        return;
-    }
-    // We need to reallocate shared status array, but there's no need to adjust
-    // existing values (NonMarker or indexes in the array).
-
-    // Prepare new shared status array
-    QubitIdType* newStatusArray = new QubitIdType[(size_t)requestedCapacity];
-    memcpy(newStatusArray, sharedQubitStatusArray, (size_t)qubitCapacity * sizeof(newStatusArray[0]));
-    QubitListInSharedArray newFreeQubits(qubitCapacity, requestedCapacity - 1, newStatusArray);
-
-    // Set new data. All fresh new qubits are added to the free qubits in the outermost area.
-    freeQubitCount += requestedCapacity - qubitCapacity;
-    FailIf(freeQubitCount <= 0, "Incorrect free qubit count.");
-    delete[] sharedQubitStatusArray;
-    sharedQubitStatusArray = newStatusArray;
-    qubitCapacity = requestedCapacity;
-    freeQubitsInAreas[0].FreeQubitsReuseAllowed.MoveAllQubitsFrom(newFreeQubits, sharedQubitStatusArray);
-}
-
-CQubitManager::QubitIdType CQubitManager::TakeFreeQubitId()
-{
-    // First we try to take qubit from the current (innermost) area.
-    QubitIdType id = freeQubitsInAreas.PeekBack().FreeQubitsReuseAllowed.TakeQubitFromFront(sharedQubitStatusArray);
-
-    // Then, if no free qubits available for reuse, we scan outer areas (if they exist).
-    if (id == NoneMarker && freeQubitsInAreas.Count() >= 2)
-    {
-        int32_t areaIndex = freeQubitsInAreas.Count() - 1;
-        do
+        // Consider optimization for initial allocation of a large array at once
+        for (int32_t i = 0; i < qubitCountToAllocate; i++)
         {
-            areaIndex = freeQubitsInAreas[(size_t)areaIndex].prevAreaWithFreeQubits;
-            id = freeQubitsInAreas[(size_t)areaIndex].FreeQubitsReuseAllowed.TakeQubitFromFront(sharedQubitStatusArray);
-        } while ((areaIndex != 0) && (id == NoneMarker));
-
-        // We remember previous area where a free qubit was found or 0 if none were found.
-        freeQubitsInAreas.PeekBack().prevAreaWithFreeQubits = areaIndex;
+            QubitIdType newQubitId = AllocateQubitId();
+            if (newQubitId == NoneMarker)
+            {
+                for (int32_t k = 0; k < i; k++)
+                {
+                    Release(qubitsToAllocate[k]);
+                }
+                FailNow("Not enough qubits.");
+            }
+            qubitsToAllocate[i] = CreateQubitObject(newQubitId);
+        }
     }
 
-    if (id != NoneMarker)
+    void CQubitManager::Release(Qubit qubit)
     {
-        FailIf(id < 0 || id >= qubitCapacity, "Internal Error: Allocated invalid qubit.");
-        allocatedQubitCount++;
-        FailIf(allocatedQubitCount <= 0, "Incorrect allocated qubit count.");
-        freeQubitCount--;
-        FailIf(freeQubitCount < 0, "Incorrect free qubit count.");
+        FailIf(!IsValidQubit(qubit), "Qubit is not valid.");
+        ReleaseQubitId(QubitToId(qubit));
+        DeleteQubitObject(qubit);
     }
 
-    return id;
-}
-
-CQubitManager::QubitIdType CQubitManager::AllocateQubitId()
-{
-    QubitIdType newQubitId = TakeFreeQubitId();
-    if (newQubitId == NoneMarker && mayExtendCapacity)
+    void CQubitManager::Release(Qubit* qubitsToRelease, int32_t qubitCountToRelease)
     {
-        QubitIdType newQubitCapacity = qubitCapacity * 2;
-        FailIf(newQubitCapacity <= qubitCapacity, "Cannot extend capacity.");
-        EnsureCapacity(newQubitCapacity);
-        newQubitId = TakeFreeQubitId();
-    }
-    return newQubitId;
-}
+        if (qubitCountToRelease == 0)
+        {
+            return;
+        }
+        FailIf(qubitCountToRelease < 0, "Cannot release negative number of qubits.");
+        FailIf(qubitsToRelease == nullptr, "No array provided with qubits to be released.");
 
-void CQubitManager::ReleaseQubitId(QubitIdType id)
-{
-    FailIf(id < 0 || id >= qubitCapacity, "Internal Error: Cannot release an invalid qubit.");
-    if (IsDisabledId(id))
+        for (int32_t i = 0; i < qubitCountToRelease; i++)
+        {
+            Release(qubitsToRelease[i]);
+            qubitsToRelease[i] = nullptr;
+        }
+    }
+
+    Qubit CQubitManager::Borrow()
     {
-        // Nothing to do. Qubit will stay disabled.
-        return;
+        // We don't support true borrowing/returning at the moment.
+        return Allocate();
     }
 
-    FailIf(!IsExplicitlyAllocatedId(id), "Attempt to free qubit that has not been allocated.");
+    void CQubitManager::Borrow(Qubit* qubitsToBorrow, int32_t qubitCountToBorrow)
+    {
+        // We don't support true borrowing/returning at the moment.
+        return Allocate(qubitsToBorrow, qubitCountToBorrow);
+    }
 
-    // Released qubits are added to reuse area/segment in which they were released
-    // (rather than area/segment where they are allocated).
-    // Although counterintuitive, this makes code simple.
-    // This is reasonable because qubits should be allocated and released in the same segment. (This is not enforced)
-    freeQubitsInAreas.PeekBack().FreeQubitsReuseAllowed.AddQubit(id, sharedQubitStatusArray);
+    void CQubitManager::Return(Qubit qubit)
+    {
+        // We don't support true borrowing/returning at the moment.
+        Release(qubit);
+    }
 
-    freeQubitCount++;
-    FailIf(freeQubitCount <= 0, "Incorrect free qubit count.");
-    allocatedQubitCount--;
-    FailIf(allocatedQubitCount < 0, "Incorrect allocated qubit count.");
-}
+    void CQubitManager::Return(Qubit* qubitsToReturn, int32_t qubitCountToReturn)
+    {
+        // We don't support true borrowing/returning at the moment.
+        Release(qubitsToReturn, qubitCountToReturn);
+    }
+
+    void CQubitManager::Disable(Qubit qubit)
+    {
+        FailIf(!IsValidQubit(qubit), "Qubit is not valid.");
+        QubitIdType id = QubitToId(qubit);
+
+        // We can only disable explicitly allocated qubits that were not borrowed.
+        FailIf(!IsExplicitlyAllocatedId(id), "Cannot disable qubit that is not explicitly allocated.");
+        sharedQubitStatusArray[id] = DisabledMarker;
+
+        disabledQubitCount++;
+        FailIf(disabledQubitCount <= 0, "Incorrect disabled qubit count.");
+        allocatedQubitCount--;
+        FailIf(allocatedQubitCount < 0, "Incorrect allocated qubit count.");
+    }
+
+    void CQubitManager::Disable(Qubit* qubitsToDisable, int32_t qubitCountToDisable)
+    {
+        if (qubitCountToDisable == 0)
+        {
+            return;
+        }
+        FailIf(qubitCountToDisable < 0, "Cannot disable negative number of qubits.");
+        FailIf(qubitsToDisable == nullptr, "No array provided with qubits to be disabled.");
+
+        for (int32_t i = 0; i < qubitCountToDisable; i++)
+        {
+            Disable(qubitsToDisable[i]);
+        }
+    }
+
+    bool CQubitManager::IsValidId(QubitIdType id) const
+    {
+        return (id >= 0) && (id < qubitCapacity);
+    }
+
+    bool CQubitManager::IsDisabledId(QubitIdType id) const
+    {
+        return sharedQubitStatusArray[id] == DisabledMarker;
+    }
+
+    bool CQubitManager::IsExplicitlyAllocatedId(QubitIdType id) const
+    {
+        return sharedQubitStatusArray[id] == AllocatedMarker;
+    }
+
+    bool CQubitManager::IsFreeId(QubitIdType id) const
+    {
+        return sharedQubitStatusArray[id] >= 0;
+    }
 
 
-}
-}
+    bool CQubitManager::IsValidQubit(Qubit qubit) const
+    {
+        return IsValidId(QubitToId(qubit));
+    }
+
+    bool CQubitManager::IsDisabledQubit(Qubit qubit) const
+    {
+        return IsValidQubit(qubit) && IsDisabledId(QubitToId(qubit));
+    }
+
+    bool CQubitManager::IsExplicitlyAllocatedQubit(Qubit qubit) const
+    {
+        return IsValidQubit(qubit) && IsExplicitlyAllocatedId(QubitToId(qubit));
+    }
+
+    bool CQubitManager::IsFreeQubitId(QubitIdType id) const
+    {
+        return IsValidId(id) && IsFreeId(id);
+    }
+
+    CQubitManager::QubitIdType CQubitManager::GetQubitId(Qubit qubit) const
+    {
+        FailIf(!IsValidQubit(qubit), "Not a valid qubit.");
+        return QubitToId(qubit);
+    }
+
+
+    Qubit CQubitManager::CreateQubitObject(QubitIdType id)
+    {
+        // Make sure the static_cast won't overflow:
+        FailIf(id < 0 || id >= MaximumQubitCapacity, "Qubit id is out of range.");
+        intptr_t pointerSizedId = static_cast<intptr_t>(id);
+        return reinterpret_cast<Qubit>(pointerSizedId);
+    }
+
+    void CQubitManager::DeleteQubitObject(Qubit /*qubit*/)
+    {
+        // Do nothing. By default we store qubit Id in place of a pointer to a qubit.
+    }
+
+    CQubitManager::QubitIdType CQubitManager::QubitToId(Qubit qubit) const
+    {
+        intptr_t pointerSizedId = reinterpret_cast<intptr_t>(qubit);
+        // Make sure the static_cast won't overflow:
+        FailIf(pointerSizedId < 0 || pointerSizedId > std::numeric_limits<QubitIdType>::max(),
+               "Qubit id is out of range.");
+        return static_cast<QubitIdType>(pointerSizedId);
+    }
+
+    void CQubitManager::EnsureCapacity(QubitIdType requestedCapacity)
+    {
+        FailIf(requestedCapacity <= 0, "Requested qubit capacity must be positive.");
+        if (requestedCapacity <= qubitCapacity)
+        {
+            return;
+        }
+        // We need to reallocate shared status array, but there's no need to adjust
+        // existing values (NonMarker or indexes in the array).
+
+        // Prepare new shared status array
+        QubitIdType* newStatusArray = new QubitIdType[(size_t)requestedCapacity];
+        memcpy(newStatusArray, sharedQubitStatusArray, (size_t)qubitCapacity * sizeof(newStatusArray[0]));
+        QubitListInSharedArray newFreeQubits(qubitCapacity, requestedCapacity - 1, newStatusArray);
+
+        // Set new data. All fresh new qubits are added to the free qubits in the outermost area.
+        freeQubitCount += requestedCapacity - qubitCapacity;
+        FailIf(freeQubitCount <= 0, "Incorrect free qubit count.");
+        delete[] sharedQubitStatusArray;
+        sharedQubitStatusArray = newStatusArray;
+        qubitCapacity          = requestedCapacity;
+        freeQubitsInAreas[0].FreeQubitsReuseAllowed.MoveAllQubitsFrom(newFreeQubits, sharedQubitStatusArray);
+    }
+
+    CQubitManager::QubitIdType CQubitManager::TakeFreeQubitId()
+    {
+        // First we try to take qubit from the current (innermost) area.
+        QubitIdType id = freeQubitsInAreas.PeekBack().FreeQubitsReuseAllowed.TakeQubitFromFront(sharedQubitStatusArray);
+
+        // Then, if no free qubits available for reuse, we scan outer areas (if they exist).
+        if (id == NoneMarker && freeQubitsInAreas.Count() >= 2)
+        {
+            int32_t areaIndex = freeQubitsInAreas.Count() - 1;
+            do
+            {
+                areaIndex = freeQubitsInAreas[(size_t)areaIndex].prevAreaWithFreeQubits;
+                id        = freeQubitsInAreas[(size_t)areaIndex].FreeQubitsReuseAllowed.TakeQubitFromFront(
+                    sharedQubitStatusArray);
+            } while ((areaIndex != 0) && (id == NoneMarker));
+
+            // We remember previous area where a free qubit was found or 0 if none were found.
+            freeQubitsInAreas.PeekBack().prevAreaWithFreeQubits = areaIndex;
+        }
+
+        if (id != NoneMarker)
+        {
+            FailIf(id < 0 || id >= qubitCapacity, "Internal Error: Allocated invalid qubit.");
+            allocatedQubitCount++;
+            FailIf(allocatedQubitCount <= 0, "Incorrect allocated qubit count.");
+            freeQubitCount--;
+            FailIf(freeQubitCount < 0, "Incorrect free qubit count.");
+        }
+
+        return id;
+    }
+
+    CQubitManager::QubitIdType CQubitManager::AllocateQubitId()
+    {
+        QubitIdType newQubitId = TakeFreeQubitId();
+        if (newQubitId == NoneMarker && mayExtendCapacity)
+        {
+            QubitIdType newQubitCapacity = qubitCapacity * 2;
+            FailIf(newQubitCapacity <= qubitCapacity, "Cannot extend capacity.");
+            EnsureCapacity(newQubitCapacity);
+            newQubitId = TakeFreeQubitId();
+        }
+        return newQubitId;
+    }
+
+    void CQubitManager::ReleaseQubitId(QubitIdType id)
+    {
+        FailIf(id < 0 || id >= qubitCapacity, "Internal Error: Cannot release an invalid qubit.");
+        if (IsDisabledId(id))
+        {
+            // Nothing to do. Qubit will stay disabled.
+            return;
+        }
+
+        FailIf(!IsExplicitlyAllocatedId(id), "Attempt to free qubit that has not been allocated.");
+
+        // Released qubits are added to reuse area/segment in which they were released
+        // (rather than area/segment where they are allocated).
+        // Although counterintuitive, this makes code simple.
+        // This is reasonable because qubits should be allocated and released in the same segment. (This is not
+        // enforced)
+        freeQubitsInAreas.PeekBack().FreeQubitsReuseAllowed.AddQubit(id, sharedQubitStatusArray);
+
+        freeQubitCount++;
+        FailIf(freeQubitCount <= 0, "Incorrect free qubit count.");
+        allocatedQubitCount--;
+        FailIf(allocatedQubitCount < 0, "Incorrect allocated qubit count.");
+    }
+
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Qir/Runtime/lib/QIR/arrays.cpp
+++ b/src/Qir/Runtime/lib/QIR/arrays.cpp
@@ -41,9 +41,9 @@ int QirArray::Release()
     const int rc = --this->refCount;
     if (rc == 0)
     {
-        if(ownsQubits)
+        if (ownsQubits)
         {
-            delete[] (reinterpret_cast<Qubit*>(this->buffer));
+            delete[](reinterpret_cast<Qubit*>(this->buffer));
         }
         else
         {
@@ -86,14 +86,13 @@ QirArray::QirArray(TItemCount count_items, TItemSize item_size_bytes, TDimCount 
 
     // Each array item needs to be properly aligned. Let's align them by correcting the `itemSizeInBytes`.
     , itemSizeInBytes(
-        (   (item_size_bytes == 1)
-         || (item_size_bytes == 2)
-         || (item_size_bytes == 4)
-         || ((item_size_bytes % sizeof(size_t)) == 0)   // For built-in types or multiples of architecture alignment
-        ) ? item_size_bytes                             // leave their natural alignment.
-                                    // Other types align on the architecture boundary `sizeof(size_t)`: 4 bytes on 32-bit arch, 8 on 64-bit arch.
-          : item_size_bytes + sizeof(size_t) - (item_size_bytes % sizeof(size_t))
-      )
+          ((item_size_bytes == 1) || (item_size_bytes == 2) || (item_size_bytes == 4) ||
+           ((item_size_bytes % sizeof(size_t)) == 0) // For built-in types or multiples of architecture alignment
+           )
+              ? item_size_bytes // leave their natural alignment.
+                                // Other types align on the architecture boundary `sizeof(size_t)`:
+                                // 4 bytes on 32-bit arch, 8 on 64-bit arch.
+              : item_size_bytes + sizeof(size_t) - (item_size_bytes % sizeof(size_t)))
 
     , dimensions(dimCount)
     , dimensionSizes(std::move(dimSizes))
@@ -117,7 +116,8 @@ QirArray::QirArray(TItemCount count_items, TItemSize item_size_bytes, TDimCount 
         }
     }
 
-    assert(this->count * (TBufSize)itemSizeInBytes < std::numeric_limits<TBufSize>::max()); // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
+    assert(this->count * (TBufSize)itemSizeInBytes < std::numeric_limits<TBufSize>::max());
+    // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
     const TBufSize buffer_size = this->count * itemSizeInBytes;
     if (buffer_size > 0)
     {
@@ -144,7 +144,8 @@ QirArray::QirArray(const QirArray& other)
         GlobalContext()->OnAllocate(this);
     }
 
-    assert((TBufSize)(this->count) * this->itemSizeInBytes < std::numeric_limits<TBufSize>::max());    // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
+    assert((TBufSize)(this->count) * this->itemSizeInBytes < std::numeric_limits<TBufSize>::max());
+    // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
     const TBufSize size = this->count * this->itemSizeInBytes;
     if (this->count > 0)
     {
@@ -175,7 +176,8 @@ void QirArray::Append(const QirArray* other)
     assert(this->itemSizeInBytes == other->itemSizeInBytes);
     assert(this->dimensions == 1 && other->dimensions == 1);
 
-    assert((TBufSize)(other->count) * other->itemSizeInBytes < std::numeric_limits<TBufSize>::max());  // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
+    assert((TBufSize)(other->count) * other->itemSizeInBytes < std::numeric_limits<TBufSize>::max());
+    // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
     const TBufSize other_size = other->count * other->itemSizeInBytes;
 
     if (other_size == 0)
@@ -183,11 +185,12 @@ void QirArray::Append(const QirArray* other)
         return;
     }
 
-    assert((TBufSize)(this->count) * this->itemSizeInBytes < std::numeric_limits<TBufSize>::max());    // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
+    assert((TBufSize)(this->count) * this->itemSizeInBytes < std::numeric_limits<TBufSize>::max());
+    // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
     const TBufSize this_size = this->count * this->itemSizeInBytes;
 
     char* new_buffer = new char[this_size + other_size];
-    if(this_size)
+    if (this_size)
     {
         memcpy(new_buffer, this->buffer, this_size);
     }
@@ -210,12 +213,13 @@ void QirArray::Append(const QirArray* other)
 // ...                                                    [36 - 47]
 // 400 401 402 403 | 410 411 412 413 | 420 421 422 423 -- [48 - 59]
 // index[112] ~ linear index 18 = 1*3*4 + 1*4 + 2
-static QirArray::TItemCount GetLinearIndex(const QirArray::TDimContainer& dimensionSizes, const QirArray::TDimContainer& indexes)
+static QirArray::TItemCount GetLinearIndex(const QirArray::TDimContainer& dimensionSizes,
+                                           const QirArray::TDimContainer& indexes)
 {
-    const size_t dimensions = dimensionSizes.size();
+    const size_t dimensions          = dimensionSizes.size();
     QirArray::TItemCount linearIndex = 0;
-    QirArray::TItemCount layerSize = 1;
-    for (size_t i = dimensions; i > 0; )
+    QirArray::TItemCount layerSize   = 1;
+    for (size_t i = dimensions; i > 0;)
     {
         --i;
         linearIndex += indexes[i] * layerSize;
@@ -229,7 +233,8 @@ static QirArray::TItemCount GetLinearIndex(const QirArray::TDimContainer& dimens
 static QirArray::TItemCount RunCount(const QirArray::TDimContainer& dimensionSizes, QirArray::TDimCount dimension)
 {
     assert((0 <= dimension) && ((size_t)dimension < dimensionSizes.size()));
-    return std::accumulate(dimensionSizes.begin() + dimension + 1, dimensionSizes.end(), (QirArray::TDimCount)1, std::multiplies<QirArray::TItemCount>());
+    return std::accumulate(dimensionSizes.begin() + dimension + 1, dimensionSizes.end(), (QirArray::TDimCount)1,
+                           std::multiplies<QirArray::TItemCount>());
 }
 
 /*==============================================================================
@@ -237,8 +242,8 @@ static QirArray::TItemCount RunCount(const QirArray::TDimContainer& dimensionSiz
 ==============================================================================*/
 extern "C"
 {
-    QirArray* quantum__rt__qubit_allocate_array(int64_t count)  // TODO: Use `QirArray::TItemCount count` (breaking change).
-    {
+    QirArray* quantum__rt__qubit_allocate_array(int64_t count) // TODO: Use `QirArray::TItemCount count`
+    {                                                          // (breaking change).
         return new QirArray((QirArray::TItemCount)count);
     }
 
@@ -262,7 +267,8 @@ extern "C"
         quantum__rt__array_update_reference_count(qa, -1);
     }
 
-    QirArray* quantum__rt__array_create_1d(int32_t itemSizeInBytes, int64_t count_items)    // TODO: Use `QirArray::TItemSize itemSizeInBytes, QirArray::TItemCount count_items` (breaking change).
+    // TODO: Use `QirArray::TItemSize itemSizeInBytes, QirArray::TItemCount count_items` (breaking change):
+    QirArray* quantum__rt__array_create_1d(int32_t itemSizeInBytes, int64_t count_items)
     {
         assert(itemSizeInBytes > 0);
         return new QirArray((QirArray::TItemCount)count_items, (QirArray::TItemSize)itemSizeInBytes);
@@ -311,20 +317,22 @@ extern "C"
         }
     }
 
-    char* quantum__rt__array_get_element_ptr_1d(QirArray* array, int64_t index)     // TODO: Use `QirArray::TItemCount index` (breaking change).
+    // TODO: Use `QirArray::TItemCount index` (breaking change):
+    char* quantum__rt__array_get_element_ptr_1d(QirArray* array, int64_t index)
     {
         assert(array != nullptr);
         return array->GetItemPointer((QirArray::TItemCount)index);
     }
 
     // Returns the number of dimensions in the array.
-    int32_t quantum__rt__array_get_dim(QirArray* array)     // TODO: Return `QirArray::TDimCount` (breaking change).
+    int32_t quantum__rt__array_get_dim(QirArray* array) // TODO: Return `QirArray::TDimCount` (breaking change).
     {
         assert(array != nullptr);
         return array->dimensions;
     }
 
-    int64_t quantum__rt__array_get_size(QirArray* array, int32_t dim)   // TODO: Use `QirArray::TDimCount dim`, return `QirArray::TItemCount` (breaking change).
+    // TODO: Use `QirArray::TDimCount dim`, return `QirArray::TItemCount` (breaking change):
+    int64_t quantum__rt__array_get_size(QirArray* array, int32_t dim)
     {
         assert(array != nullptr);
         assert(dim < array->dimensions);
@@ -359,7 +367,8 @@ extern "C"
     // Creates a new array. The first int is the size of each element in bytes. The second int is the dimension count.
     // The variable arguments should be a sequence of int64_ts contains the length of each dimension. The bytes of the
     // new array should be set to zero.
-    QirArray* quantum__rt__array_create_nonvariadic(int itemSizeInBytes, int countDimensions, va_list dims) // TODO: Use unsigned types (breaking change).
+    // TODO: Use unsigned types (breaking change):
+    QirArray* quantum__rt__array_create_nonvariadic(int itemSizeInBytes, int countDimensions, va_list dims)
     {
         QirArray::TDimContainer dimSizes;
         dimSizes.reserve((size_t)countDimensions);
@@ -367,13 +376,17 @@ extern "C"
 
         for (int i = 0; i < countDimensions; i++)
         {
-            const QirArray::TItemCount dimSize = (QirArray::TItemCount)va_arg(dims, int64_t);   // TODO: Use `va_arg(dims, QirArray::TItemCount)`.
+            const QirArray::TItemCount dimSize = (QirArray::TItemCount)va_arg(dims, int64_t);
+            // TODO: Use `va_arg(dims, QirArray::TItemCount)`.
             dimSizes.push_back(dimSize);
             totalCount *= dimSize;
         }
 
-        assert(countDimensions < std::numeric_limits<QirArray::TDimCount>::max());  // Using `<` rather than `<=` to calm down the compiler in case `countDimensions` becomes `QirArray::TDimCount`.
-        return new QirArray(totalCount, (QirArray::TItemSize)itemSizeInBytes, (QirArray::TDimCount)countDimensions, std::move(dimSizes));
+        assert(countDimensions < std::numeric_limits<QirArray::TDimCount>::max());
+        // Using `<` rather than `<=` to calm down the compiler in case `countDimensions` becomes
+        // `QirArray::TDimCount`.
+        return new QirArray(totalCount, (QirArray::TItemSize)itemSizeInBytes, (QirArray::TDimCount)countDimensions,
+                            std::move(dimSizes));
     }
 
     QirArray* quantum__rt__array_create(int itemSizeInBytes, int countDimensions, ...) // NOLINT
@@ -395,7 +408,8 @@ extern "C"
 
         for (QirArray::TDimCount i = 0; i < array->dimensions; i++)
         {
-            indexes.push_back((QirArray::TItemCount)va_arg(args, int64_t));   // TODO: Use `va_arg(args, QirArray::TItemCount)`.
+            indexes.push_back((QirArray::TItemCount)va_arg(args, int64_t));
+            // TODO: Use `va_arg(args, QirArray::TItemCount)`.
             assert(indexes.back() < array->dimensionSizes[i]);
         }
 
@@ -412,7 +426,7 @@ extern "C"
         assert(array != nullptr);
 
         va_list args;
-        va_start(args, array->dimensions);                                          // TODO: (Bug or hack?) Replace `array->dimensions` with `array`.
+        va_start(args, array->dimensions); // TODO: (Bug or hack?) Replace `array->dimensions` with `array`.
         char* ptr = quantum__rt__array_get_element_ptr_nonvariadic(array, args);
         va_end(args);
 
@@ -430,22 +444,22 @@ extern "C"
         CheckedRange(const QirRange& r, int64_t upperBound) // lower bound assumed to be 0
         {
             this->start = r.start;
-            this->step = r.step;
+            this->step  = r.step;
 
             if (r.step == 0)
             {
                 throw std::runtime_error("invalid range");
             }
-            else if (   (r.step > 0 && r.end   < r.start)     // Positive step and negative range.
-                     || (r.step < 0 && r.start < r.end  ))    // Negative step and positive range.
+            else if ((r.step > 0 && r.end < r.start)     // Positive step and negative range.
+                     || (r.step < 0 && r.start < r.end)) // Negative step and positive range.
             {
                 // the QirRange generates empty sequence, normalize it
                 this->start = 0;
-                this->step = 1;
-                this->end = 0;
+                this->step  = 1;
+                this->end   = 0;
                 this->width = 0;
             }
-            else if (r.step > 0)    // Positive step and positive range.
+            else if (r.step > 0) // Positive step and positive range.
             {
                 this->width = (r.end - r.start + 1) / r.step + ((r.end - r.start + 1) % r.step != 0 ? 1 : 0);
                 assert(this->width > 0);
@@ -458,33 +472,34 @@ extern "C"
 
                 this->end = lastSequenceItem + r.step;
             }
-            else    // Negative step and negative range.
-            {   // Range{10, -3, 1} == { 10, 7, 4, 1 }
+            else // Negative step and negative range.
+            {    // Range{10, -3, 1} == { 10, 7, 4, 1 }
                 // (B) Range{1, -5 , 0} = { 1 }
                 // (C) Range{4, -2, 0} = {4, 2, 0}
-                this->width = (r.end - r.start - 1) / r.step    // (1 - 10 - 1) / (-3) == (-10) / (-3) == 3.
-                                                                // (B) (0 - 1 - 1) / (-5) == -2 / -5 == 0.
-                            + ((r.end - r.start - 1) % r.step != 0 ? 1 : 0); // (-10) % (-3) == -1; (-1) ? 1 : 0 == 1.
-                                                                // (B) -2 % -5 = -2; -2 ? 1 : 0 == 1.
-                                                                // Total: 4.
-                                                                // (B) Total: 1.
+                this->width = (r.end - r.start - 1) / r.step // (1 - 10 - 1) / (-3) == (-10) / (-3) == 3.
+                                                             // (B) (0 - 1 - 1) / (-5) == -2 / -5 == 0.
+                              + ((r.end - r.start - 1) % r.step != 0 ? 1 : 0); // (-10) % (-3) == -1; (-1) ? 1 : 0 == 1.
+                                                                               // (B) -2 % -5 = -2; -2 ? 1 : 0 == 1.
+                                                                               // Total: 4.
+                                                                               // (B) Total: 1.
                 assert(this->width > 0);
 
-                const int64_t lastSequenceItem = r.start + (this->width - 1) * r.step;  // 10 + (4 - 1) * (-3) = 1.
-                                                                // (B) 1 + (1 - 1)*(-5) = 1 + 0*5 = 1.
+                const int64_t lastSequenceItem =
+                    r.start + (this->width - 1) * r.step; // 10 + (4 - 1) * (-3) = 1.
+                                                          // (B) 1 + (1 - 1)*(-5) = 1 + 0*5 = 1.
                 if (lastSequenceItem < 0 || r.start >= upperBound)
                 {
                     throw std::runtime_error("range out of bounds");
                 }
 
-                this->end = lastSequenceItem + r.step;          // (B) 1 + (-5) = -4.
+                this->end = lastSequenceItem + r.step; // (B) 1 + (-5) = -4.
             }
 
             // normalize the range of width 1, as the step doesn't matter for it
             if (this->width == 1)
             {
                 this->step = 1;
-                this->end = this->start + 1;
+                this->end  = this->start + 1;
             }
         }
 
@@ -497,13 +512,14 @@ extern "C"
     // Creates and returns an array that is a slice of an existing array. The int indicates which dimension the slice is
     // on. The %Range specifies the slice. Both ends of the range are inclusive. Negative step means the the order of
     // elements should be reversed.
-    QirArray* quantum__rt__array_slice(QirArray* array, int32_t dim, const QirRange& qirRange) // NOLINT     // TODO: Use `QirArray::TDimCount dim` (breaking change).
+    // TODO: Use `QirArray::TDimCount dim` (breaking change):
+    QirArray* quantum__rt__array_slice(QirArray* array, int32_t dim, const QirRange& qirRange) // NOLINT
     {
         assert(array != nullptr);
         assert(dim >= 0 && dim < array->dimensions);
 
         const QirArray::TItemSize itemSizeInBytes = array->itemSizeInBytes;
-        const QirArray::TDimCount dimensions = array->dimensions;
+        const QirArray::TDimCount dimensions      = array->dimensions;
 
         const CheckedRange range(qirRange, array->dimensionSizes[(size_t)dim]);
 
@@ -511,7 +527,7 @@ extern "C"
         if (range.IsEmpty())
         {
             QirArray::TDimContainer dims = array->dimensionSizes;
-            dims[(size_t)dim] = 0;
+            dims[(size_t)dim]            = 0;
             return new QirArray(0, itemSizeInBytes, dimensions, std::move(dims));
         }
 
@@ -522,21 +538,24 @@ extern "C"
         }
 
         // Create slice array of appropriate size.
-        QirArray::TDimContainer sliceDims = array->dimensionSizes;
-        sliceDims[(size_t)dim] = (QirArray::TItemCount)(range.width);
-        const QirArray::TItemCount sliceItemsCount =
-            std::accumulate(sliceDims.begin(), sliceDims.end(), (QirArray::TItemCount)1, std::multiplies<QirArray::TItemCount>());
+        QirArray::TDimContainer sliceDims          = array->dimensionSizes;
+        sliceDims[(size_t)dim]                     = (QirArray::TItemCount)(range.width);
+        const QirArray::TItemCount sliceItemsCount = std::accumulate(
+            sliceDims.begin(), sliceDims.end(), (QirArray::TItemCount)1, std::multiplies<QirArray::TItemCount>());
         QirArray* slice = new QirArray(sliceItemsCount, itemSizeInBytes, dimensions, std::move(sliceDims));
         const QirArray::TItemCount singleIndexRunCount = RunCount(array->dimensionSizes, (QirArray::TDimCount)dim);
-        const QirArray::TItemCount rowCount = singleIndexRunCount * array->dimensionSizes[(size_t)dim];
+        const QirArray::TItemCount rowCount            = singleIndexRunCount * array->dimensionSizes[(size_t)dim];
 
         // When range is continuous, can copy data in larger chunks. For example, if the slice is on dim = 0,
         // we will copy exactly once.
         if (range.step == 1)
         {
-            const QirArray::TItemCount rangeRunCount = (QirArray::TItemCount)(singleIndexRunCount * (range.end - range.start));
+            const QirArray::TItemCount rangeRunCount =
+                (QirArray::TItemCount)(singleIndexRunCount * (range.end - range.start));
 
-            assert((QirArray::TBufSize)rangeRunCount * itemSizeInBytes < std::numeric_limits<QirArray::TBufSize>::max());   // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
+            assert((QirArray::TBufSize)rangeRunCount * itemSizeInBytes <
+                   std::numeric_limits<QirArray::TBufSize>::max());
+            // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
             const QirArray::TBufSize rangeChunkSize = rangeRunCount * itemSizeInBytes;
 
             QirArray::TItemCount dst = 0;
@@ -552,19 +571,22 @@ extern "C"
         }
 
         // In case of disconnected or reversed range have to copy the data one run at a time.
-        assert((QirArray::TBufSize)singleIndexRunCount * itemSizeInBytes < std::numeric_limits<QirArray::TBufSize>::max());    // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
+        assert((QirArray::TBufSize)singleIndexRunCount * itemSizeInBytes <
+               std::numeric_limits<QirArray::TBufSize>::max());
+        // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
         const QirArray::TBufSize chunkSize = singleIndexRunCount * itemSizeInBytes;
-        QirArray::TItemCount dst = 0;
-        QirArray::TItemCount src = (QirArray::TItemCount)(singleIndexRunCount * range.start);
+        QirArray::TItemCount dst           = 0;
+        QirArray::TItemCount src           = (QirArray::TItemCount)(singleIndexRunCount * range.start);
         while (src < array->count)
         {
             assert(dst < slice->count);
 
-            int64_t srcInner = src;     // The `srcInner` can go negative in the end of the last iteration.
+            int64_t srcInner = src; // The `srcInner` can go negative in the end of the last iteration.
             for (int64_t index = range.start; index != range.end; index += range.step)
             {
                 assert((dst * itemSizeInBytes + chunkSize) <= (slice->count * slice->itemSizeInBytes));
-                assert((srcInner * (int64_t)itemSizeInBytes + (int64_t)chunkSize) <= (array->count * array->itemSizeInBytes));
+                assert((srcInner * (int64_t)itemSizeInBytes + (int64_t)chunkSize) <=
+                       (array->count * array->itemSizeInBytes));
                 assert(srcInner >= 0);
 
                 memcpy(&slice->buffer[dst * itemSizeInBytes], &array->buffer[srcInner * itemSizeInBytes], chunkSize);
@@ -579,7 +601,8 @@ extern "C"
     // Creates and returns an array that is a projection of an existing array. The int indicates which dimension the
     // projection is on, and the int64_t specifies the specific index value to project. The returned Array* will have
     // one fewer dimension than the existing array.
-    QirArray* quantum__rt__array_project(QirArray* array, int dim, int64_t index) // NOLINT     // TODO: Use `QirArray::TDimCount dim, QirArray::TItemCount index` (breaking change).
+    // TODO: Use `QirArray::TDimCount dim, QirArray::TItemCount index` (breaking change):
+    QirArray* quantum__rt__array_project(QirArray* array, int dim, int64_t index) // NOLINT
     {
         assert(array != nullptr);
         assert(dim >= 0 && dim < array->dimensions);
@@ -587,20 +610,22 @@ extern "C"
         assert(index >= 0 && index < array->dimensionSizes[(size_t)dim]);
 
         const QirArray::TItemSize itemSizeInBytes = array->itemSizeInBytes;
-        const QirArray::TDimCount dimensions = array->dimensions;
+        const QirArray::TDimCount dimensions      = array->dimensions;
 
         // Create projected array of appropriate size.
         QirArray::TDimContainer projectDims = array->dimensionSizes;
         projectDims.erase(projectDims.begin() + dim);
 
-        const QirArray::TItemCount projectItemsCount =
-            std::accumulate(projectDims.begin(), projectDims.end(), (QirArray::TItemCount)1, std::multiplies<QirArray::TItemCount>());
+        const QirArray::TItemCount projectItemsCount = std::accumulate(
+            projectDims.begin(), projectDims.end(), (QirArray::TItemCount)1, std::multiplies<QirArray::TItemCount>());
         QirArray* project = new QirArray(projectItemsCount, itemSizeInBytes, dimensions - 1, std::move(projectDims));
 
         const QirArray::TItemCount singleIndexRunCount = RunCount(array->dimensionSizes, (QirArray::TDimCount)dim);
-        const QirArray::TItemCount rowCount = singleIndexRunCount * array->dimensionSizes[(size_t)dim];
-        
-        assert((QirArray::TBufSize)singleIndexRunCount * itemSizeInBytes < std::numeric_limits<QirArray::TBufSize>::max());    // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
+        const QirArray::TItemCount rowCount            = singleIndexRunCount * array->dimensionSizes[(size_t)dim];
+
+        assert((QirArray::TBufSize)singleIndexRunCount * itemSizeInBytes <
+               std::numeric_limits<QirArray::TBufSize>::max());
+        // Using `<` rather than `<=` to calm down the compiler on 32-bit arch.
         const QirArray::TBufSize chunkSize = singleIndexRunCount * itemSizeInBytes;
 
         QirArray::TItemCount dst = 0;

--- a/src/Qir/Runtime/lib/QIR/context.cpp
+++ b/src/Qir/Runtime/lib/QIR/context.cpp
@@ -14,7 +14,10 @@ namespace Microsoft
 namespace Quantum
 {
     std::unique_ptr<QirExecutionContext> g_context = nullptr;
-    std::unique_ptr<QirExecutionContext>& GlobalContext() { return g_context; }
+    std::unique_ptr<QirExecutionContext>& GlobalContext()
+    {
+        return g_context;
+    }
 
     void InitializeQirContext(IRuntimeDriver* driver, bool trackAllocatedObjects)
     {
@@ -44,10 +47,10 @@ namespace Quantum
         }
     }
 
-    // If we just remove this user-declared-and-defined dtor 
+    // If we just remove this user-declared-and-defined dtor
     // then it will be automatically defined together with the class definition,
-    // which will require the `AllocationsTracker` to be a complete type 
-    // everywhere where `public/QirContext.hpp` is included 
+    // which will require the `AllocationsTracker` to be a complete type
+    // everywhere where `public/QirContext.hpp` is included
     // (we'll have to move `allocationsTracker.hpp` to `public/`).
     QirExecutionContext::~QirExecutionContext() = default;
 
@@ -71,7 +74,7 @@ namespace Quantum
 
     void QirExecutionContext::OnAddRef(void* object)
     {
-        if(trackAllocatedObjects)
+        if (trackAllocatedObjects)
         {
             this->allocationsTracker->OnAddRef(object);
         }
@@ -79,7 +82,7 @@ namespace Quantum
 
     void QirExecutionContext::OnRelease(void* object)
     {
-        if(this->trackAllocatedObjects)
+        if (this->trackAllocatedObjects)
         {
             this->allocationsTracker->OnRelease(object);
         }
@@ -87,7 +90,7 @@ namespace Quantum
 
     void QirExecutionContext::OnAllocate(void* object)
     {
-        if(this->trackAllocatedObjects)
+        if (this->trackAllocatedObjects)
         {
             this->allocationsTracker->OnAllocate(object);
         }
@@ -112,7 +115,7 @@ namespace Quantum
     {
         InitializeQirContext(driver, trackAllocatedObj);
     }
-    
+
     QirContextScope::~QirContextScope()
     {
         ReleaseQirContext();

--- a/src/Qir/Runtime/lib/QIR/delegated.cpp
+++ b/src/Qir/Runtime/lib/QIR/delegated.cpp
@@ -31,7 +31,6 @@ extern "C"
     {
         return Microsoft::Quantum::GlobalContext()->GetDriver()->UseZero();
     }
-
     Result quantum__rt__result_get_one()
     {
         return Microsoft::Quantum::GlobalContext()->GetDriver()->UseOne();
@@ -58,7 +57,7 @@ extern "C"
             // If we don't have the result in our map, assume it has been allocated by a measurement with refcount = 1,
             // and this is the first attempt to share it.
             std::unordered_map<RESULT*, int>& trackedResults = AllocatedResults();
-            auto rit = trackedResults.find(r);
+            auto rit                                         = trackedResults.find(r);
             if (rit == trackedResults.end())
             {
                 trackedResults[r] = 1 + increment;
@@ -72,7 +71,7 @@ extern "C"
         {
             // If we don't have the result in our map, assume it has been never shared, so it's reference count is 1.
             std::unordered_map<RESULT*, int>& trackedResults = AllocatedResults();
-            auto rit = trackedResults.find(r);
+            auto rit                                         = trackedResults.find(r);
             if (rit == trackedResults.end())
             {
                 assert(increment == -1);
@@ -116,6 +115,7 @@ extern "C"
     // Returns a string representation of the qubit.
     QirString* quantum__rt__qubit_to_string(QUBIT* qubit) // NOLINT
     {
-        return quantum__rt__string_create(Microsoft::Quantum::GlobalContext()->GetDriver()->QubitToString(qubit).c_str());
+        return quantum__rt__string_create(
+            Microsoft::Quantum::GlobalContext()->GetDriver()->QubitToString(qubit).c_str());
     }
 }

--- a/src/Qir/Runtime/lib/QIR/strings.cpp
+++ b/src/Qir/Runtime/lib/QIR/strings.cpp
@@ -15,7 +15,7 @@
 std::unordered_map<std::string, QirString*>& AllocatedStrings();
 
 
-std::unordered_map<std::string, QirString*>& AllocatedStrings()     // Cannot be static, is called by tests. 
+std::unordered_map<std::string, QirString*>& AllocatedStrings() // Cannot be static, is called by tests.
 {
     static std::unordered_map<std::string, QirString*> allocatedStrings;
     return allocatedStrings;
@@ -23,7 +23,7 @@ std::unordered_map<std::string, QirString*>& AllocatedStrings()     // Cannot be
 
 static QirString* CreateOrReuseAlreadyAllocated(std::string&& str)
 {
-    QirString* qstr = nullptr;
+    QirString* qstr       = nullptr;
     auto alreadyAllocated = AllocatedStrings().find(str);
     if (alreadyAllocated != AllocatedStrings().end())
     {
@@ -33,19 +33,23 @@ static QirString* CreateOrReuseAlreadyAllocated(std::string&& str)
     }
     else
     {
-        qstr = new QirString(std::move(str));
+        qstr                          = new QirString(std::move(str));
         AllocatedStrings()[qstr->str] = qstr;
     }
     return qstr;
 }
 
 QirString::QirString(std::string&& otherStr)
+    // clang-format off
     : str(std::move(otherStr))
+// clang-format on
 {
 }
 
 QirString::QirString(const char* cstr)
+    // clang-format off
     : str(cstr)
+// clang-format on
 {
 }
 
@@ -170,7 +174,7 @@ extern "C"
         return str->str.c_str();
     }
 
-    uint32_t quantum__rt__string_get_length(QirString* str)  // NOLINT
+    uint32_t quantum__rt__string_get_length(QirString* str) // NOLINT
     {
         return (uint32_t)(str->str.size());
     }

--- a/src/Qir/Runtime/lib/QIR/utils.cpp
+++ b/src/Qir/Runtime/lib/QIR/utils.cpp
@@ -18,7 +18,7 @@ extern "C"
 {
     char* quantum__rt__memory_allocate(uint64_t size)
     {
-        return (char *)malloc((size_t)size);
+        return (char*)malloc((size_t)size);
     }
 
     // Fail the computation with the given error message.

--- a/src/Qir/Runtime/lib/QSharpCore/intrinsics.cpp
+++ b/src/Qir/Runtime/lib/QSharpCore/intrinsics.cpp
@@ -42,9 +42,8 @@ extern "C"
         assert(paulis->count == qubits->count);
 
         std::vector<PauliId> pauliIds = ExtractPauliIds(paulis);
-        return GateSet()->Exp(
-            (long)(paulis->count), reinterpret_cast<PauliId*>(pauliIds.data()), reinterpret_cast<Qubit*>(qubits->buffer),
-            angle);
+        return GateSet()->Exp((long)(paulis->count), reinterpret_cast<PauliId*>(pauliIds.data()),
+                              reinterpret_cast<Qubit*>(qubits->buffer), angle);
     }
 
     void quantum__qis__exp__adj(QirArray* paulis, double angle, QirArray* qubits)
@@ -57,9 +56,9 @@ extern "C"
         assert(paulis->count == qubits->count);
 
         std::vector<PauliId> pauliIds = ExtractPauliIds(paulis);
-        return GateSet()->ControlledExp(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), (long)(paulis->count),
-            reinterpret_cast<PauliId*>(pauliIds.data()), reinterpret_cast<Qubit*>(qubits->buffer), angle);
+        return GateSet()->ControlledExp((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer),
+                                        (long)(paulis->count), reinterpret_cast<PauliId*>(pauliIds.data()),
+                                        reinterpret_cast<Qubit*>(qubits->buffer), angle);
     }
 
     void quantum__qis__exp__ctladj(QirArray* ctls, QirArray* paulis, double angle, QirArray* qubits)
@@ -74,8 +73,7 @@ extern "C"
 
     void quantum__qis__h__ctl(QirArray* ctls, Qubit qubit)
     {
-        GateSet()->ControlledH(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledH((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
     }
 
     Result quantum__qis__measure__body(QirArray* paulis, QirArray* qubits)
@@ -84,8 +82,8 @@ extern "C"
         assert(count == paulis->count);
 
         std::vector<PauliId> pauliIds = ExtractPauliIds(paulis);
-        return GateSet()->Measure(
-            (long)(count), reinterpret_cast<PauliId*>(pauliIds.data()), (long)(count), reinterpret_cast<Qubit*>(qubits->buffer));
+        return GateSet()->Measure((long)(count), reinterpret_cast<PauliId*>(pauliIds.data()), (long)(count),
+                                  reinterpret_cast<Qubit*>(qubits->buffer));
     }
 
     void quantum__qis__r__body(PauliId axis, double angle, QUBIT* qubit)
@@ -96,12 +94,11 @@ extern "C"
     void quantum__qis__r__adj(PauliId axis, double angle, QUBIT* qubit)
     {
         quantum__qis__r__body(axis, -angle, qubit);
-     }
+    }
 
     void quantum__qis__r__ctl(QirArray* ctls, PauliId axis, double angle, QUBIT* qubit)
     {
-        return GateSet()->ControlledR(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), axis, qubit, angle);
+        return GateSet()->ControlledR((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), axis, qubit, angle);
     }
 
     void quantum__qis__r__ctladj(QirArray* ctls, PauliId axis, double angle, QUBIT* qubit)
@@ -121,14 +118,12 @@ extern "C"
 
     void quantum__qis__s__ctl(QirArray* ctls, Qubit qubit)
     {
-        GateSet()->ControlledS(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledS((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
     }
 
     void quantum__qis__s__ctladj(QirArray* ctls, Qubit qubit)
     {
-        GateSet()->ControlledAdjointS(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledAdjointS((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
     }
 
     void quantum__qis__t__body(Qubit qubit)
@@ -143,14 +138,12 @@ extern "C"
 
     void quantum__qis__t__ctl(QirArray* ctls, Qubit qubit)
     {
-        GateSet()->ControlledT(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledT((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
     }
 
     void quantum__qis__t__ctladj(QirArray* ctls, Qubit qubit)
     {
-        GateSet()->ControlledAdjointT(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledAdjointT((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
     }
 
     void quantum__qis__x__body(Qubit qubit)
@@ -160,8 +153,7 @@ extern "C"
 
     void quantum__qis__x__ctl(QirArray* ctls, Qubit qubit)
     {
-        GateSet()->ControlledX(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledX((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
     }
 
     void quantum__qis__y__body(Qubit qubit)
@@ -171,8 +163,7 @@ extern "C"
 
     void quantum__qis__y__ctl(QirArray* ctls, Qubit qubit)
     {
-        GateSet()->ControlledY(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledY((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
     }
 
     void quantum__qis__z__body(Qubit qubit)
@@ -182,7 +173,6 @@ extern "C"
 
     void quantum__qis__z__ctl(QirArray* ctls, Qubit qubit)
     {
-        GateSet()->ControlledZ(
-            (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledZ((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
     }
 }

--- a/src/Qir/Runtime/lib/QSharpCore/qsharp__core__qis.hpp
+++ b/src/Qir/Runtime/lib/QSharpCore/qsharp__core__qis.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CoreTypes.hpp"    // QUBIT, PauliId, RESULT
+#include "CoreTypes.hpp" // QUBIT, PauliId, RESULT
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
@@ -9,7 +9,7 @@ struct QirArray;
 
 /*
     Methods from __quantum__qis namespace are specific to the target. When QIR is generated it might limit or extend
-    the set of intrinsics, supported by the target (known to QIR generator at compile time). This provides the 
+    the set of intrinsics, supported by the target (known to QIR generator at compile time). This provides the
     implementation of the QSharp.Core intrinsics that redirect to IQuantumGateSet.
 */
 extern "C"
@@ -42,7 +42,8 @@ extern "C"
     QIR_SHARED_API void quantum__qis__z__ctl(QirArray*, QUBIT*);                            // NOLINT
 
     // Q# Dump:
-    // Note: The param `location` must be `const void*`, but it is called from .ll, where `const void*` is not supported.
-    QIR_SHARED_API void quantum__qis__dumpmachine__body(uint8_t* location);                 // NOLINT
-    QIR_SHARED_API void quantum__qis__dumpregister__body(uint8_t* location, const QirArray* qubits);   // NOLINT
+    // Note: The param `location` must be `const void*`,
+    // but it is called from .ll, where `const void*` is not supported.
+    QIR_SHARED_API void quantum__qis__dumpmachine__body(uint8_t* location);                          // NOLINT
+    QIR_SHARED_API void quantum__qis__dumpregister__body(uint8_t* location, const QirArray* qubits); // NOLINT
 }

--- a/src/Qir/Runtime/lib/QSharpFoundation/AssertMeasurement.cpp
+++ b/src/Qir/Runtime/lib/QSharpFoundation/AssertMeasurement.cpp
@@ -18,31 +18,31 @@ static IDiagnostics* GetDiagnostics()
 // Implementation:
 extern "C"
 {
-    void quantum__qis__assertmeasurementprobability__body(
-        QirArray* bases, QirArray* qubits, RESULT* result, double prob, QirString* msg, double tol)
+    void quantum__qis__assertmeasurementprobability__body(QirArray* bases, QirArray* qubits, RESULT* result,
+                                                          double prob, QirString* msg, double tol)
     {
-        if(bases->count != qubits->count)
+        if (bases->count != qubits->count)
         {
-            quantum__rt__fail_cstr(
-                "Both input arrays - bases, qubits - for AssertMeasurementProbability(), "
-                "must be of same size.");
+            quantum__rt__fail_cstr("Both input arrays - bases, qubits - for AssertMeasurementProbability(), "
+                                   "must be of same size.");
         }
 
-        IRuntimeDriver *driver = GlobalContext()->GetDriver();
-        if(driver->AreEqualResults(result, driver->UseOne()))
+        IRuntimeDriver* driver = GlobalContext()->GetDriver();
+        if (driver->AreEqualResults(result, driver->UseOne()))
         {
             prob = 1.0 - prob;
         }
 
         // Convert paulis from sequence of bytes to sequence of PauliId:
         std::vector<PauliId> paulis(bases->count);
-        for(QirArray::TItemCount i = 0; i < bases->count; ++i)
+        for (QirArray::TItemCount i = 0; i < bases->count; ++i)
         {
-            paulis[i] = (PauliId)*(bases->GetItemPointer(i));
+            paulis[i] = (PauliId) * (bases->GetItemPointer(i));
         }
 
-        if(!GetDiagnostics()->AssertProbability(
-            (long)qubits->count, paulis.data(), reinterpret_cast<Qubit*>(qubits->GetItemPointer(0)), prob, tol, nullptr))
+        if (!GetDiagnostics()->AssertProbability((long)qubits->count, paulis.data(),
+                                                 reinterpret_cast<Qubit*>(qubits->GetItemPointer(0)), prob, tol,
+                                                 nullptr))
         {
             quantum__rt__fail(msg);
         }

--- a/src/Qir/Runtime/lib/QSharpFoundation/conditionals.cpp
+++ b/src/Qir/Runtime/lib/QSharpFoundation/conditionals.cpp
@@ -35,11 +35,8 @@ extern "C"
         clb->Invoke();
     }
 
-    void quantum__qis__applyconditionallyintrinsic__body(
-        QirArray* rs1,
-        QirArray* rs2,
-        QirCallable* clbOnAllEqual,
-        QirCallable* clbOnSomeDifferent)
+    void quantum__qis__applyconditionallyintrinsic__body(QirArray* rs1, QirArray* rs2, QirCallable* clbOnAllEqual,
+                                                         QirCallable* clbOnSomeDifferent)
     {
         QirCallable* clb = ArraysContainEqualResults(rs1, rs2) ? clbOnAllEqual : clbOnSomeDifferent;
         clb->Invoke();

--- a/src/Qir/Runtime/lib/QSharpFoundation/intrinsicsMath.cpp
+++ b/src/Qir/Runtime/lib/QSharpFoundation/intrinsicsMath.cpp
@@ -14,110 +14,107 @@ namespace // Visible in this translation unit only.
 extern thread_local bool randomizeSeed;
 extern int64_t lastGeneratedRndI64;
 extern double lastGeneratedRndDouble;
-}
+} // namespace
 
 // Implementation:
 extern "C"
 {
 
-// Implementations:
-bool quantum__qis__isnan__body(double d)
-{
-    return std::isnan(d);           // https://en.cppreference.com/w/cpp/numeric/math/isnan
-}
-
-double quantum__qis__infinity__body()
-{
-    return (double)INFINITY;                // https://en.cppreference.com/w/c/numeric/math/INFINITY
-}
-
-bool quantum__qis__isinf__body(double d)
-{
-    return std::isinf(d);           // https://en.cppreference.com/w/cpp/numeric/math/isinf
-}
-
-double quantum__qis__arctan2__body(double y, double x)
-{
-    return std::atan2(y, x);        // https://en.cppreference.com/w/cpp/numeric/math/atan2
-}
-
-double quantum__qis__sinh__body(double theta)
-{
-    return std::sinh(theta);
-}
-
-double quantum__qis__cosh__body(double theta)
-{
-    return std::cosh(theta);
-}
-
-double quantum__qis__arcsin__body(double theta)
-{
-    return std::asin(theta);        // https://en.cppreference.com/w/cpp/numeric/math/asin
-}
-
-double quantum__qis__arccos__body(double theta)
-{
-    return std::acos(theta);        // https://en.cppreference.com/w/cpp/numeric/math/acos
-}
-
-double quantum__qis__arctan__body(double theta)
-{
-    return std::atan(theta);        // https://en.cppreference.com/w/cpp/numeric/math/atan
-}
-
-double quantum__qis__ieeeremainder__body(double x, double y)
-{
-    return std::remainder(x, y);    // https://en.cppreference.com/w/cpp/numeric/math/remainder
-}
-
-int64_t quantum__qis__drawrandomint__body(int64_t minimum, int64_t maximum)
-{
-    if(minimum > maximum)
+    // Implementations:
+    bool quantum__qis__isnan__body(double d)
     {
-        quantum__rt__fail_cstr(Quantum::Qis::Internal::excStrDrawRandomVal);
+        return std::isnan(d); // https://en.cppreference.com/w/cpp/numeric/math/isnan
     }
 
-    // https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
-    // https://en.cppreference.com/w/cpp/numeric/random
-    thread_local static std::mt19937_64 gen(randomizeSeed
-                                                ? std::random_device()() :  // Default
-                                                0);                         // For test purposes only.
-
-    lastGeneratedRndI64 = std::uniform_int_distribution<int64_t>(minimum, maximum)(gen);
-    return lastGeneratedRndI64;
-}
-
-double quantum__qis__drawrandomdouble__body(double minimum, double maximum)
-{
-    if(minimum > maximum)
+    double quantum__qis__infinity__body()
     {
-        quantum__rt__fail_cstr(Quantum::Qis::Internal::excStrDrawRandomVal);
+        return (double)INFINITY; // https://en.cppreference.com/w/c/numeric/math/INFINITY
     }
 
-    // For testing purposes we need separate generators for Int and Double:
-    // https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
-    // https://en.cppreference.com/w/cpp/numeric/random
-    thread_local static std::mt19937_64 gen(randomizeSeed
-                                                ? std::random_device()() :  // Default
-                                                0);                         // For test purposes only.
+    bool quantum__qis__isinf__body(double d)
+    {
+        return std::isinf(d); // https://en.cppreference.com/w/cpp/numeric/math/isinf
+    }
 
-    // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
-    lastGeneratedRndDouble = std::uniform_real_distribution<double>(
-            minimum, 
-            std::nextafter(maximum, std::numeric_limits<double>::max())) // "Notes" section.
-        (gen);    
-    return lastGeneratedRndDouble;
-}
+    double quantum__qis__arctan2__body(double y, double x)
+    {
+        return std::atan2(y, x); // https://en.cppreference.com/w/cpp/numeric/math/atan2
+    }
+
+    double quantum__qis__sinh__body(double theta)
+    {
+        return std::sinh(theta);
+    }
+
+    double quantum__qis__cosh__body(double theta)
+    {
+        return std::cosh(theta);
+    }
+
+    double quantum__qis__arcsin__body(double theta)
+    {
+        return std::asin(theta); // https://en.cppreference.com/w/cpp/numeric/math/asin
+    }
+
+    double quantum__qis__arccos__body(double theta)
+    {
+        return std::acos(theta); // https://en.cppreference.com/w/cpp/numeric/math/acos
+    }
+
+    double quantum__qis__arctan__body(double theta)
+    {
+        return std::atan(theta); // https://en.cppreference.com/w/cpp/numeric/math/atan
+    }
+
+    double quantum__qis__ieeeremainder__body(double x, double y)
+    {
+        return std::remainder(x, y); // https://en.cppreference.com/w/cpp/numeric/math/remainder
+    }
+
+    int64_t quantum__qis__drawrandomint__body(int64_t minimum, int64_t maximum)
+    {
+        if (minimum > maximum)
+        {
+            quantum__rt__fail_cstr(Quantum::Qis::Internal::excStrDrawRandomVal);
+        }
+
+        // https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
+        // https://en.cppreference.com/w/cpp/numeric/random
+        thread_local static std::mt19937_64 gen(randomizeSeed ? std::random_device()() : // Default
+                                                    0);                                  // For test purposes only.
+
+        lastGeneratedRndI64 = std::uniform_int_distribution<int64_t>(minimum, maximum)(gen);
+        return lastGeneratedRndI64;
+    }
+
+    double quantum__qis__drawrandomdouble__body(double minimum, double maximum)
+    {
+        if (minimum > maximum)
+        {
+            quantum__rt__fail_cstr(Quantum::Qis::Internal::excStrDrawRandomVal);
+        }
+
+        // For testing purposes we need separate generators for Int and Double:
+        // https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
+        // https://en.cppreference.com/w/cpp/numeric/random
+        thread_local static std::mt19937_64 gen(randomizeSeed ? std::random_device()() : // Default
+                                                    0);                                  // For test purposes only.
+
+        // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
+        lastGeneratedRndDouble = std::uniform_real_distribution<double>(
+            minimum, std::nextafter(maximum, std::numeric_limits<double>::max())) // "Notes" section.
+            (gen);
+        return lastGeneratedRndDouble;
+    }
 
 } // extern "C"
 
 namespace // Visible in this translation unit only.
 {
 thread_local bool randomizeSeed = true;
-int64_t lastGeneratedRndI64 = 0;
-double lastGeneratedRndDouble = 0.0;
-}
+int64_t lastGeneratedRndI64     = 0;
+double lastGeneratedRndDouble   = 0.0;
+} // namespace
 
 // For test purposes only:
 namespace Quantum

--- a/src/Qir/Runtime/lib/QSharpFoundation/qsharp__foundation__qis.hpp
+++ b/src/Qir/Runtime/lib/QSharpFoundation/qsharp__foundation__qis.hpp
@@ -35,14 +35,11 @@ extern "C"
 
     // Q# ApplyIf:
     QIR_SHARED_API void quantum__qis__applyifelseintrinsic__body(RESULT*, QirCallable*, QirCallable*); // NOLINT
-    QIR_SHARED_API void quantum__qis__applyconditionallyintrinsic__body( // NOLINT
-        QirArray*,
-        QirArray*,
-        QirCallable*,
-        QirCallable*);
+    QIR_SHARED_API void quantum__qis__applyconditionallyintrinsic__body(                               // NOLINT
+        QirArray*, QirArray*, QirCallable*, QirCallable*);
 
     // Q# Assert Measurement:
-    QIR_SHARED_API void quantum__qis__assertmeasurementprobability__body(   // NOLINT
+    QIR_SHARED_API void quantum__qis__assertmeasurementprobability__body( // NOLINT
         QirArray* bases, QirArray* qubits, RESULT* result, double prob, QirString* msg, double tol);
 
 } // extern "C"

--- a/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
@@ -13,15 +13,17 @@
 #include <chrono>
 #include <cstdint>
 
+// clang-format off
 #pragma clang diagnostic push
     // Ignore warnings for reserved macro names `_In_`, `_In_reads_(n)`:
     #pragma clang diagnostic ignored "-Wreserved-id-macro"
     #include "capi.hpp"
 #pragma clang diagnostic pop
+// clang-format on
 
 
 #include "FloatUtils.hpp"
-#include "QirTypes.hpp"         // TODO: Consider removing dependency on this file.
+#include "QirTypes.hpp" // TODO: Consider removing dependency on this file.
 #include "QirRuntimeApi_I.hpp"
 #include "QSharpSimApi_I.hpp"
 #include "SimFactory.hpp"
@@ -52,9 +54,8 @@ QUANTUM_SIMULATOR LoadQuantumSimulator()
     handle = ::LoadLibraryA(FULLSTATESIMULATORLIB);
     if (handle == nullptr)
     {
-        throw std::runtime_error(
-            std::string("Failed to load ") + FULLSTATESIMULATORLIB +
-            " (error code: " + std::to_string(GetLastError()) + ")");
+        throw std::runtime_error(std::string("Failed to load ") + FULLSTATESIMULATORLIB +
+                                 " (error code: " + std::to_string(GetLastError()) + ")");
     }
 #else
     handle = ::dlopen(FULLSTATESIMULATORLIB, RTLD_LAZY);
@@ -63,8 +64,8 @@ QUANTUM_SIMULATOR LoadQuantumSimulator()
         handle = ::dlopen(XPLATFULLSTATESIMULATORLIB, RTLD_LAZY);
         if (handle == nullptr)
         {
-            throw std::runtime_error(
-                std::string("Failed to load ") + XPLATFULLSTATESIMULATORLIB + " (" + ::dlerror() + ")");
+            throw std::runtime_error(std::string("Failed to load ") + XPLATFULLSTATESIMULATORLIB + " (" + ::dlerror() +
+                                     ")");
         }
     }
 #endif
@@ -87,14 +88,14 @@ namespace Microsoft
 namespace Quantum
 {
     // TODO: is it OK to load/unload the dll for each simulator instance?
-    class CFullstateSimulator : public IRuntimeDriver, public IQuantumGateSet, public IDiagnostics
+    class CFullstateSimulator
+        : public IRuntimeDriver
+        , public IQuantumGateSet
+        , public IDiagnostics
     {
         typedef void (*TSingleQubitGate)(unsigned /*simulator id*/, unsigned /*qubit id*/);
-        typedef void (*TSingleQubitControlledGate)(
-            unsigned /*simulator id*/,
-            unsigned /*number of controls*/,
-            unsigned* /*controls*/,
-            unsigned /*qubit id*/);
+        typedef void (*TSingleQubitControlledGate)(unsigned /*simulator id*/, unsigned /*number of controls*/,
+                                                   unsigned* /*controls*/, unsigned /*qubit id*/);
 
         // QuantumSimulator defines paulis as:
         // enum Basis
@@ -112,8 +113,11 @@ namespace Quantum
 
         const QUANTUM_SIMULATOR handle = nullptr;
 
-        using TSimulatorId = unsigned;      // TODO: Use `void*` or a fixed-size integer, starting in native simulator (breaking change).
-        static constexpr TSimulatorId NULL_SIMULATORID = UINT_MAX;  // Should be `= std::numeric_limits<TSimulatorId>::max()` but the Clang 12.0.0 complains.
+        using TSimulatorId = unsigned; // TODO: Use `void*` or a fixed-size integer,
+                                       // starting in native simulator (breaking change).
+        static constexpr TSimulatorId NULL_SIMULATORID = UINT_MAX;
+        // Should be `= std::numeric_limits<TSimulatorId>::max()` but the Clang 12.0.0 complains.
+
         TSimulatorId simulatorId = NULL_SIMULATORID;
 
         // the QuantumSimulator expects contiguous ids, starting from 0
@@ -161,21 +165,20 @@ namespace Quantum
         }
 
       public:
-        CFullstateSimulator(uint32_t userProvidedSeed = 0)
-            : handle(LoadQuantumSimulator())
+        CFullstateSimulator(uint32_t userProvidedSeed = 0) : handle(LoadQuantumSimulator())
         {
             typedef unsigned (*TInit)();
             static TInit initSimulatorInstance = reinterpret_cast<TInit>(this->GetProc("init"));
 
-            qubitManager = std::make_unique<CQubitManager>();
+            qubitManager      = std::make_unique<CQubitManager>();
             this->simulatorId = initSimulatorInstance();
 
             typedef void (*TSeed)(unsigned, unsigned);
             static TSeed setSimulatorSeed = reinterpret_cast<TSeed>(this->GetProc("seed"));
-            setSimulatorSeed(this->simulatorId, 
-                             (userProvidedSeed == 0) 
-                                ? (unsigned)std::chrono::system_clock::now().time_since_epoch().count()
-                                : (unsigned)userProvidedSeed);
+            setSimulatorSeed(this->simulatorId,
+                             (userProvidedSeed == 0)
+                                 ? (unsigned)std::chrono::system_clock::now().time_since_epoch().count()
+                                 : (unsigned)userProvidedSeed);
         }
         ~CFullstateSimulator() override
         {
@@ -214,9 +217,9 @@ namespace Quantum
             typedef void (*TAllocateQubit)(unsigned, unsigned);
             static TAllocateQubit allocateQubit = reinterpret_cast<TAllocateQubit>(this->GetProc("allocateQubit"));
 
-            Qubit q = qubitManager->Allocate(); // Allocate qubit in qubit manager.
-            unsigned id = GetQubitId(q); // Get its id.
-            allocateQubit(this->simulatorId, id); // Allocate it in the simulator.
+            Qubit q     = qubitManager->Allocate(); // Allocate qubit in qubit manager.
+            unsigned id = GetQubitId(q);            // Get its id.
+            allocateQubit(this->simulatorId, id);   // Allocate it in the simulator.
             return q;
         }
 
@@ -226,20 +229,22 @@ namespace Quantum
             static TReleaseQubit releaseQubit = reinterpret_cast<TReleaseQubit>(this->GetProc("release"));
 
             releaseQubit(this->simulatorId, GetQubitId(q)); // Release qubit in the simulator.
-            qubitManager->Release(q); // Release it in the qubit manager.
+            qubitManager->Release(q);                       // Release it in the qubit manager.
         }
 
         Result Measure(long numBases, PauliId bases[], long numTargets, Qubit targets[]) override
         {
             assert(numBases == numTargets);
             typedef unsigned (*TMeasure)(unsigned, unsigned, unsigned*, unsigned*);
-            static TMeasure m = reinterpret_cast<TMeasure>(this->GetProc("Measure"));
+            static TMeasure m         = reinterpret_cast<TMeasure>(this->GetProc("Measure"));
             std::vector<unsigned> ids = GetQubitIds(numTargets, targets);
             return reinterpret_cast<Result>(
                 m(this->simulatorId, (unsigned)numBases, reinterpret_cast<unsigned*>(bases), ids.data()));
         }
 
-        void ReleaseResult(Result /*r*/) override {}
+        void ReleaseResult(Result /*r*/) override
+        {
+        }
 
         ResultValue GetResultValue(Result r) override
         {
@@ -272,7 +277,7 @@ namespace Quantum
         void ControlledX(long numControls, Qubit controls[], Qubit target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCX"));
-            std::vector<unsigned> ids = GetQubitIds(numControls, controls);
+            std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
             op(this->simulatorId, (unsigned)numControls, ids.data(), GetQubitId(target));
         }
 
@@ -285,7 +290,7 @@ namespace Quantum
         void ControlledY(long numControls, Qubit controls[], Qubit target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCY"));
-            std::vector<unsigned> ids = GetQubitIds(numControls, controls);
+            std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
             op(this->simulatorId, (unsigned)numControls, ids.data(), GetQubitId(target));
         }
 
@@ -298,7 +303,7 @@ namespace Quantum
         void ControlledZ(long numControls, Qubit controls[], Qubit target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCZ"));
-            std::vector<unsigned> ids = GetQubitIds(numControls, controls);
+            std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
             op(this->simulatorId, (unsigned)numControls, ids.data(), GetQubitId(target));
         }
 
@@ -311,7 +316,7 @@ namespace Quantum
         void ControlledH(long numControls, Qubit controls[], Qubit target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCH"));
-            std::vector<unsigned> ids = GetQubitIds(numControls, controls);
+            std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
             op(this->simulatorId, (unsigned)numControls, ids.data(), GetQubitId(target));
         }
 
@@ -324,7 +329,7 @@ namespace Quantum
         void ControlledS(long numControls, Qubit controls[], Qubit target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCS"));
-            std::vector<unsigned> ids = GetQubitIds(numControls, controls);
+            std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
             op(this->simulatorId, (unsigned)numControls, ids.data(), GetQubitId(target));
         }
 
@@ -351,7 +356,7 @@ namespace Quantum
         void ControlledT(long numControls, Qubit controls[], Qubit target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCT"));
-            std::vector<unsigned> ids = GetQubitIds(numControls, controls);
+            std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
             op(this->simulatorId, (unsigned)numControls, ids.data(), GetQubitId(target));
         }
 
@@ -389,26 +394,20 @@ namespace Quantum
         void Exp(long numTargets, PauliId paulis[], Qubit targets[], double theta) override
         {
             typedef unsigned (*TExp)(unsigned, unsigned, unsigned*, double, unsigned*);
-            static TExp exp = reinterpret_cast<TExp>(this->GetProc("Exp"));
+            static TExp exp           = reinterpret_cast<TExp>(this->GetProc("Exp"));
             std::vector<unsigned> ids = GetQubitIds(numTargets, targets);
             exp(this->simulatorId, (unsigned)numTargets, reinterpret_cast<unsigned*>(paulis), theta, ids.data());
         }
 
-        void ControlledExp(
-            long numControls,
-            Qubit controls[],
-            long numTargets,
-            PauliId paulis[],
-            Qubit targets[],
-            double theta) override
+        void ControlledExp(long numControls, Qubit controls[], long numTargets, PauliId paulis[], Qubit targets[],
+                           double theta) override
         {
             typedef unsigned (*TMCExp)(unsigned, unsigned, unsigned*, double, unsigned, unsigned*, unsigned*);
-            static TMCExp cexp = reinterpret_cast<TMCExp>(this->GetProc("MCExp"));
-            std::vector<unsigned> idsTargets = GetQubitIds(numTargets, targets);
+            static TMCExp cexp                = reinterpret_cast<TMCExp>(this->GetProc("MCExp"));
+            std::vector<unsigned> idsTargets  = GetQubitIds(numTargets, targets);
             std::vector<unsigned> idsControls = GetQubitIds(numControls, controls);
-            cexp(
-                this->simulatorId, (unsigned)numTargets, reinterpret_cast<unsigned*>(paulis), theta, (unsigned)numControls,
-                idsControls.data(), idsTargets.data());
+            cexp(this->simulatorId, (unsigned)numTargets, reinterpret_cast<unsigned*>(paulis), theta,
+                 (unsigned)numControls, idsControls.data(), idsTargets.data());
         }
 
         bool Assert(long numTargets, PauliId* bases, Qubit* targets, Result result, const char* failureMessage) override
@@ -417,21 +416,15 @@ namespace Quantum
             return AssertProbability(numTargets, bases, targets, probabilityOfZero, 1e-10, failureMessage);
         }
 
-        bool AssertProbability(
-            long numTargets,
-            PauliId bases[],
-            Qubit targets[],
-            double probabilityOfZero,
-            double precision,
-            const char* /*failureMessage*/) override
+        bool AssertProbability(long numTargets, PauliId bases[], Qubit targets[], double probabilityOfZero,
+                               double precision, const char* /*failureMessage*/) override
         {
             typedef double (*TOp)(unsigned id, unsigned n, int* b, unsigned* q);
             static TOp jointEnsembleProbability = reinterpret_cast<TOp>(this->GetProc("JointEnsembleProbability"));
 
             std::vector<unsigned> ids = GetQubitIds(numTargets, targets);
-            double actualProbability =
-                1.0 -
-                jointEnsembleProbability(this->simulatorId, (unsigned)numTargets, reinterpret_cast<int*>(bases), ids.data());
+            double actualProbability  = 1.0 - jointEnsembleProbability(this->simulatorId, (unsigned)numTargets,
+                                                                      reinterpret_cast<int*>(bases), ids.data());
 
             return (std::abs(actualProbability - probabilityOfZero) < precision);
         }
@@ -444,16 +437,16 @@ namespace Quantum
         bool GetRegisterTo(TDumpLocation location, TDumpToLocationCallback callback, const QirArray* qubits);
 
       private:
-        TDumpToLocationCallback const dumpToLocationCallback = [](size_t idx, double re, double im, TDumpLocation location) -> bool
-            {
-                std::ostream& outStream = *reinterpret_cast<std::ostream*>(location);
+        TDumpToLocationCallback const dumpToLocationCallback = [](size_t idx, double re, double im,
+                                                                  TDumpLocation location) -> bool {
+            std::ostream& outStream = *reinterpret_cast<std::ostream*>(location);
 
-                if (!Close(re, 0.0) || !Close(im, 0.0))
-                {
-                    outStream << "|" << std::bitset<8>(idx) << ">: " << re << "+" << im << "i" << std::endl;
-                }
-                return true;
-            };
+            if (!Close(re, 0.0) || !Close(im, 0.0))
+            {
+                outStream << "|" << std::bitset<8>(idx) << ">: " << re << "+" << im << "i" << std::endl;
+            }
+            return true;
+        };
     }; // class CFullstateSimulator
 
     void CFullstateSimulator::DumpMachineImpl(std::ostream& outStream)
@@ -466,9 +459,9 @@ namespace Quantum
     void CFullstateSimulator::DumpRegisterImpl(std::ostream& outStream, const QirArray* qubits)
     {
         outStream << "# wave function for qubits with ids (least to most significant): ";
-        for(QirArray::TItemCount idx = 0; idx < qubits->count; ++idx)
+        for (QirArray::TItemCount idx = 0; idx < qubits->count; ++idx)
         {
-            if(idx != 0)
+            if (idx != 0)
             {
                 outStream << "; ";
             }
@@ -476,56 +469,54 @@ namespace Quantum
         }
         outStream << ':' << std::endl;
 
-        if(!this->GetRegisterTo((TDumpLocation)&outStream, dumpToLocationCallback, qubits))
+        if (!this->GetRegisterTo((TDumpLocation)&outStream, dumpToLocationCallback, qubits))
         {
-            outStream << "## Qubits were entangled with an external qubit. Cannot dump corresponding wave function. ##" << std::endl;
+            outStream << "## Qubits were entangled with an external qubit. Cannot dump corresponding wave function. ##"
+                      << std::endl;
         }
         outStream.flush();
     }
 
-    bool CFullstateSimulator::GetRegisterTo(TDumpLocation location, TDumpToLocationCallback callback, const QirArray* qubits)
+    bool CFullstateSimulator::GetRegisterTo(TDumpLocation location, TDumpToLocationCallback callback,
+                                            const QirArray* qubits)
     {
-        std::vector<unsigned> ids = GetQubitIds((long)(qubits->count), reinterpret_cast<Qubit*>(qubits->GetItemPointer(0)));
-
+        std::vector<unsigned> ids =
+            GetQubitIds((long)(qubits->count), reinterpret_cast<Qubit*>(qubits->GetItemPointer(0)));
         static TDumpQubitsToLocationAPI dumpQubitsToLocation =
             reinterpret_cast<TDumpQubitsToLocationAPI>(this->GetProc("DumpQubitsToLocation"));
-        return dumpQubitsToLocation(
-            this->simulatorId, (unsigned)(qubits->count), ids.data(), callback,
-            location);
+        return dumpQubitsToLocation(this->simulatorId, (unsigned)(qubits->count), ids.data(), callback, location);
     }
 
     void CFullstateSimulator::GetStateTo(TDumpLocation location, TDumpToLocationCallback callback)
     {
         static TDumpToLocationAPI dumpTo = reinterpret_cast<TDumpToLocationAPI>(this->GetProc("DumpToLocation"));
-        
+
         dumpTo(this->simulatorId, callback, location);
     }
 
     std::ostream& CFullstateSimulator::GetOutStream(const void* location, std::ofstream& outFileStream)
     {
         // If the location is not nullptr and not empty string then dump to a file:
-        if((location != nullptr) &&
-            (((static_cast<const QirString *>(location))->str) != ""))
+        if ((location != nullptr) && (((static_cast<const QirString*>(location))->str) != ""))
         {
             // Open the file for appending:
-            const std::string& filePath = (static_cast<const QirString *>(location))->str;
+            const std::string& filePath = (static_cast<const QirString*>(location))->str;
 
             bool openException = false;
             try
             {
                 outFileStream.open(filePath, std::ofstream::out | std::ofstream::app);
             }
-            catch(const std::ofstream::failure& e)
+            catch (const std::ofstream::failure& e)
             {
                 openException = true;
                 std::cerr << "Exception caught: \"" << e.what() << "\".\n";
             }
-            
-            if(   ((outFileStream.rdstate() & std::ofstream::failbit) != 0)
-               || openException)
+
+            if (((outFileStream.rdstate() & std::ofstream::failbit) != 0) || openException)
             {
                 std::cerr << "Failed to open dump file \"" + filePath + "\".\n";
-                return OutputStream::Get();     // Dump to std::cout.
+                return OutputStream::Get(); // Dump to std::cout.
             }
 
             return outFileStream;

--- a/src/Qir/Runtime/lib/Simulators/ToffoliSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/ToffoliSimulator.cpp
@@ -18,9 +18,12 @@ namespace Quantum
         CToffoliSimulator
         Simulator for reversible classical logic.
     ==============================================================================*/
-    class CToffoliSimulator final : public IRuntimeDriver, public IQuantumGateSet, public IDiagnostics
+    class CToffoliSimulator final
+        : public IRuntimeDriver
+        , public IQuantumGateSet
+        , public IDiagnostics
     {
-        using QubitId = uint64_t;
+        using QubitId       = uint64_t;
         QubitId nextQubitId = 0;
 
         // State of a qubit is represented by a bit in states indexed by qubit's id,
@@ -30,7 +33,7 @@ namespace Quantum
         // The clients should never attempt to derefenece the Result, so we'll use fake
         // pointers to avoid allocation and deallocation.
         Result zero = reinterpret_cast<Result>(0xface0000);
-        Result one = reinterpret_cast<Result>(0xface1000);
+        Result one  = reinterpret_cast<Result>(0xface1000);
 
         static uint64_t GetQubitId(Qubit qubit)
         {
@@ -38,13 +41,15 @@ namespace Quantum
         }
 
       public:
-        CToffoliSimulator() = default;
+        CToffoliSimulator()           = default;
         ~CToffoliSimulator() override = default;
 
         ///
         /// Implementation of IRuntimeDriver
         ///
-        void ReleaseResult(Result /* result */) override {}
+        void ReleaseResult(Result /* result */) override
+        {
+        }
 
         bool AreEqualResults(Result r1, Result r2) override
         {
@@ -69,7 +74,7 @@ namespace Quantum
         {
             Qubit retVal = (Qubit)(uintptr_t)(this->nextQubitId);
             ++(this->nextQubitId);
-            assert(this->nextQubitId < std::numeric_limits<QubitId>::max());    // Check aginast the risk of overflow.
+            assert(this->nextQubitId < std::numeric_limits<QubitId>::max()); // Check aginast the risk of overflow.
             this->states.emplace_back(false);
             return retVal;
         }
@@ -92,20 +97,16 @@ namespace Quantum
         ///
         /// Implementation of IDiagnostics
         ///
-        bool Assert(long numTargets, PauliId* bases, Qubit* targets, Result result, const char* /* failureMessage */) override
+        bool Assert(long numTargets, PauliId* bases, Qubit* targets, Result result,
+                    const char* /* failureMessage */) override
         {
             // Measurements in Toffoli simulator don't change the state.
             // TODO: log failureMessage?
             return AreEqualResults(result, Measure(numTargets, bases, numTargets, targets));
         }
 
-        bool AssertProbability(
-            long numTargets,
-            PauliId bases[],
-            Qubit targets[],
-            double probabilityOfZero,
-            double precision,
-            const char* /* failureMessage */) override
+        bool AssertProbability(long numTargets, PauliId bases[], Qubit targets[], double probabilityOfZero,
+                               double precision, const char* /* failureMessage */) override
         {
             assert(precision >= 0);
 
@@ -122,12 +123,12 @@ namespace Quantum
 
         void DumpMachine(const void* /* location */) override
         {
-            std::cerr << __func__ << " is not yet implemented" << std::endl;    // #645
+            std::cerr << __func__ << " is not yet implemented" << std::endl; // #645
         }
 
         void DumpRegister(const void* /* location */, const QirArray* /* qubits */) override
         {
-            std::cerr << __func__ << " is not yet implemented" << std::endl;    // #645
+            std::cerr << __func__ << " is not yet implemented" << std::endl; // #645
         }
 
 
@@ -227,17 +228,13 @@ namespace Quantum
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledR(long /*numControls*/, Qubit* /*controls*/, PauliId /*axis*/, Qubit /*target*/, double /*theta*/) override
+        void ControlledR(long /*numControls*/, Qubit* /*controls*/, PauliId /*axis*/, Qubit /*target*/,
+                         double /*theta*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledExp(
-            long /*numControls*/,
-            Qubit* /*controls*/,
-            long /*numTargets*/,
-            PauliId* /*paulis*/,
-            Qubit* /*targets*/,
-            double /* theta */) override
+        void ControlledExp(long /*numControls*/, Qubit* /*controls*/, long /*numTargets*/, PauliId* /*paulis*/,
+                           Qubit* /*targets*/, double /* theta */) override
         {
             throw std::logic_error("operation_not_supported");
         }

--- a/src/Qir/Runtime/lib/Tracer/TracerInternal.hpp
+++ b/src/Qir/Runtime/lib/Tracer/TracerInternal.hpp
@@ -15,4 +15,4 @@ namespace Quantum
 } // namespace Quantum
 } // namespace Microsoft
 
-#endif  // #ifndef TRACERINTERNAL_HPP
+#endif // #ifndef TRACERINTERNAL_HPP

--- a/src/Qir/Runtime/lib/Tracer/tracer-qis.cpp
+++ b/src/Qir/Runtime/lib/Tracer/tracer-qis.cpp
@@ -30,18 +30,18 @@ extern "C"
     }
     void quantum__qis__single_qubit_op_ctl(int32_t id, int32_t duration, QirArray* ctls, Qubit target) // NOLINT
     {
-        (void)tracer->TraceMultiQubitOp(id, duration, (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), 1, &target);
+        (void)tracer->TraceMultiQubitOp(id, duration, (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), 1,
+                                        &target);
     }
     void quantum__qis__multi_qubit_op(int32_t id, int32_t duration, QirArray* targets) // NOLINT
     {
-        (void)tracer->TraceMultiQubitOp(
-            id, duration, 0, nullptr, (long)(targets->count), reinterpret_cast<Qubit*>(targets->buffer));
+        (void)tracer->TraceMultiQubitOp(id, duration, 0, nullptr, (long)(targets->count),
+                                        reinterpret_cast<Qubit*>(targets->buffer));
     }
     void quantum__qis__multi_qubit_op_ctl(int32_t id, int32_t duration, QirArray* ctls, QirArray* targets) // NOLINT
     {
-        (void)tracer->TraceMultiQubitOp(
-            id, duration, (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), (long)(targets->count),
-            reinterpret_cast<Qubit*>(targets->buffer));
+        (void)tracer->TraceMultiQubitOp(id, duration, (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer),
+                                        (long)(targets->count), reinterpret_cast<Qubit*>(targets->buffer));
     }
 
     void quantum__qis__inject_barrier(int32_t id, int32_t duration) // NOLINT
@@ -56,18 +56,15 @@ extern "C"
 
     RESULT* quantum__qis__joint_measure(int32_t id, int32_t duration, QirArray* qs) // NOLINT
     {
-        return tracer->TraceMultiQubitMeasurement(id, duration, (long)(qs->count), reinterpret_cast<Qubit*>(qs->buffer));
+        return tracer->TraceMultiQubitMeasurement(id, duration, (long)(qs->count),
+                                                  reinterpret_cast<Qubit*>(qs->buffer));
     }
 
     void quantum__qis__apply_conditionally( // NOLINT
-        QirArray* rs1,
-        QirArray* rs2,
-        QirCallable* clbOnAllEqual,
-        QirCallable* clbOnSomeDifferent)
+        QirArray* rs1, QirArray* rs2, QirCallable* clbOnAllEqual, QirCallable* clbOnSomeDifferent)
     {
-        CTracer::FenceScope sf(
-            tracer.get(), (long)(rs1->count), reinterpret_cast<Result*>(rs1->buffer), (long)(rs2->count),
-            reinterpret_cast<Result*>(rs2->buffer));
+        CTracer::FenceScope sf(tracer.get(), (long)(rs1->count), reinterpret_cast<Result*>(rs1->buffer),
+                               (long)(rs2->count), reinterpret_cast<Result*>(rs2->buffer));
 
         clbOnAllEqual->Invoke();
         clbOnSomeDifferent->Invoke();

--- a/src/Qir/Runtime/lib/Tracer/tracer-qis.hpp
+++ b/src/Qir/Runtime/lib/Tracer/tracer-qis.hpp
@@ -10,23 +10,20 @@
 extern "C"
 {
     void quantum__qis__on_operation_start(int64_t /* id */); // NOLINT
-    void quantum__qis__on_operation_end(int64_t /* id */); // NOLINT
-    void quantum__qis__swap(Qubit /*q1*/, Qubit /*q2*/); // NOLINT
+    void quantum__qis__on_operation_end(int64_t /* id */);   // NOLINT
+    void quantum__qis__swap(Qubit /*q1*/, Qubit /*q2*/);     // NOLINT
 
-    void quantum__qis__single_qubit_op(int32_t id, int32_t duration, Qubit target); // NOLINT
-    void quantum__qis__single_qubit_op_ctl(int32_t id, int32_t duration, QirArray* ctls, Qubit target); // NOLINT
-    void quantum__qis__multi_qubit_op(int32_t id, int32_t duration, QirArray* targets); // NOLINT
+    void quantum__qis__single_qubit_op(int32_t id, int32_t duration, Qubit target);                         // NOLINT
+    void quantum__qis__single_qubit_op_ctl(int32_t id, int32_t duration, QirArray* ctls, Qubit target);     // NOLINT
+    void quantum__qis__multi_qubit_op(int32_t id, int32_t duration, QirArray* targets);                     // NOLINT
     void quantum__qis__multi_qubit_op_ctl(int32_t id, int32_t duration, QirArray* ctls, QirArray* targets); // NOLINT
 
-    void quantum__qis__inject_barrier(int32_t id, int32_t duration); // NOLINT
+    void quantum__qis__inject_barrier(int32_t id, int32_t duration);                    // NOLINT
     RESULT* quantum__qis__single_qubit_measure(int32_t id, int32_t duration, QUBIT* q); // NOLINT
 
     RESULT* quantum__qis__joint_measure(int32_t id, int32_t duration, QirArray* qs); // NOLINT
 
     void quantum__qis__apply_conditionally( // NOLINT
-        QirArray* rs1,
-        QirArray* rs2,
-        QirCallable* clbOnAllEqual,
-        QirCallable* clbOnSomeDifferent);
+        QirArray* rs1, QirArray* rs2, QirCallable* clbOnAllEqual, QirCallable* clbOnSomeDifferent);
 
 } // extern "C"

--- a/src/Qir/Runtime/lib/Tracer/tracer.cpp
+++ b/src/Qir/Runtime/lib/Tracer/tracer.cpp
@@ -19,9 +19,8 @@ namespace Quantum
         tracer = std::make_shared<CTracer>(preferredLayerDuration);
         return tracer;
     }
-    std::shared_ptr<CTracer> CreateTracer(
-        int preferredLayerDuration,
-        const std::unordered_map<OpId, std::string>& opNames)
+    std::shared_ptr<CTracer> CreateTracer(int preferredLayerDuration,
+                                          const std::unordered_map<OpId, std::string>& opNames)
     {
         tracer = std::make_shared<CTracer>(preferredLayerDuration, opNames);
         return tracer;
@@ -53,7 +52,7 @@ namespace Quantum
     // TODO: what would be meaningful information we could printout for a qubit?
     std::string CTracer::QubitToString(Qubit q)
     {
-        size_t qubitIndex = reinterpret_cast<size_t>(q);
+        size_t qubitIndex        = reinterpret_cast<size_t>(q);
         const QubitState& qstate = this->UseQubit(q);
 
         std::stringstream str(std::to_string(qubitIndex));
@@ -89,7 +88,7 @@ namespace Quantum
         if (!this->metricsByLayer.empty())
         {
             const Layer& lastLayer = this->metricsByLayer.back();
-            layerStartTime = lastLayer.startTime + lastLayer.duration;
+            layerStartTime         = lastLayer.startTime + lastLayer.duration;
         }
         this->metricsByLayer.emplace_back(
             Layer{layerStartTime, std::max(this->preferredLayerDuration, minRequiredDuration)});
@@ -126,7 +125,7 @@ namespace Quantum
         {
             // Find the earliest layer that the operation fits in by duration
             const Layer& candidateLayer = this->metricsByLayer[(size_t)candidate];
-            const Time lastUsedTime = std::max(qstate.lastUsedTime, candidateLayer.startTime);
+            const Time lastUsedTime     = std::max(qstate.lastUsedTime, candidateLayer.startTime);
             if (lastUsedTime + opDuration <= candidateLayer.startTime + candidateLayer.duration)
             {
                 layerToInsertInto = candidate;
@@ -170,9 +169,9 @@ namespace Quantum
         }
 
         // Update the qubit state.
-        qstate.layer = layer;
+        qstate.layer          = layer;
         const Time layerStart = this->metricsByLayer[(size_t)layer].startTime;
-        qstate.lastUsedTime = std::max(layerStart, qstate.lastUsedTime) + opDuration;
+        qstate.lastUsedTime   = std::max(layerStart, qstate.lastUsedTime) + opDuration;
         qstate.pendingZeroDurationOps.clear();
     }
 
@@ -183,7 +182,7 @@ namespace Quantum
     {
         this->seenOps.insert(id);
 
-        QubitState& qstate = this->UseQubit(target);
+        QubitState& qstate    = this->UseQubit(target);
         const LayerId barrier = this->GetEffectiveFence();
         if (opDuration == 0 && (qstate.layer == INVALID || (barrier != INVALID && qstate.layer < barrier)))
         {
@@ -208,13 +207,8 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer::TraceMultiQubitOp
     //------------------------------------------------------------------------------------------------------------------
-    LayerId CTracer::TraceMultiQubitOp(
-        OpId id,
-        Duration opDuration,
-        long nFirstGroup,
-        Qubit* firstGroup,
-        long nSecondGroup,
-        Qubit* secondGroup)
+    LayerId CTracer::TraceMultiQubitOp(OpId id, Duration opDuration, long nFirstGroup, Qubit* firstGroup,
+                                       long nSecondGroup, Qubit* secondGroup)
     {
         assert(nFirstGroup >= 0);
         assert(nSecondGroup > 0);
@@ -238,7 +232,8 @@ namespace Quantum
         }
         for (long i = 0; i < nFirstGroup && layerToInsertInto != REQUESTNEW; i++)
         {
-            layerToInsertInto = std::max(layerToInsertInto, this->FindLayerToInsertOperationInto(firstGroup[i], opDuration));
+            layerToInsertInto =
+                std::max(layerToInsertInto, this->FindLayerToInsertOperationInto(firstGroup[i], opDuration));
         }
         if (layerToInsertInto == REQUESTNEW)
         {
@@ -266,9 +261,9 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     LayerId CTracer::InjectGlobalBarrier(OpId id, Duration duration)
     {
-        LayerId layer = this->CreateNewLayer(duration);
+        LayerId layer                                 = this->CreateNewLayer(duration);
         this->metricsByLayer[(size_t)layer].barrierId = id;
-        this->globalBarrier = layer;
+        this->globalBarrier                           = layer;
         return layer;
     }
 
@@ -299,7 +294,7 @@ namespace Quantum
         for (long i = 0; i < count; i++)
         {
             const LayerId id = this->GetLayerIdOfSourceMeasurement(results[i]);
-            latest = CTracer::LaterLayerOf(latest, id);
+            latest           = CTracer::LaterLayerOf(latest, id);
         }
         return latest;
     }
@@ -307,8 +302,7 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer::FenceScope
     //------------------------------------------------------------------------------------------------------------------
-    CTracer::FenceScope::FenceScope(CTracer* trc, long count1, Result* rs1, long count2, Result* rs2)
-        : tracer(trc)
+    CTracer::FenceScope::FenceScope(CTracer* trc, long count1, Result* rs1, long count2, Result* rs2) : tracer(trc)
     {
         const LayerId fence1 =
             (rs1 != nullptr && count1 > 0) ? this->tracer->FindLatestMeasurementLayer(count1, rs1) : INVALID;

--- a/src/Qir/Runtime/lib/Tracer/tracer.hpp
+++ b/src/Qir/Runtime/lib/Tracer/tracer.hpp
@@ -34,8 +34,10 @@ namespace Quantum
         OpId barrierId = -1;
 
         Layer(Time startTm, Duration dur)
+            // clang-format off
             : startTime(startTm)
             , duration(dur)
+        // clang-format on
         {
         }
     };
@@ -130,7 +132,9 @@ namespace Quantum
         static LayerId LaterLayerOf(LayerId l1, LayerId l2);
 
         explicit CTracer(int preferredLayerDur)
+            // clang-format off
             : preferredLayerDuration(preferredLayerDur)
+        // clang-format on
         {
         }
 
@@ -168,13 +172,8 @@ namespace Quantum
         // where the first one can be empty or can be viewed as the set of controls.
         // -------------------------------------------------------------------------------------------------------------
         LayerId TraceSingleQubitOp(OpId id, Duration duration, Qubit target);
-        LayerId TraceMultiQubitOp(
-            OpId id,
-            Duration duration,
-            long nFirstGroup,
-            Qubit* firstGroup,
-            long nSecondGroup,
-            Qubit* secondGroup);
+        LayerId TraceMultiQubitOp(OpId id, Duration duration, long nFirstGroup, Qubit* firstGroup, long nSecondGroup,
+                                  Qubit* secondGroup);
 
         Result TraceSingleQubitMeasurement(OpId id, Duration duration, Qubit target);
         Result TraceMultiQubitMeasurement(OpId id, Duration duration, long nTargets, Qubit* targets);
@@ -191,7 +190,7 @@ namespace Quantum
         struct FenceScope
         {
             CTracer* tracer = nullptr;
-            LayerId fence = INVALID;
+            LayerId fence   = INVALID;
             explicit FenceScope(CTracer* tracer, long count1, Result* results1, long count2, Result* results2);
             ~FenceScope();
         };
@@ -210,9 +209,8 @@ namespace Quantum
     };
 
     QIR_SHARED_API std::shared_ptr<CTracer> CreateTracer(int preferredLayerDuration);
-    QIR_SHARED_API std::shared_ptr<CTracer> CreateTracer(
-        int preferredLayerDuration,
-        const std::unordered_map<OpId, std::string>& opNames);
+    QIR_SHARED_API std::shared_ptr<CTracer> CreateTracer(int preferredLayerDuration,
+                                                         const std::unordered_map<OpId, std::string>& opNames);
 
 } // namespace Quantum
 } // namespace Microsoft

--- a/src/Qir/Runtime/public/CoreTypes.hpp
+++ b/src/Qir/Runtime/public/CoreTypes.hpp
@@ -26,12 +26,13 @@
   dereferenced in client's code.
 ==============================================================================*/
 class QUBIT;
-typedef QUBIT* Qubit;   
-// TODO: 
+typedef QUBIT* Qubit;
+// TODO:
 // Replace `typedef QUBIT* Qubit` with `typedef uint64_t QubitId`. Remove all the `GetQubitId()`, `QUBIT`.
 
 class RESULT;
-typedef RESULT* Result; // TODO: Replace with `typedef uintXX_t Result`, where XX is 8|16|32|64. Remove all the `RESULT`.
+typedef RESULT* Result; // TODO: Replace with `typedef uintXX_t Result`, where XX is 8|16|32|64.
+                        //       Remove all the `RESULT`.
 
 enum ResultValue
 {

--- a/src/Qir/Runtime/public/OutputStream.hpp
+++ b/src/Qir/Runtime/public/OutputStream.hpp
@@ -5,9 +5,9 @@
 #define OUTPUTSTREAM_HPP
 
 #include <ostream>
-#include "CoreTypes.hpp"      // QIR_SHARED_API
+#include "CoreTypes.hpp" // QIR_SHARED_API
 
-namespace Microsoft           // Replace with `namespace Microsoft::Quantum` after migration to C++17.
+namespace Microsoft // Replace with `namespace Microsoft::Quantum` after migration to C++17.
 {
 namespace Quantum
 {
@@ -23,13 +23,13 @@ namespace Quantum
         };
 
         static std::ostream& Get();
-        static std::ostream& Set(std::ostream & newOStream);
+        static std::ostream& Set(std::ostream& newOStream);
 
       private:
         static std::ostream* currentOutputStream;
     };
 
-} // namespace Microsoft
 } // namespace Quantum
+} // namespace Microsoft
 
 #endif // #ifndef OUTPUTSTREAM_HPP

--- a/src/Qir/Runtime/public/QirContext.hpp
+++ b/src/Qir/Runtime/public/QirContext.hpp
@@ -21,7 +21,7 @@ namespace Quantum
 
     struct QIR_SHARED_API QirExecutionContext
     {
-        // Direct access from outside of `QirExecutionContext` is deprecated: The variables are to become `private`. 
+        // Direct access from outside of `QirExecutionContext` is deprecated: The variables are to become `private`.
         // {
         // Use `Microsoft::Quantum::GlobalContext()->GetDriver()` instead:
         IRuntimeDriver* driver = nullptr;
@@ -46,13 +46,14 @@ namespace Quantum
         {
             Scoped(IRuntimeDriver* driver, bool trackAllocatedObjects = false);
             ~Scoped();
+
           private:
             Scoped& operator=(const Scoped&) = delete;
         };
     };
-    
+
     // Direct access is deprecated, use GlobalContext() instead.
-    extern std::unique_ptr<QirExecutionContext> g_context;  
+    extern std::unique_ptr<QirExecutionContext> g_context;
     extern QIR_SHARED_API std::unique_ptr<QirExecutionContext>& GlobalContext();
 
     // Deprecated, use `QirExecutionContext::Scoped` instead.
@@ -60,6 +61,7 @@ namespace Quantum
     {
         QirContextScope(IRuntimeDriver* driver, bool trackAllocatedObjects = false);
         ~QirContextScope();
+
       private:
         QirContextScope& operator=(const QirContextScope&) = delete;
     };

--- a/src/Qir/Runtime/public/QirRuntime.hpp
+++ b/src/Qir/Runtime/public/QirRuntime.hpp
@@ -53,7 +53,7 @@ extern "C"
     QIR_SHARED_API char* quantum__rt__memory_allocate(uint64_t size); // NOLINT
 
     // Fail the computation with the given error message.
-    [[noreturn]] QIR_SHARED_API void quantum__rt__fail(QirString* msg); // NOLINT
+    [[noreturn]] QIR_SHARED_API void quantum__rt__fail(QirString* msg);       // NOLINT
     [[noreturn]] QIR_SHARED_API void quantum__rt__fail_cstr(const char* msg); // NOLINT
 
     // Include the given message in the computation's execution log or equivalent.
@@ -70,7 +70,7 @@ extern "C"
     // becomes 0. The behavior is undefined if the reference count becomes negative.
     QIR_SHARED_API void quantum__rt__result_update_reference_count(RESULT*, int32_t); // NOLINT
 
-    QIR_SHARED_API RESULT* quantum__rt__result_get_one(); // NOLINT
+    QIR_SHARED_API RESULT* quantum__rt__result_get_one();  // NOLINT
     QIR_SHARED_API RESULT* quantum__rt__result_get_zero(); // NOLINT
 
     // ------------------------------------------------------------------------
@@ -123,9 +123,7 @@ extern "C"
     // new array should be set to zero.
     QIR_SHARED_API QirArray* quantum__rt__array_create(int, int, ...); // NOLINT
     QIR_SHARED_API QirArray* quantum__rt__array_create_nonvariadic(    // NOLINT
-        int itemSizeInBytes,
-        int countDimensions,
-        va_list dims);
+        int itemSizeInBytes, int countDimensions, va_list dims);
 
     // Returns the number of dimensions in the array.
     QIR_SHARED_API int32_t quantum__rt__array_get_dim(QirArray*); // NOLINT
@@ -217,13 +215,13 @@ extern "C"
     // Returns a string representation of the range.
     QIR_SHARED_API QirString* quantum__rt__range_to_string(const QirRange&); // NOLINT
 
-    // Returns a pointer to an array that contains a null-terminated sequence of characters 
+    // Returns a pointer to an array that contains a null-terminated sequence of characters
     // (i.e., a C-string) representing the current value of the string object.
     QIR_SHARED_API const char* quantum__rt__string_get_data(QirString* str); // NOLINT
 
     // Returns the length of the string, in terms of bytes.
     // http://www.cplusplus.com/reference/string/string/size/
-    QIR_SHARED_API uint32_t quantum__rt__string_get_length(QirString* str);  // NOLINT
+    QIR_SHARED_API uint32_t quantum__rt__string_get_length(QirString* str); // NOLINT
 
     // Returns a string representation of the big integer.
     // TODO QIR_SHARED_API QirString* quantum__rt__bigint_to_string(QirBigInt*); // NOLINT
@@ -293,12 +291,12 @@ extern "C"
 }
 
 // TODO: Consider separating the `extern "C"` exports and C++ exports.
-namespace Microsoft           // Replace with `namespace Microsoft::Quantum` after migration to C++17.
+namespace Microsoft // Replace with `namespace Microsoft::Quantum` after migration to C++17.
 {
 namespace Quantum
 {
-    // Deprecated, use `Microsoft::Quantum::OutputStream::ScopedRedirector` or `Microsoft::Quantum::OutputStream::Set()` instead.
-    QIR_SHARED_API std::ostream& SetOutputStream(std::ostream & newOStream);
-} // namespace Microsoft
+    // Deprecated, use `Microsoft::Quantum::OutputStream::ScopedRedirector` or `Microsoft::Quantum::OutputStream::Set()`
+    // instead.
+    QIR_SHARED_API std::ostream& SetOutputStream(std::ostream& newOStream);
 } // namespace Quantum
-
+} // namespace Microsoft

--- a/src/Qir/Runtime/public/QirTypes.hpp
+++ b/src/Qir/Runtime/public/QirTypes.hpp
@@ -15,16 +15,18 @@
 ======================================================================================================================*/
 struct QIR_SHARED_API QirArray
 {
-    using TItemCount    = uint32_t;     // Data type of number of items (potentially can be increased to `uint64_t`).
-    using TItemSize     = uint32_t;     // Data type of item size.
-    using TBufSize      = size_t;       // Size of the buffer pointed to by `buffer` (32 bit on 32-bit arch, 64 bit on 64-bit arch). 
-    using TDimCount     = uint8_t;      // Data type for number of dimensions (3 for 3D array).
-    using TDimContainer = std::vector<TItemCount>;  // Data type for container of dimensions (for array 2x3x5 3 items: 2, 3, 5).
+    using TItemCount = uint32_t;   // Data type of number of items (potentially can be increased to `uint64_t`).
+    using TItemSize  = uint32_t;   // Data type of item size.
+    using TBufSize   = size_t;     // Size of the buffer pointed to by `buffer`
+                                   // (32 bit on 32-bit arch, 64 bit on 64-bit arch).
+    using TDimCount     = uint8_t; // Data type for number of dimensions (3 for 3D array).
+    using TDimContainer = std::vector<TItemCount>; // Data type for container of dimensions
+                                                   // (for array 2x3x5 3 items: 2, 3, 5).
 
     // The product of all dimensions (2x3x5 = 30) should be equal to the overall number of items - `count`,
     // i.e. the product must fit in `TItemCount`. That is why `TItemCount` should be sufficient to store each dimension.
 
-    TItemCount count = 0; // Overall number of elements in the array across all dimensions
+    TItemCount count                = 0; // Overall number of elements in the array across all dimensions
     const TItemSize itemSizeInBytes = 0;
 
     const TDimCount dimensions = 1;
@@ -33,8 +35,8 @@ struct QIR_SHARED_API QirArray
     char* buffer = nullptr;
 
     bool ownsQubits = false;
-    int refCount = 1;
-    int aliasCount = 0; // used to enable copy elision, see the QIR specifications for details
+    int refCount    = 1;
+    int aliasCount  = 0; // used to enable copy elision, see the QIR specifications for details
 
     // NB: Release doesn't trigger destruction of the Array itself (only of its data buffer) to allow for it being used
     // both on the stack and on the heap. The creator of the array should delete it, if allocated from the heap.
@@ -72,13 +74,14 @@ struct QIR_SHARED_API QirString
 ======================================================================================================================*/
 // TODO: Move these types to inside of `QirTupleHeader`.
 using PTuplePointedType = uint8_t;
-using PTuple = PTuplePointedType*;  // TODO: consider replacing `uint8_t*` with `void*` in order to block the accidental {dereferencing and pointer arithmtic}.
-                                    //       Much pointer arithmetic in tests. GetHeader() uses the pointer arithmetic.
+using PTuple = PTuplePointedType*; // TODO: consider replacing `uint8_t*` with `void*` in order to block the accidental
+                                   //       {dereferencing and pointer arithmtic}.
+                                   //       Much pointer arithmetic in tests. GetHeader() uses the pointer arithmetic.
 struct QIR_SHARED_API QirTupleHeader
 {
-    using TBufSize = size_t;  // Type of the buffer size.
+    using TBufSize = size_t; // Type of the buffer size.
 
-    int     refCount = 0;
+    int refCount       = 0;
     int32_t aliasCount = 0; // used to enable copy elision, see the QIR specifications for details
     TBufSize tupleSize = 0; // when creating the tuple, must be set to the size of the tuple's data buffer (in bytes)
 
@@ -130,34 +133,32 @@ struct QIR_SHARED_API TupleWithControls
         return QirTupleHeader::GetHeader(this->AsTuple());
     }
 };
-static_assert(
-    sizeof(TupleWithControls) == 2 * sizeof(void*),
-    L"TupleWithControls must be tightly packed for FlattenControlArrays to be correct");
+static_assert(sizeof(TupleWithControls) == 2 * sizeof(void*),
+              L"TupleWithControls must be tightly packed for FlattenControlArrays to be correct");
 
 /*======================================================================================================================
     QirCallable
 ======================================================================================================================*/
-typedef void (*t_CallableEntry)(PTuple, PTuple, PTuple);    // TODO: Move to `QirCallable::t_CallableEntry`.
-typedef void (*t_CaptureCallback)(PTuple, int32_t);         // TODO: Move to `QirCallable::t_CaptureCallback`.
+typedef void (*t_CallableEntry)(PTuple, PTuple, PTuple); // TODO: Move to `QirCallable::t_CallableEntry`.
+typedef void (*t_CaptureCallback)(PTuple, int32_t);      // TODO: Move to `QirCallable::t_CaptureCallback`.
 struct QIR_SHARED_API QirCallable
 {
-    static int constexpr Adjoint = 1;
+    static int constexpr Adjoint    = 1;
     static int constexpr Controlled = 1 << 1;
 
   private:
     static int constexpr TableSize = 4;
-    static_assert(
-        QirCallable::Adjoint + QirCallable::Controlled < QirCallable::TableSize,
-        L"functor kind is used as index into the functionTable");
+    static_assert(QirCallable::Adjoint + QirCallable::Controlled < QirCallable::TableSize,
+                  L"functor kind is used as index into the functionTable");
 
-    int refCount = 1;
+    int refCount   = 1;
     int aliasCount = 0;
 
     // If the callable doesn't support Adjoint or Controlled functors, the corresponding entries in the table should be
     // set to nullptr.
     t_CallableEntry functionTable[QirCallable::TableSize] = {nullptr, nullptr, nullptr, nullptr};
 
-    static int constexpr CaptureCallbacksTableSize = 2;
+    static int constexpr CaptureCallbacksTableSize                             = 2;
     t_CaptureCallback captureCallbacks[QirCallable::CaptureCallbacksTableSize] = {nullptr, nullptr};
 
     // The callable stores the capture, it's given at creation, and passes it to the functions from the function table,
@@ -193,9 +194,9 @@ struct QIR_SHARED_API QirCallable
 
 struct QIR_SHARED_API QirRange
 {
-    int64_t start   = 0;
-    int64_t step    = 0;
-    int64_t end     = 0;
+    int64_t start = 0;
+    int64_t step  = 0;
+    int64_t end   = 0;
 
     QirRange(int64_t start, int64_t step, int64_t end);
 };

--- a/src/Qir/Runtime/public/QubitManager.hpp
+++ b/src/Qir/Runtime/public/QubitManager.hpp
@@ -55,7 +55,8 @@ namespace Quantum
         // Fail if the qubit cannot be allocated.
         // Computation complexity is O(number of nested restricted reuse areas) worst case, O(1) amortized cost.
         Qubit Allocate();
-        // Allocate qubitCountToAllocate qubits and store them in the provided array. Extend manager capacity if necessary and possible.
+        // Allocate qubitCountToAllocate qubits and store them in the provided array. 
+        // Extend manager capacity if necessary and possible.
         // Fail without allocating any qubits if the qubits cannot be allocated.
         // Caller is responsible for providing array of sufficient size to hold qubitCountToAllocate.
         void Allocate(Qubit* qubitsToAllocate, int32_t qubitCountToAllocate);
@@ -63,7 +64,8 @@ namespace Quantum
         // Releases a given qubit.
         void Release(Qubit qubit);
         // Releases qubitCountToRelease qubits in the provided array.
-        // Caller is responsible for managing memory used by the array itself (i.e. delete[] array if it was dynamically allocated).
+        // Caller is responsible for managing memory used by the array itself 
+        // (i.e. delete[] array if it was dynamically allocated).
         void Release(Qubit* qubitsToRelease, int32_t qubitCountToRelease);
 
         // Borrow (We treat borrowing as allocation currently)

--- a/src/Qir/Runtime/public/TracerTypes.hpp
+++ b/src/Qir/Runtime/public/TracerTypes.hpp
@@ -9,12 +9,12 @@ namespace Microsoft
 {
 namespace Quantum
 {
-    using OpId = int;
-    using Time = int;
+    using OpId     = int;
+    using Time     = int;
     using Duration = int;
-    using LayerId = int64_t;    // TODO: Use unsigned type.
+    using LayerId  = int64_t; // TODO: Use unsigned type.
 
-    constexpr LayerId INVALID = std::numeric_limits<LayerId>::min();
+    constexpr LayerId INVALID    = std::numeric_limits<LayerId>::min();
     constexpr LayerId REQUESTNEW = std::numeric_limits<LayerId>::max();
-}
-}
+} // namespace Quantum
+} // namespace Microsoft

--- a/src/Qir/Runtime/unittests/QirRuntimeTests.cpp
+++ b/src/Qir/Runtime/unittests/QirRuntimeTests.cpp
@@ -22,7 +22,7 @@ using namespace Microsoft::Quantum;
 struct ResultsReferenceCountingTestQAPI : public SimulatorStub
 {
     int lastId = -1;
-    const int maxResults;       // TODO: Use unsigned type.
+    const int maxResults; // TODO: Use unsigned type.
     std::vector<bool> allocated;
 
     static int GetResultId(Result r)
@@ -30,9 +30,7 @@ struct ResultsReferenceCountingTestQAPI : public SimulatorStub
         return static_cast<int>(reinterpret_cast<int64_t>(r));
     }
 
-    ResultsReferenceCountingTestQAPI(int maxRes)
-        : maxResults(maxRes),
-        allocated((size_t)maxRes, false)
+    ResultsReferenceCountingTestQAPI(int maxRes) : maxResults(maxRes), allocated((size_t)maxRes, false)
     {
     }
 
@@ -111,7 +109,7 @@ TEST_CASE("Arrays: one dimensional", "[qir_support]")
     REQUIRE(quantum__rt__array_get_dim(a) == 1);
     REQUIRE(quantum__rt__array_get_size(a, 0) == 5);
 
-    QirArray* b = new QirArray(1, sizeof(char));
+    QirArray* b                                  = new QirArray(1, sizeof(char));
     *quantum__rt__array_get_element_ptr_1d(b, 0) = '!';
 
     QirArray* ab = quantum__rt__array_concatenate(a, b);
@@ -127,7 +125,7 @@ TEST_CASE("Arrays: one dimensional", "[qir_support]")
 TEST_CASE("Arrays: multiple dimensions", "[qir_support]")
 {
     const size_t count = 5 * 3 * 4; // 60
-    QirArray* a = quantum__rt__array_create(sizeof(int), 3, (int64_t)5, (int64_t)3, (int64_t)4);
+    QirArray* a        = quantum__rt__array_create(sizeof(int), 3, (int64_t)5, (int64_t)3, (int64_t)4);
     REQUIRE(quantum__rt__array_get_dim(a) == 3);
     REQUIRE(quantum__rt__array_get_size(a, 0) == 5);
     REQUIRE(quantum__rt__array_get_size(a, 1) == 3);
@@ -215,15 +213,15 @@ TEST_CASE("Arrays: empty", "[qir_support]")
     quantum__rt__array_update_reference_count(a, -1);
     quantum__rt__array_update_reference_count(ac, -1);
     quantum__rt__array_update_reference_count(ca, -1);
-    quantum__rt__array_update_reference_count(c , -1);
+    quantum__rt__array_update_reference_count(c, -1);
 }
 
 TEST_CASE("Arrays: check the slice range", "[qir_support]")
 {
     const int64_t dim0 = 5;
     const int64_t dim1 = 6;
-    QirArray* a = quantum__rt__array_create(sizeof(int), 2, dim0, dim1);
-    QirArray* slice = nullptr;
+    QirArray* a        = quantum__rt__array_create(sizeof(int), 2, dim0, dim1);
+    QirArray* slice    = nullptr;
 
     // invalid range
     CHECK_THROWS(quantum__rt__array_slice(a, 0, {0, 0, 0}));
@@ -262,7 +260,7 @@ TEST_CASE("Arrays: check the slice range", "[qir_support]")
 TEST_CASE("Arrays: slice of 1D array", "[qir_support]")
 {
     const int64_t dim = 5;
-    QirArray* a = quantum__rt__array_create_1d(sizeof(char), dim);
+    QirArray* a       = quantum__rt__array_create_1d(sizeof(char), dim);
     memcpy(a->buffer, "01234", 5);
     QirArray* slice = nullptr;
 
@@ -293,20 +291,20 @@ TEST_CASE("Arrays: slice of 1D array", "[qir_support]")
 TEST_CASE("Arrays: reversed slice of 1D array", "[qir_support]")
 {
     const int64_t dim = 5;
-    QirArray* a = quantum__rt__array_create_1d(sizeof(char), dim);
+    QirArray* a       = quantum__rt__array_create_1d(sizeof(char), dim);
     memcpy(a->buffer, "01234", 5);
     QirArray* slice = nullptr;
 
     // even if slice results in a single value, it's still an array
-    slice = quantum__rt__array_slice(a, 0, {1, -dim, 0});   // Range{1, -dim, 0} == Range{1, -5, 0} == { 1 }.
-                                                            // slice == char[1] == { '1' }.
+    slice = quantum__rt__array_slice(a, 0, {1, -dim, 0}); // Range{1, -dim, 0} == Range{1, -5, 0} == { 1 }.
+                                                          // slice == char[1] == { '1' }.
     REQUIRE(quantum__rt__array_get_size(slice, 0) == 1);
     REQUIRE(*quantum__rt__array_get_element_ptr_1d(slice, 0) == '1');
-    quantum__rt__array_update_reference_count(slice, -1);   // slice == dangling pointer.
+    quantum__rt__array_update_reference_count(slice, -1); // slice == dangling pointer.
 
     // reversed slices are alwayes disconnected
-    slice = quantum__rt__array_slice(a, 0, {dim - 1, -2, 0});   // Range{dim - 1, -2, 0} == Range{4, -2, 0} == {4, 2, 0}.
-                                                                // slice == char[3] == {'4', '2', '0'}.
+    slice = quantum__rt__array_slice(a, 0, {dim - 1, -2, 0}); // Range{dim - 1, -2, 0} == Range{4, -2, 0} == {4, 2, 0}.
+                                                              // slice == char[3] == {'4', '2', '0'}.
     REQUIRE(quantum__rt__array_get_size(slice, 0) == 3);
     REQUIRE(*quantum__rt__array_get_element_ptr_1d(slice, 0) == '4');
     REQUIRE(*quantum__rt__array_get_element_ptr_1d(slice, 1) == '2');
@@ -323,7 +321,7 @@ TEST_CASE("Arrays: slice of 3D array", "[qir_support]")
     const int64_t dim1 = 3;
     const int64_t dim2 = 4;
 
-    QirArray* a = quantum__rt__array_create(sizeof(int), dims, dim0, dim1, dim2);
+    QirArray* a     = quantum__rt__array_create(sizeof(int), dims, dim0, dim1, dim2);
     QirArray* slice = nullptr;
 
     const size_t count = (size_t)(dim0 * dim1 * dim2); // 60
@@ -340,8 +338,8 @@ TEST_CASE("Arrays: slice of 3D array", "[qir_support]")
     // 400 401 402 403 | 410 411 412 413 | 420 421 422 423 -- [48 - 59]
     memcpy(a->buffer, reinterpret_cast<char*>(data.data()), count * sizeof(int));
     REQUIRE(*(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, 1, 0, 0))) == 12);
-    REQUIRE(
-        *(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, dim0 - 1, dim1 - 1, dim2 - 1))) == count - 1);
+    REQUIRE(*(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, dim0 - 1, dim1 - 1, dim2 - 1))) ==
+            count - 1);
 
     // if the range covers the whole dimension, it's effectively a copy
     slice = quantum__rt__array_slice(a, 1, {0, 1, dim1 - 1});
@@ -440,7 +438,7 @@ TEST_CASE("Arrays: reversed slice of 3D array", "[qir_support]")
     const int64_t dim1 = 3;
     const int64_t dim2 = 4;
 
-    QirArray* a = quantum__rt__array_create(sizeof(int), dims, dim0, dim1, dim2);
+    QirArray* a     = quantum__rt__array_create(sizeof(int), dims, dim0, dim1, dim2);
     QirArray* slice = nullptr;
 
     const size_t count = (size_t)(dim0 * dim1 * dim2); // 60
@@ -457,8 +455,8 @@ TEST_CASE("Arrays: reversed slice of 3D array", "[qir_support]")
     // 400 401 402 403 | 410 411 412 413 | 420 421 422 423 -- [48 - 59]
     memcpy(a->buffer, reinterpret_cast<char*>(data.data()), count * sizeof(int));
     REQUIRE(*(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, 1, 0, 0))) == 12);
-    REQUIRE(
-        *(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, dim0 - 1, dim1 - 1, dim2 - 1))) == count - 1);
+    REQUIRE(*(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, dim0 - 1, dim1 - 1, dim2 - 1))) ==
+            count - 1);
 
     // if the range consists of a single point, the slice still has the same dimensions
     slice = quantum__rt__array_slice(a, 1, {1, -dim1, 0}); // items with second index = 1
@@ -501,7 +499,7 @@ TEST_CASE("Arrays: reversed slice of 3D array", "[qir_support]")
     REQUIRE(*(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(slice, 1, 1, 0))) == 19);
     REQUIRE(*(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(slice, 4, 2, 1))) == 57);
     quantum__rt__array_update_reference_count(slice, -1);
-    quantum__rt__array_update_reference_count(a    , -1);
+    quantum__rt__array_update_reference_count(a, -1);
 }
 
 TEST_CASE("Arrays: project of 3D array", "[qir_support]")
@@ -511,7 +509,7 @@ TEST_CASE("Arrays: project of 3D array", "[qir_support]")
     const int64_t dim1 = 3;
     const int64_t dim2 = 4;
 
-    QirArray* a = quantum__rt__array_create(sizeof(int), dims, dim0, dim1, dim2);
+    QirArray* a       = quantum__rt__array_create(sizeof(int), dims, dim0, dim1, dim2);
     QirArray* project = nullptr;
 
     const size_t count = (size_t)(dim0 * dim1 * dim2); // 60
@@ -528,8 +526,8 @@ TEST_CASE("Arrays: project of 3D array", "[qir_support]")
     // 400 401 402 403 | 410 411 412 413 | 420 421 422 423 -- [48 - 59]
     memcpy(a->buffer, reinterpret_cast<char*>(data.data()), count * sizeof(int));
     REQUIRE(*(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, 1, 0, 0))) == 12);
-    REQUIRE(
-        *(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, dim0 - 1, dim1 - 1, dim2 - 1))) == count - 1);
+    REQUIRE(*(reinterpret_cast<int*>(quantum__rt__array_get_element_ptr(a, dim0 - 1, dim1 - 1, dim2 - 1))) ==
+            count - 1);
 
     // project on 0 dimension, expected result:
     // indexes                                 -- values
@@ -585,8 +583,8 @@ TEST_CASE("Strings: reuse", "[qir_support]")
 
 TEST_CASE("Strings: concatenate", "[qir_support]")
 {
-    QirString* a = quantum__rt__string_create("abc");
-    QirString* b = quantum__rt__string_create("xyz");
+    QirString* a          = quantum__rt__string_create("abc");
+    QirString* b          = quantum__rt__string_create("xyz");
     QirString* abExpected = quantum__rt__string_create("abcxyz");
 
     QirString* ab = quantum__rt__string_concatenate(a, b);
@@ -675,8 +673,8 @@ TEST_CASE("Strings: conversions from custom qir types", "[qir_support]")
 
 struct QubitTestQAPI : public SimulatorStub
 {
-    int lastId = -1;            // TODO: Use unsigned type.
-    const int maxQubits;        // TODO: Use unsigned type.
+    int lastId = -1;     // TODO: Use unsigned type.
+    const int maxQubits; // TODO: Use unsigned type.
     std::vector<bool> allocated;
 
     static uint64_t GetQubitId(Qubit q)
@@ -684,9 +682,7 @@ struct QubitTestQAPI : public SimulatorStub
         return (uint64_t)q;
     }
 
-    QubitTestQAPI(int maxQbits)
-        : maxQubits(maxQbits),
-        allocated((size_t)maxQbits, false)
+    QubitTestQAPI(int maxQbits) : maxQubits(maxQbits), allocated((size_t)maxQbits, false)
     {
     }
 
@@ -737,7 +733,7 @@ TEST_CASE("Qubits: allocate, release, dump", "[qir_support]")
     QirString* qstr = nullptr;
 
     Qubit q = quantum__rt__qubit_allocate();
-    qstr = quantum__rt__qubit_to_string(q);
+    qstr    = quantum__rt__qubit_to_string(q);
     REQUIRE(qstr->str == std::string("0"));
     quantum__rt__string_update_reference_count(qstr, -1);
     quantum__rt__qubit_release(q);
@@ -749,14 +745,14 @@ TEST_CASE("Qubits: allocate, release, dump", "[qir_support]")
     REQUIRE(qs->itemSizeInBytes == sizeof(void*));
 
     Qubit last = *reinterpret_cast<Qubit*>(quantum__rt__array_get_element_ptr_1d(qs, 2));
-    qstr = quantum__rt__qubit_to_string(last);
+    qstr       = quantum__rt__qubit_to_string(last);
     REQUIRE(qstr->str == std::string("3"));
     quantum__rt__string_update_reference_count(qstr, -1);
 
     QirArray* copy = quantum__rt__array_copy(qs, true /*force*/);
     REQUIRE(!copy->ownsQubits);
 
-    quantum__rt__qubit_release_array(qs);   // The `qs` is a dangling pointer from now on.
+    quantum__rt__qubit_release_array(qs); // The `qs` is a dangling pointer from now on.
     REQUIRE(!qapi->HaveQubitsInFlight());
 
     quantum__rt__array_update_reference_count(copy, -1);
@@ -770,7 +766,9 @@ struct ControlledCallablesTestSimulator : public SimulatorStub
     {
         return reinterpret_cast<Qubit>(++this->lastId);
     }
-    void ReleaseQubit(Qubit /*qubit*/) override {}
+    void ReleaseQubit(Qubit /*qubit*/) override
+    {
+    }
     Result UseZero() override
     {
         return reinterpret_cast<Result>(0);
@@ -785,22 +783,22 @@ TEST_CASE("Unpacking input tuples of nested callables (case2)", "[qir_support]")
     std::unique_ptr<ControlledCallablesTestSimulator> qapi = std::make_unique<ControlledCallablesTestSimulator>();
     QirExecutionContext::Scoped qirctx(qapi.get());
 
-    Qubit target = quantum__rt__qubit_allocate();
+    Qubit target            = quantum__rt__qubit_allocate();
     QirArray* controlsInner = quantum__rt__qubit_allocate_array(3);
     QirArray* controlsOuter = quantum__rt__qubit_allocate_array(2);
 
     PTuple inner = quantum__rt__tuple_create(sizeof(/* QirArray* */ void*) + sizeof(/*Qubit*/ void*));
     TupleWithControls* innerWithControls = TupleWithControls::FromTuple(inner);
-    innerWithControls->controls = controlsInner;
+    innerWithControls->controls          = controlsInner;
     *reinterpret_cast<Qubit*>(innerWithControls->AsTuple() + sizeof(/* QirArray* */ void*)) = target;
 
     PTuple outer = quantum__rt__tuple_create(sizeof(/* QirArray* */ void*) + sizeof(/*QirTupleHeader*/ void*));
     TupleWithControls* outerWithControls = TupleWithControls::FromTuple(outer);
-    outerWithControls->controls = controlsOuter;
-    outerWithControls->innerTuple = innerWithControls;
+    outerWithControls->controls          = controlsOuter;
+    outerWithControls->innerTuple        = innerWithControls;
 
     QirTupleHeader* unpacked = FlattenControlArrays(outerWithControls->GetHeader(), 2 /*depth*/);
-    QirArray* combined = *(reinterpret_cast<QirArray**>(unpacked->AsTuple()));
+    QirArray* combined       = *(reinterpret_cast<QirArray**>(unpacked->AsTuple()));
     REQUIRE(5 == combined->count);
     REQUIRE(!combined->ownsQubits);
     REQUIRE(target == *reinterpret_cast<Qubit*>(unpacked->AsTuple() + sizeof(/*QirArrray*/ void*)));
@@ -811,8 +809,8 @@ TEST_CASE("Unpacking input tuples of nested callables (case2)", "[qir_support]")
     quantum__rt__tuple_update_reference_count(inner, -1);
 
     // release the original resources
-    quantum__rt__qubit_release_array(controlsOuter);    // The `controlsOuter` is a dangling pointer from now on.
-    quantum__rt__qubit_release_array(controlsInner);    // The `controlsInner` is a dangling pointer from now on.
+    quantum__rt__qubit_release_array(controlsOuter); // The `controlsOuter` is a dangling pointer from now on.
+    quantum__rt__qubit_release_array(controlsInner); // The `controlsInner` is a dangling pointer from now on.
     quantum__rt__qubit_release(target);
 }
 
@@ -821,26 +819,26 @@ TEST_CASE("Unpacking input tuples of nested callables (case1)", "[qir_support]")
     std::unique_ptr<ControlledCallablesTestSimulator> qapi = std::make_unique<ControlledCallablesTestSimulator>();
     QirExecutionContext::Scoped qirctx(qapi.get());
 
-    Qubit target = quantum__rt__qubit_allocate();
+    Qubit target            = quantum__rt__qubit_allocate();
     QirArray* controlsInner = quantum__rt__qubit_allocate_array(3);
     QirArray* controlsOuter = quantum__rt__qubit_allocate_array(2);
 
-    PTuple args = quantum__rt__tuple_create(sizeof(/*Qubit*/ void*) + sizeof(int));
+    PTuple args                     = quantum__rt__tuple_create(sizeof(/*Qubit*/ void*) + sizeof(int));
     *reinterpret_cast<Qubit*>(args) = target;
     *reinterpret_cast<int*>(args + sizeof(/*Qubit*/ void*)) = 42;
 
     PTuple inner = quantum__rt__tuple_create(sizeof(/* QirArray* */ void*) + sizeof(/*Tuple*/ void*));
     TupleWithControls* innerWithControls = TupleWithControls::FromTuple(inner);
-    innerWithControls->controls = controlsInner;
+    innerWithControls->controls          = controlsInner;
     *reinterpret_cast<PTuple*>(innerWithControls->AsTuple() + sizeof(/* QirArray* */ void*)) = args;
 
     PTuple outer = quantum__rt__tuple_create(sizeof(/* QirArray* */ void*) + sizeof(/*QirTupleHeader*/ void*));
     TupleWithControls* outerWithControls = TupleWithControls::FromTuple(outer);
-    outerWithControls->controls = controlsOuter;
-    outerWithControls->innerTuple = innerWithControls;
+    outerWithControls->controls          = controlsOuter;
+    outerWithControls->innerTuple        = innerWithControls;
 
     QirTupleHeader* unpacked = FlattenControlArrays(outerWithControls->GetHeader(), 2 /*depth*/);
-    QirArray* combined = *(reinterpret_cast<QirArray**>(unpacked->AsTuple()));
+    QirArray* combined       = *(reinterpret_cast<QirArray**>(unpacked->AsTuple()));
     REQUIRE(5 == combined->count);
     REQUIRE(!combined->ownsQubits);
 
@@ -856,8 +854,8 @@ TEST_CASE("Unpacking input tuples of nested callables (case1)", "[qir_support]")
     quantum__rt__tuple_update_reference_count(args, -1);
 
     // release the original resources
-    quantum__rt__qubit_release_array(controlsOuter);    // The `controlsOuter` is a dangling pointer from now on.
-    quantum__rt__qubit_release_array(controlsInner);    // The `controlsInner` is a dangling pointer from now on.
+    quantum__rt__qubit_release_array(controlsOuter); // The `controlsOuter` is a dangling pointer from now on.
+    quantum__rt__qubit_release_array(controlsInner); // The `controlsInner` is a dangling pointer from now on.
     quantum__rt__qubit_release(target);
 }
 
@@ -897,10 +895,11 @@ TEST_CASE("Allocation tracking for tuples", "[qir_support]")
 
     quantum__rt__tuple_update_reference_count(maybeLeaked, -1);
     CHECK_NOTHROW(QirExecutionContext::Deinit());
-
 }
 
-static void NoopCallableEntry(PTuple, PTuple, PTuple) {}
+static void NoopCallableEntry(PTuple, PTuple, PTuple)
+{
+}
 TEST_CASE("Allocation tracking for callables", "[qir_support]")
 {
     t_CallableEntry entries[4] = {NoopCallableEntry, nullptr, nullptr, nullptr};
@@ -974,7 +973,7 @@ TEST_CASE("Tuples: copy elision", "[qir_support]")
 // Adjoints for R and Exp are implemented by qis, so let's check they at least do the angle invertion in adjoints.
 struct AdjointsTestSimulator : public SimulatorStub
 {
-    int lastId = -1;
+    int lastId           = -1;
     double rotationAngle = 0.0;
     double exponentAngle = 0.0;
 
@@ -982,7 +981,9 @@ struct AdjointsTestSimulator : public SimulatorStub
     {
         return reinterpret_cast<Qubit>(++this->lastId);
     }
-    void ReleaseQubit(Qubit /*qubit*/) override {}
+    void ReleaseQubit(Qubit /*qubit*/) override
+    {
+    }
     Result UseZero() override
     {
         return reinterpret_cast<Result>(0);
@@ -1026,7 +1027,7 @@ TEST_CASE("Adjoints of R should use inverse of the angle", "[qir_support]")
 
     const double angle = 0.42;
 
-    Qubit target = quantum__rt__qubit_allocate();
+    Qubit target    = quantum__rt__qubit_allocate();
     QirArray* ctrls = quantum__rt__qubit_allocate_array(2);
 
     quantum__qis__r__body(PauliId_Y, angle, target);
@@ -1034,7 +1035,7 @@ TEST_CASE("Adjoints of R should use inverse of the angle", "[qir_support]")
     quantum__qis__r__ctl(ctrls, PauliId_X, angle, target);
     quantum__qis__r__ctladj(ctrls, PauliId_X, angle, target);
 
-    quantum__rt__qubit_release_array(ctrls);        // The `ctrls` is a dangling pointer from now on.
+    quantum__rt__qubit_release_array(ctrls); // The `ctrls` is a dangling pointer from now on.
     quantum__rt__qubit_release(target);
 
     REQUIRE(qapi->rotationAngle == Approx(0).epsilon(0.0001));
@@ -1048,10 +1049,10 @@ TEST_CASE("Adjoints of Exp should use inverse of the angle", "[qir_support]")
     const double angle = 0.42;
 
     QirArray* targets = quantum__rt__qubit_allocate_array(2);
-    QirArray* ctrls = quantum__rt__qubit_allocate_array(2);
-    QirArray* axes = quantum__rt__array_create_1d(1 /*element size*/, 2 /*count*/);
-    axes->buffer[0] = 2;
-    axes->buffer[1] = 3;
+    QirArray* ctrls   = quantum__rt__qubit_allocate_array(2);
+    QirArray* axes    = quantum__rt__array_create_1d(1 /*element size*/, 2 /*count*/);
+    axes->buffer[0]   = 2;
+    axes->buffer[1]   = 3;
 
     quantum__qis__exp__body(axes, angle, targets);
     quantum__qis__exp__adj(axes, angle, targets);
@@ -1059,8 +1060,8 @@ TEST_CASE("Adjoints of Exp should use inverse of the angle", "[qir_support]")
     quantum__qis__exp__ctladj(ctrls, axes, angle, targets);
 
     quantum__rt__array_update_reference_count(axes, -1);
-    quantum__rt__qubit_release_array(ctrls);    // The `ctrls` is a dangling pointer from now on.
-    quantum__rt__qubit_release_array(targets);  // The `targets` is a dangling pointer from now on.
+    quantum__rt__qubit_release_array(ctrls);   // The `ctrls` is a dangling pointer from now on.
+    quantum__rt__qubit_release_array(targets); // The `targets` is a dangling pointer from now on.
 
     REQUIRE(qapi->exponentAngle == Approx(0).epsilon(0.0001));
 }

--- a/src/Qir/Runtime/unittests/QubitManagerTests.cpp
+++ b/src/Qir/Runtime/unittests/QubitManagerTests.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::Quantum;
 TEST_CASE("Simple allocation and release of one qubit", "[QubitManagerBasic]")
 {
     std::unique_ptr<CQubitManager> qm = std::make_unique<CQubitManager>();
-    Qubit q = qm->Allocate();
+    Qubit q                           = qm->Allocate();
     qm->Release(q);
 }
 
@@ -44,7 +44,7 @@ TEST_CASE("Qubit Status", "[QubitManagerBasic]")
 {
     std::unique_ptr<CQubitManager> qm = std::make_unique<CQubitManager>(2, false);
 
-    Qubit q0 = qm->Allocate();
+    Qubit q0                        = qm->Allocate();
     CQubitManager::QubitIdType q0id = qm->GetQubitId(q0);
     REQUIRE(qm->IsValidQubit(q0));
     REQUIRE(qm->IsExplicitlyAllocatedQubit(q0));
@@ -63,7 +63,7 @@ TEST_CASE("Qubit Status", "[QubitManagerBasic]")
     REQUIRE(!qm->IsFreeQubitId(q0id));
     REQUIRE(qm->GetFreeQubitCount() == 1);
 
-    Qubit q1 = qm->Allocate();
+    Qubit q1                        = qm->Allocate();
     CQubitManager::QubitIdType q1id = qm->GetQubitId(q1);
     REQUIRE(q0id != q1id);
 
@@ -82,9 +82,9 @@ TEST_CASE("Qubit Status", "[QubitManagerBasic]")
 
 TEST_CASE("Qubit Counts", "[QubitManagerBasic]")
 {
-    constexpr int totalQubitCount = 100;
+    constexpr int totalQubitCount    = 100;
     constexpr int disabledQubitCount = 29;
-    constexpr int extraQubitCount = 43;
+    constexpr int extraQubitCount    = 43;
     static_assert(extraQubitCount <= totalQubitCount);
     static_assert(disabledQubitCount <= totalQubitCount);
     // We don't want capacity to be extended at first...
@@ -99,19 +99,19 @@ TEST_CASE("Qubit Counts", "[QubitManagerBasic]")
     Qubit* qubits = new Qubit[disabledQubitCount];
     qm->Allocate(qubits, disabledQubitCount);
     REQUIRE(qm->GetQubitCapacity() == totalQubitCount);
-    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount-disabledQubitCount);
+    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount - disabledQubitCount);
     REQUIRE(qm->GetAllocatedQubitCount() == disabledQubitCount);
     REQUIRE(qm->GetDisabledQubitCount() == 0);
 
     qm->Disable(qubits, disabledQubitCount);
     REQUIRE(qm->GetQubitCapacity() == totalQubitCount);
-    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount-disabledQubitCount);
+    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount - disabledQubitCount);
     REQUIRE(qm->GetAllocatedQubitCount() == 0);
     REQUIRE(qm->GetDisabledQubitCount() == disabledQubitCount);
 
     qm->Release(qubits, disabledQubitCount);
     REQUIRE(qm->GetQubitCapacity() == totalQubitCount);
-    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount-disabledQubitCount);
+    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount - disabledQubitCount);
     REQUIRE(qm->GetAllocatedQubitCount() == 0);
     REQUIRE(qm->GetDisabledQubitCount() == disabledQubitCount);
     delete[] qubits;
@@ -119,13 +119,13 @@ TEST_CASE("Qubit Counts", "[QubitManagerBasic]")
     qubits = new Qubit[extraQubitCount];
     qm->Allocate(qubits, extraQubitCount);
     REQUIRE(qm->GetQubitCapacity() == totalQubitCount);
-    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount-disabledQubitCount-extraQubitCount);
+    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount - disabledQubitCount - extraQubitCount);
     REQUIRE(qm->GetAllocatedQubitCount() == extraQubitCount);
     REQUIRE(qm->GetDisabledQubitCount() == disabledQubitCount);
 
     qm->Release(qubits, extraQubitCount);
     REQUIRE(qm->GetQubitCapacity() == totalQubitCount);
-    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount-disabledQubitCount);
+    REQUIRE(qm->GetFreeQubitCount() == totalQubitCount - disabledQubitCount);
     REQUIRE(qm->GetAllocatedQubitCount() == 0);
     REQUIRE(qm->GetDisabledQubitCount() == disabledQubitCount);
     delete[] qubits;
@@ -254,11 +254,12 @@ TEST_CASE("Restricted Area", "[QubitManager]")
 
 TEST_CASE("Nested Restricted Areas", "[QubitManager]")
 {
-    constexpr int n = 10;
+    constexpr int n                   = 10;
     std::unique_ptr<CQubitManager> qm = std::make_unique<CQubitManager>(n, false);
-    for (int i = 0; i<n; i++) {
+    for (int i = 0; i < n; i++)
+    {
         Qubit q = qm->Allocate(); // Reuse qubit from previous area
-        qm->Release(q); // Put a free qubit in the innermost area
+        qm->Release(q);           // Put a free qubit in the innermost area
         qm->StartRestrictedReuseArea();
     }
     REQUIRE(qm->GetFreeQubitCount() == n);
@@ -270,7 +271,8 @@ TEST_CASE("Nested Restricted Areas", "[QubitManager]")
     REQUIRE(qm->GetFreeQubitCount() == 0);
     REQUIRE_THROWS(qm->Allocate()); // Reached capacity
     qm->Release(qubits, n);
-    for (int i = 0; i<n; i++) {
+    for (int i = 0; i < n; i++)
+    {
         qm->EndRestrictedReuseArea();
     }
     qm->Allocate(qubits, n);
@@ -284,25 +286,27 @@ TEST_CASE("Nested Restricted Areas With Qubits", "[QubitManager]")
     constexpr int n = 100;
 
     std::unique_ptr<CQubitManager> qm = std::make_unique<CQubitManager>(n, false);
-    Qubit* qubits = new Qubit[n];
+    Qubit* qubits                     = new Qubit[n];
     qm->Allocate(qubits, n); // Allocate All
     REQUIRE(qm->GetFreeQubitCount() == 0);
 
-    for (int i = 0; i<n; i++) {
+    for (int i = 0; i < n; i++)
+    {
         qm->StartRestrictedReuseArea();
         qm->Release(qubits[i]); // Put a free qubit in this area
     }
     REQUIRE(qm->GetFreeQubitCount() == n); // There're n free qubits, one in each area
-    qm->Allocate(qubits, n); // And we can allocate them all
+    qm->Allocate(qubits, n);               // And we can allocate them all
 
-    for (int i = 0; i<n; i++) {
+    for (int i = 0; i < n; i++)
+    {
         qm->EndRestrictedReuseArea();
         qm->Release(qubits[i]); // Release out of order
     }
 
     REQUIRE(qm->GetFreeQubitCount() == n); // There're n free qubits still
-    qm->Allocate(qubits, n); // And we can allocate them.
-    REQUIRE_THROWS(qm->Allocate()); // Reached capacity
+    qm->Allocate(qubits, n);               // And we can allocate them.
+    REQUIRE_THROWS(qm->Allocate());        // Reached capacity
     qm->Release(qubits, n);
     REQUIRE(qm->GetFreeQubitCount() == n);
     delete[] qubits;
@@ -310,12 +314,13 @@ TEST_CASE("Nested Restricted Areas With Qubits", "[QubitManager]")
 
 TEST_CASE("Many Nested Restricted Areas", "[QubitManager]")
 {
-    constexpr int n = 10000;
+    constexpr int n                   = 10000;
     std::unique_ptr<CQubitManager> qm = std::make_unique<CQubitManager>(1, false);
     REQUIRE(qm->GetFreeQubitCount() == 1);
 
     // Allocate a lot of nested areas
-    for (int i = 0; i<n; i++) {
+    for (int i = 0; i < n; i++)
+    {
         qm->StartRestrictedReuseArea();
     }
 
@@ -325,7 +330,8 @@ TEST_CASE("Many Nested Restricted Areas", "[QubitManager]")
     qm->Release(q);
     REQUIRE(qm->GetFreeQubitCount() == 1);
 
-    for (int i = 0; i<n; i++) {
+    for (int i = 0; i < n; i++)
+    {
         qm->EndRestrictedReuseArea();
     }
 

--- a/src/Qir/Runtime/unittests/ToffoliTests.cpp
+++ b/src/Qir/Runtime/unittests/ToffoliTests.cpp
@@ -14,14 +14,14 @@ using namespace Microsoft::Quantum;
 static Result MZ(IQuantumGateSet* iqa, Qubit q)
 {
     PauliId pauliZ[1] = {PauliId_Z};
-    Qubit qs[1] = {q};
+    Qubit qs[1]       = {q};
     return iqa->Measure(1, pauliZ, 1, qs);
 }
 
 TEST_CASE("Basis vector", "[toffoli]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateToffoliSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     constexpr int n = 1000;
     std::vector<Qubit> qubits;
@@ -50,7 +50,7 @@ TEST_CASE("Basis vector", "[toffoli]")
 TEST_CASE("Controlled X", "[toffoli]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateToffoliSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     Qubit q[4];
     q[0] = sim->AllocateQubit();
@@ -94,7 +94,7 @@ TEST_CASE("Controlled X", "[toffoli]")
 TEST_CASE("Measure and assert probability", "[toffoli]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateToffoliSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     const int count = 3;
     Qubit qs[count];

--- a/src/Qir/Runtime/unittests/TracerTests.cpp
+++ b/src/Qir/Runtime/unittests/TracerTests.cpp
@@ -401,7 +401,7 @@ TEST_CASE("Conditionals: fences and barriers", "[tracer][tracer.conditionals]")
 TEST_CASE("Output: to string", "[tracer]")
 {
     std::unordered_map<OpId, std::string> opNames = {{1, "X"}, {2, "Y"}, {3, "Z"}, {4, "b"}};
-    std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/, opNames);
+    std::shared_ptr<CTracer> tr                   = CreateTracer(1 /*layer duration*/, opNames);
 
     Qubit q1 = tr->AllocateQubit();
     tr->TraceSingleQubitOp(3, 1, q1);
@@ -448,7 +448,7 @@ TEST_CASE("Output: to string", "[tracer]")
 TEST_CASE("Output: to file", "[tracer]")
 {
     std::unordered_map<OpId, std::string> opNames = {{1, "X"}, {2, "Y"}, {3, "Z"}, {4, "b"}};
-    std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/, opNames);
+    std::shared_ptr<CTracer> tr                   = CreateTracer(1 /*layer duration*/, opNames);
 
     Qubit q1 = tr->AllocateQubit();
     tr->TraceSingleQubitOp(3, 1, q1);

--- a/src/Qir/Runtime/unittests/driver.cpp
+++ b/src/Qir/Runtime/unittests/driver.cpp
@@ -5,4 +5,3 @@
 #include "catch.hpp"
 
 // https://github.com/catchorg/Catch2/blob/master/docs/tutorial.md
-

--- a/src/Qir/Samples/StandaloneInputReference/qir-driver.cpp
+++ b/src/Qir/Samples/StandaloneInputReference/qir-driver.cpp
@@ -7,11 +7,13 @@
 #include <memory>
 #include <vector>
 
+// clang-format off
 #pragma clang diagnostic push
     // Temporarily disable `-Wswitch-enum`, one of the `switch`es in "CLI11.hpp" handles not all the enumerators.
     #pragma clang diagnostic ignored "-Wswitch-enum"
     #include "CLI11.hpp"
 #pragma clang diagnostic pop
+// clang-format on
 
 #include "QirContext.hpp"
 #include "SimFactory.hpp"
@@ -20,16 +22,16 @@
 using namespace Microsoft::Quantum;
 using namespace std;
 
-namespace   // == `static`
+namespace // == `static`
 {
 struct InteropArray
 {
-    size_t Size;   // TODO: Never used?
+    size_t Size; // TODO: Never used?
     void* Data;
 
-    InteropArray(size_t size, void* data) :
-        Size(size),
-        Data(data){}
+    InteropArray(size_t size, void* data) : Size(size), Data(data)
+    {
+    }
 };
 
 using RangeTuple = tuple<int64_t, int64_t, int64_t>;
@@ -39,56 +41,44 @@ struct InteropRange
     int64_t Step;
     int64_t End;
 
-    [[maybe_unused]] InteropRange() :
-        Start(0),
-        Step(0),
-        End(0){}
+    [[maybe_unused]] InteropRange() : Start(0), Step(0), End(0)
+    {
+    }
 
-    [[maybe_unused]] InteropRange(RangeTuple rangeTuple) :
-        Start(get<0>(rangeTuple)),
-        Step(get<1>(rangeTuple)),
-        End(get<2>(rangeTuple)){}
+    [[maybe_unused]] InteropRange(RangeTuple rangeTuple)
+        : Start(get<0>(rangeTuple))
+        , Step(get<1>(rangeTuple))
+        , End(get<2>(rangeTuple))
+    {
+    }
 };
 
-} // namespace   // == `static`
+} // namespace
 
 // This is the function corresponding to the QIR entry-point.
 extern "C" void Quantum__StandaloneSupportedInputs__ExerciseInputs( // NOLINT
-    int64_t intValue,
-    InteropArray* integerArray,
-    double doubleValue,
-    InteropArray* doubleArray,
-    char boolValue,
-    InteropArray* boolArray,
-    char pauliValue,
-    InteropArray* pauliArray,
-    InteropRange* rangeValue,
-    char resultValue,
-    InteropArray* resultArray,
-    const char* stringValue);
+    int64_t intValue, InteropArray* integerArray, double doubleValue, InteropArray* doubleArray, char boolValue,
+    InteropArray* boolArray, char pauliValue, InteropArray* pauliArray, InteropRange* rangeValue, char resultValue,
+    InteropArray* resultArray, const char* stringValue);
 
 static const char InteropFalseAsChar = 0x0;
-static const char InteropTrueAsChar = 0x1;
-static map<string, bool> BoolAsCharMap{
-    {"0", InteropFalseAsChar},
-    {"false", InteropFalseAsChar},
-    {"1", InteropTrueAsChar},
-    {"true", InteropTrueAsChar}};
+static const char InteropTrueAsChar  = 0x1;
+static map<string, bool> BoolAsCharMap{{"0", InteropFalseAsChar},
+                                       {"false", InteropFalseAsChar},
+                                       {"1", InteropTrueAsChar},
+                                       {"true", InteropTrueAsChar}};
 
-static map<string, PauliId> PauliMap{
-    {"PauliI", PauliId::PauliId_I},
-    {"PauliX", PauliId::PauliId_X},
-    {"PauliY", PauliId::PauliId_Y},
-    {"PauliZ", PauliId::PauliId_Z}};
+static map<string, PauliId> PauliMap{{"PauliI", PauliId::PauliId_I},
+                                     {"PauliX", PauliId::PauliId_X},
+                                     {"PauliY", PauliId::PauliId_Y},
+                                     {"PauliZ", PauliId::PauliId_Z}};
 
 static const char InteropResultZeroAsChar = 0x0;
-static const char InteropResultOneAsChar = 0x1;
-static map<string, char> ResultAsCharMap{
-    {"0", InteropResultZeroAsChar},
-    {"Zero", InteropResultZeroAsChar},
-    {"1", InteropResultOneAsChar},
-    {"One", InteropResultOneAsChar}
-};
+static const char InteropResultOneAsChar  = 0x1;
+static map<string, char> ResultAsCharMap{{"0", InteropResultZeroAsChar},
+                                         {"Zero", InteropResultZeroAsChar},
+                                         {"1", InteropResultOneAsChar},
+                                         {"One", InteropResultOneAsChar}};
 
 template<typename T>
 unique_ptr<InteropArray> CreateInteropArray(vector<T>& v)
@@ -146,9 +136,9 @@ int main(int argc, char* argv[])
     // Add the --simulation-output options.
     // N.B. This option should be present in all standalone drivers.
     string simulationOutputFile;
-    CLI::Option* simulationOutputFileOpt = app.add_option(
-        "-s,--simulation-output", simulationOutputFile,
-        "File where the output produced during the simulation is written");
+    CLI::Option* simulationOutputFileOpt =
+        app.add_option("-s,--simulation-output", simulationOutputFile,
+                       "File where the output produced during the simulation is written");
 
     // Add the options that correspond to the parameters that the QIR entry-point needs.
     // Option for a Q# Int type.
@@ -259,7 +249,7 @@ int main(int argc, char* argv[])
     unique_ptr<InteropArray> resultArray = CreateInteropArray(resultAsCharVector);
 
     // Create an interop array of String values.
-    vector<const char *> stringBufferVector;
+    vector<const char*> stringBufferVector;
     TranslateVector<string, const char*>(stringVector, stringBufferVector, TranslateStringToCharBuffer);
     unique_ptr<InteropArray> stringArray = CreateInteropArray(stringBufferVector);
 
@@ -274,19 +264,10 @@ int main(int argc, char* argv[])
     }
 
     // Run simulation and write the output of the operation to the corresponding stream.
-    Quantum__StandaloneSupportedInputs__ExerciseInputs(
-        intValue,
-        integerArray.get(),
-        doubleValue,
-        doubleArray.get(),
-        boolAsCharValue,
-        boolArray.get(),
-        pauliAsCharValue,
-        pauliArray.get(),
-        rangeValue.get(),
-        resultAsCharValue,
-        resultArray.get(),
-        stringValue.c_str());
+    Quantum__StandaloneSupportedInputs__ExerciseInputs(intValue, integerArray.get(), doubleValue, doubleArray.get(),
+                                                       boolAsCharValue, boolArray.get(), pauliAsCharValue,
+                                                       pauliArray.get(), rangeValue.get(), resultAsCharValue,
+                                                       resultArray.get(), stringValue.c_str());
 
     FreePointerVector(rangeVector);
     simulatorOutputStream->flush();

--- a/src/Qir/Tests/FullstateSimulator/FullstateSimulatorTests.cpp
+++ b/src/Qir/Tests/FullstateSimulator/FullstateSimulatorTests.cpp
@@ -26,7 +26,7 @@ static unsigned GetQubitId(Qubit q)
 static Result MZ(IQuantumGateSet* iqa, Qubit q)
 {
     PauliId pauliZ[1] = {PauliId_Z};
-    Qubit qs[1] = {q};
+    Qubit qs[1]       = {q};
     return iqa->Measure(1, pauliZ, 1, qs);
 }
 
@@ -45,10 +45,10 @@ TEST_CASE("Fullstate simulator: allocate qubits", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: multiple instances", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim1 = CreateFullstateSimulator();
-    Qubit q1 = sim1->AllocateQubit();
+    Qubit q1                             = sim1->AllocateQubit();
 
     std::unique_ptr<IRuntimeDriver> sim2 = CreateFullstateSimulator();
-    Qubit q2 = sim2->AllocateQubit();
+    Qubit q2                             = sim2->AllocateQubit();
 
     REQUIRE(GetQubitId(q1) == 0);
     REQUIRE(GetQubitId(q2) == 0);
@@ -60,9 +60,9 @@ TEST_CASE("Fullstate simulator: multiple instances", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: X and measure", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q = sim->AllocateQubit();
+    Qubit q   = sim->AllocateQubit();
     Result r1 = MZ(iqa, q);
     REQUIRE(Result_Zero == sim->GetResultValue(r1));
     REQUIRE(sim->AreEqualResults(r1, sim->UseZero()));
@@ -80,9 +80,9 @@ TEST_CASE("Fullstate simulator: X and measure", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: X, M, reuse, M", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q = sim->AllocateQubit();
+    Qubit q   = sim->AllocateQubit();
     Result r1 = MZ(iqa, q);
     REQUIRE(Result_Zero == sim->GetResultValue(r1));
     REQUIRE(sim->AreEqualResults(r1, sim->UseZero()));
@@ -96,13 +96,13 @@ TEST_CASE("Fullstate simulator: X, M, reuse, M", "[fullstate_simulator]")
     sim->ReleaseResult(r1);
     sim->ReleaseResult(r2);
 
-    Qubit qq = sim->AllocateQubit();
+    Qubit qq  = sim->AllocateQubit();
     Result r3 = MZ(iqa, qq);
     // Allocated qubit should always be in |0> state even though we released
     // q in |1> state, and qq is likely reusing the same underlying qubit as q.
     REQUIRE(Result_Zero == sim->GetResultValue(r3));
     REQUIRE(sim->AreEqualResults(r3, sim->UseZero()));
-    
+
     sim->ReleaseQubit(qq);
     sim->ReleaseResult(r3);
 }
@@ -110,7 +110,7 @@ TEST_CASE("Fullstate simulator: X, M, reuse, M", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: measure Bell state", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     Qubit q1 = sim->AllocateQubit();
     Qubit q2 = sim->AllocateQubit();
@@ -129,7 +129,7 @@ TEST_CASE("Fullstate simulator: measure Bell state", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: ZZ measure", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     Qubit q[2];
     PauliId paulis[2] = {PauliId_Z, PauliId_Z};
@@ -152,7 +152,7 @@ TEST_CASE("Fullstate simulator: ZZ measure", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: assert probability", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     Qubit qs[2];
     qs[0] = sim->AllocateQubit();
@@ -180,7 +180,7 @@ TEST_CASE("Fullstate simulator: assert probability", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: toffoli", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     Qubit qs[3];
     for (int i = 0; i < 3; i++)
@@ -205,7 +205,7 @@ TEST_CASE("Fullstate simulator: toffoli", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: SSZ=Id", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     Qubit q = sim->AllocateQubit();
 
@@ -227,7 +227,7 @@ TEST_CASE("Fullstate simulator: SSZ=Id", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: TTSAdj=Id", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     Qubit q = sim->AllocateQubit();
 
@@ -249,7 +249,7 @@ TEST_CASE("Fullstate simulator: TTSAdj=Id", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: TTAdj=Id", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     Qubit q = sim->AllocateQubit();
 
@@ -269,11 +269,11 @@ TEST_CASE("Fullstate simulator: TTAdj=Id", "[fullstate_simulator]")
 
 TEST_CASE("Fullstate simulator: R", "[fullstate_simulator]")
 {
-    constexpr double pi = 3.1415926535897932384626433832795028841971693993751058209749445923078164062;
+    constexpr double pi                 = 3.1415926535897932384626433832795028841971693993751058209749445923078164062;
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q = sim->AllocateQubit();
+    Qubit q       = sim->AllocateQubit();
     bool identity = true;
     for (int i = 0; i < 100 && identity; i++)
     {
@@ -295,8 +295,8 @@ TEST_CASE("Fullstate simulator: R", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: exponents", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
-    const int n = 5;
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
+    const int n                         = 5;
 
     Qubit qs[n];
     for (int i = 0; i < n; i++)
@@ -320,9 +320,9 @@ TEST_CASE("Fullstate simulator: exponents", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: get qubit state of Bell state", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
-    IQuantumGateSet* iqa = dynamic_cast<IQuantumGateSet*>(sim.get());
+    IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    const int n = 3;
+    const int n        = 3;
     static double norm = 0.0;
 
     Qubit qs[n];

--- a/src/Qir/Tests/QIR-dynamic/qir-driver.cpp
+++ b/src/Qir/Tests/QIR-dynamic/qir-driver.cpp
@@ -16,26 +16,26 @@
 extern "C"
 {
     int64_t Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__Interop(); // NOLINT
-   
-    void Microsoft__Quantum__Testing__QIR__DumpMachineTest__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__Interop(const void*); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__DumpRegisterTest__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__Interop(const void*); // NOLINT
-   
-    void Microsoft__Quantum__Testing__QIR__AssertMeasurementTest__Interop(); // NOLINT
-   
-    void Microsoft__Quantum__Testing__QIR__AssertMeasAlloc1OKTest__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertMeasProbAlloc1HalfProbTest__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertMeasProbAllocPlusMinusTest__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertMeasSPlusMinusTest__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertMeas0011__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertMeas4Qubits__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertBellPairMeasurementsAreCorrectTest__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertMeasMixedBasesTest__Interop(); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertGHZMeasurementsTest__Interop(); // NOLINT
 
-    void Microsoft__Quantum__Testing__QIR__AssertMeasMessageTest__Interop(const char *); // NOLINT
-    void Microsoft__Quantum__Testing__QIR__AssertMeasProbMessageTest__Interop(const char *); // NOLINT
+    void Microsoft__Quantum__Testing__QIR__DumpMachineTest__Interop();                   // NOLINT
+    void Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__Interop(const void*);  // NOLINT
+    void Microsoft__Quantum__Testing__QIR__DumpRegisterTest__Interop();                  // NOLINT
+    void Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__Interop(const void*); // NOLINT
+
+    void Microsoft__Quantum__Testing__QIR__AssertMeasurementTest__Interop(); // NOLINT
+
+    void Microsoft__Quantum__Testing__QIR__AssertMeasAlloc1OKTest__Interop();                   // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertMeasProbAlloc1HalfProbTest__Interop();         // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertMeasProbAllocPlusMinusTest__Interop();         // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertMeasSPlusMinusTest__Interop();                 // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertMeas0011__Interop();                           // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertMeas4Qubits__Interop();                        // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertBellPairMeasurementsAreCorrectTest__Interop(); // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertMeasMixedBasesTest__Interop();                 // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertGHZMeasurementsTest__Interop();                // NOLINT
+
+    void Microsoft__Quantum__Testing__QIR__AssertMeasMessageTest__Interop(const char*);     // NOLINT
+    void Microsoft__Quantum__Testing__QIR__AssertMeasProbMessageTest__Interop(const char*); // NOLINT
 } // extern "C"
 
 using namespace Microsoft::Quantum;
@@ -48,9 +48,8 @@ TEST_CASE("QIR: Generate a random number with full state simulator", "[qir]")
     const int64_t ret1 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__Interop();
     const int64_t ret2 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__Interop();
     const int64_t ret3 = Microsoft__Quantum__Testing__QIR__QuantumRandomNumberGenerator__Interop();
-    INFO(
-        std::string("Three random numbers: ") + std::to_string(ret1) + ", " + std::to_string(ret2) + ", " +
-        std::to_string(ret3));
+    INFO(std::string("Three random numbers: ") + std::to_string(ret1) + ", " + std::to_string(ret2) + ", " +
+         std::to_string(ret3));
 
     // Check that the returned numbers are at least somewhat random...
     CHECK(ret1 != ret2);
@@ -59,7 +58,7 @@ TEST_CASE("QIR: Generate a random number with full state simulator", "[qir]")
 }
 
 
-static bool FileExists(const char * filePath)
+static bool FileExists(const char* filePath)
 {
     return std::ifstream(filePath).operator bool();
 }
@@ -71,7 +70,7 @@ TEST_CASE("QIR: DumpMachine", "[qir][DumpMachine]")
 
     // Dump to the std::cout:
     {
-        std::ostringstream      outStrStream;
+        std::ostringstream outStrStream;
         {
             // Redirect the output from std::cout to outStrStream:
             OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
@@ -85,7 +84,7 @@ TEST_CASE("QIR: DumpMachine", "[qir][DumpMachine]")
 
     // Dump to empty string location (std::cout):
     {
-        std::ostringstream      outStrStream;
+        std::ostringstream outStrStream;
         {
             // Redirect the output from std::cout to outStrStream:
             OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
@@ -101,7 +100,7 @@ TEST_CASE("QIR: DumpMachine", "[qir][DumpMachine]")
     const char* filePath = "DumpMachineTest.log";
 
     // Remove the `filePath`, if exists.
-    if(FileExists(filePath))
+    if (FileExists(filePath))
     {
         CHECK(0 == remove(filePath));
     }
@@ -117,7 +116,7 @@ TEST_CASE("QIR: DumpMachine", "[qir][DumpMachine]")
     // If we got here then the test has succeeded, we don't need the file.
     // Otherwise (test fails) we don't get here, and the file is kept for the subsequent analysis.
     // Remove the file, ignore the failure:
-    (void) remove(filePath);
+    (void)remove(filePath);
 }
 
 
@@ -128,7 +127,7 @@ TEST_CASE("QIR: DumpRegister", "[qir][DumpRegister]")
 
     // Dump to the std::cout:
     {
-        std::ostringstream      outStrStream;
+        std::ostringstream outStrStream;
         {
             // Redirect the output from std::cout to outStrStream:
             OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
@@ -142,7 +141,7 @@ TEST_CASE("QIR: DumpRegister", "[qir][DumpRegister]")
 
     // Dump to empty string location (std::cout):
     {
-        std::ostringstream      outStrStream;
+        std::ostringstream outStrStream;
         {
             // Redirect the output from std::cout to outStrStream:
             OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
@@ -158,7 +157,7 @@ TEST_CASE("QIR: DumpRegister", "[qir][DumpRegister]")
     const char* filePath = "DumpRegisterTest.log";
 
     // Remove the `filePath` if exists.
-    if(FileExists(filePath))
+    if (FileExists(filePath))
     {
         CHECK(0 == remove(filePath));
     }
@@ -174,21 +173,21 @@ TEST_CASE("QIR: DumpRegister", "[qir][DumpRegister]")
     // If we got here then the test has succeeded, we don't need the file.
     // Otherwise (test fails) we don't get here, and the file is kept for the subsequent analysis.
     // Remove the file, ignore the failure:
-    (void) remove(filePath);
+    (void)remove(filePath);
 }
 
-static void AssertMeasMessageTest(void (*funcPtr)(const char *))
+static void AssertMeasMessageTest(void (*funcPtr)(const char*))
 {
-    const char * const  testStr = "Testing the Assertion Failure Message";
-    std::ostringstream      outStrStream;
+    const char* const testStr = "Testing the Assertion Failure Message";
+    std::ostringstream outStrStream;
 
     // Redirect the output from std::cout to outStrStream:
     Microsoft::Quantum::OutputStream::ScopedRedirector qOStreamRedirector(outStrStream);
 
     // Log something (to the redirected output):
-    REQUIRE_THROWS(funcPtr(testStr));   // Returns with exception caught. Leaks any instances allocated (in .ll)
-                                        // from the moment of a call to the moment of the exception throw.
-                                        // TODO: Extract into a separate .cpp compiled with leak detection off.
+    REQUIRE_THROWS(funcPtr(testStr)); // Returns with exception caught. Leaks any instances allocated (in .ll)
+                                      // from the moment of a call to the moment of the exception throw.
+                                      // TODO: Extract into a separate .cpp compiled with leak detection off.
     REQUIRE(outStrStream.str() == (std::string(testStr) + "\n"));
 }
 

--- a/src/Qir/Tests/QIR-static/qir-driver.cpp
+++ b/src/Qir/Tests/QIR-static/qir-driver.cpp
@@ -20,8 +20,8 @@
 #include "catch.hpp"
 
 // Identifiers exposed externally:
-extern "C" void __quantum__qis__k__body(Qubit q);                       // NOLINT
-extern "C" void __quantum__qis__k__ctl(QirArray* controls, Qubit q);    // NOLINT
+extern "C" void __quantum__qis__k__body(Qubit q);                    // NOLINT
+extern "C" void __quantum__qis__k__ctl(QirArray* controls, Qubit q); // NOLINT
 
 // Used by a couple test simulators. Catch's REQUIRE macro doesn't deal well with static class members so making it
 // into a global constant.
@@ -43,7 +43,8 @@ To update the *.ll files to a newer version:
 - the generated file name.ll will be placed into `s` folder
 */
 
-struct Array {
+struct Array
+{
     int64_t itemSize;
     void* buffer;
 };
@@ -52,16 +53,14 @@ struct Array {
 // index (starting from index backwards) and every element from index to the end. It returns the sum of elements in this
 // new array
 extern "C" int64_t Microsoft__Quantum__Testing__QIR__Test_Arrays__Interop( // NOLINT
-    Array* array,
-    int64_t index,
-    int64_t val);
+    Array* array, int64_t index, int64_t val);
 TEST_CASE("QIR: Using 1D arrays", "[qir][qir.arr1d]")
 {
     QirExecutionContext::Scoped qirctx(nullptr, true /*trackAllocatedObjects*/);
 
     constexpr int64_t n = 5;
-    int64_t values[n] = {0, 1, 2, 3, 4};
-    auto array = Array{5, values};
+    int64_t values[n]   = {0, 1, 2, 3, 4};
+    auto array          = Array{5, values};
 
     int64_t res = Microsoft__Quantum__Testing__QIR__Test_Arrays__Interop(&array, 2, 42);
     REQUIRE(res == (0 + 42) + (42 + 3 + 4));
@@ -110,7 +109,8 @@ struct QubitsResultsTestSimulator : public Microsoft::Quantum::SimulatorStub
         this->qubits[id] = 1 - this->qubits[id];
     }
 
-    Result Measure([[maybe_unused]] long numBases, PauliId* /* bases */, long /* numTargets */, Qubit targets[]) override
+    Result Measure([[maybe_unused]] long numBases, PauliId* /* bases */, long /* numTargets */,
+                   Qubit targets[]) override
     {
         assert(numBases == 1 && "QubitsResultsTestSimulator doesn't support joint measurements");
 
@@ -196,9 +196,9 @@ TEST_CASE("QIR: Report range in a failure message", "[qir][qir.range]")
     bool failed = false;
     try
     {
-        TestFailWithRangeString(0, 5, 42);  // Returns with exception. Leaks the instances created from the moment of call 
-                                            // to the moment of exception throw.
-                                            // TODO: Extract into a separate file compiled with leaks check off.
+        TestFailWithRangeString(0, 5, 42); // Returns with exception. Leaks the instances created from the moment of
+                                           // call to the moment of exception throw.
+                                           // TODO: Extract into a separate file compiled with leaks check off.
     }
     catch (const std::exception& e)
     {
@@ -218,8 +218,8 @@ TEST_CASE("QIR: Partial application of a callable", "[qir][qir.partCallable]")
     REQUIRE(res == 42 - 17);
 }
 
-// The Microsoft__Quantum__Testing__QIR__TestFunctors__Interop tests needs proper semantics of X and M, and nothing else.
-// The validation is done inside the test and it would throw in case of failure.
+// The Microsoft__Quantum__Testing__QIR__TestFunctors__Interop tests needs proper semantics of X and M, and nothing
+// else. The validation is done inside the test and it would throw in case of failure.
 struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
 {
     std::vector<int> qubits;
@@ -265,7 +265,8 @@ struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
         X(qubit);
     }
 
-    Result Measure([[maybe_unused]] long numBases, PauliId* /* bases */, long /* numTargets */, Qubit targets[]) override
+    Result Measure([[maybe_unused]] long numBases, PauliId* /* bases */, long /* numTargets */,
+                   Qubit targets[]) override
     {
         assert(numBases == 1 && "FunctorsTestSimulator doesn't support joint measurements");
 
@@ -280,7 +281,9 @@ struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
         return (r1 == r2);
     }
 
-    void ReleaseResult(Result /*result*/) override {} // the results aren't allocated by this test simulator
+    void ReleaseResult(Result /*result*/) override
+    {
+    } // the results aren't allocated by this test simulator
 
     Result UseZero() override
     {
@@ -293,11 +296,11 @@ struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
     }
 };
 static FunctorsTestSimulator* g_ctrqapi = nullptr;
-static int g_cKCalls = 0;
-static int g_cKCallsControlled = 0;
+static int g_cKCalls                    = 0;
+static int g_cKCallsControlled          = 0;
 extern "C" void Microsoft__Quantum__Testing__QIR__TestFunctors__Interop();       // NOLINT
 extern "C" void Microsoft__Quantum__Testing__QIR__TestFunctorsNoArgs__Interop(); // NOLINT
-extern "C" void __quantum__qis__k__body(Qubit q)                              // NOLINT
+extern "C" void __quantum__qis__k__body(Qubit q)                                 // NOLINT
 {
     g_cKCalls++;
     g_ctrqapi->X(q);
@@ -315,7 +318,7 @@ TEST_CASE("QIR: application of nested controlled functor", "[qir][qir.functor]")
 
     CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestFunctors__Interop());
 
-    const int cKCalls = g_cKCalls;
+    const int cKCalls           = g_cKCalls;
     const int cKCallsControlled = g_cKCallsControlled;
     CHECK_NOTHROW(Microsoft__Quantum__Testing__QIR__TestFunctorsNoArgs__Interop());
     CHECK(g_cKCalls - cKCalls == 3);

--- a/src/Qir/Tests/QIR-static/qir-test-conditionals.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-conditionals.cpp
@@ -29,8 +29,7 @@ struct ConditionalsTestSimulator : public Microsoft::Quantum::SimulatorStub
     vector<ResultValue> mockMeasurements;
     size_t nextMeasureResult = 0;
 
-    explicit ConditionalsTestSimulator(vector<ResultValue>&& results)
-        : mockMeasurements(results)
+    explicit ConditionalsTestSimulator(vector<ResultValue>&& results) : mockMeasurements(results)
     {
     }
 
@@ -61,7 +60,9 @@ struct ConditionalsTestSimulator : public Microsoft::Quantum::SimulatorStub
     {
         return nullptr;
     }
-    void ReleaseQubit(Qubit /*qubit*/) override {}
+    void ReleaseQubit(Qubit /*qubit*/) override
+    {
+    }
 
     void X(Qubit) override
     {
@@ -86,9 +87,8 @@ struct ConditionalsTestSimulator : public Microsoft::Quantum::SimulatorStub
 
     Result Measure(long /* numBases */, PauliId* /* bases */, long /* numTargets */, Qubit* /* targets */) override
     {
-        assert(
-            this->nextMeasureResult < this->mockMeasurements.size() &&
-            "ConditionalsTestSimulator isn't set up correctly");
+        assert(this->nextMeasureResult < this->mockMeasurements.size() &&
+               "ConditionalsTestSimulator isn't set up correctly");
 
         Result r = (this->mockMeasurements[this->nextMeasureResult] == Result_Zero) ? UseZero() : UseOne();
         this->nextMeasureResult++;
@@ -101,7 +101,9 @@ struct ConditionalsTestSimulator : public Microsoft::Quantum::SimulatorStub
         return (r1 == r2);
     }
 
-    void ReleaseResult(Result /*result*/) override {} // the results aren't allocated by this test simulator
+    void ReleaseResult(Result /*result*/) override
+    {
+    } // the results aren't allocated by this test simulator
 
     Result UseZero() override
     {

--- a/src/Qir/Tests/QIR-static/qir-test-math.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-math.cpp
@@ -9,21 +9,23 @@
 #include "qsharp__foundation_internal.hpp"
 #include "FloatUtils.hpp"
 
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SqrtTest__Interop();                                  // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__LogTest__Interop();                                   // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcTan2Test__Interop();                               // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SinTest__Interop();                                   // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__CosTest__Interop();                                   // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TanTest__Interop();                                   // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcSinTest__Interop();                                // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcCosTest__Interop();                                // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcTanTest__Interop();                                // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SinhTest__Interop();                                  // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__CoshTest__Interop();                                  // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TanhTest__Interop();                                  // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__IeeeRemainderTest__Interop();                         // NOLINT
-extern "C"  int64_t Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(int64_t min, int64_t max); // NOLINT
-extern "C" double Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(double min, double max);  // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SqrtTest__Interop();          // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__LogTest__Interop();           // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcTan2Test__Interop();       // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SinTest__Interop();           // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__CosTest__Interop();           // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TanTest__Interop();           // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcSinTest__Interop();        // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcCosTest__Interop();        // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__ArcTanTest__Interop();        // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__SinhTest__Interop();          // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__CoshTest__Interop();          // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__TanhTest__Interop();          // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Math__IeeeRemainderTest__Interop(); // NOLINT
+extern "C" int64_t Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(    // NOLINT
+    int64_t min, int64_t max);
+extern "C" double Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop( // NOLINT
+    double min, double max);
 
 TEST_CASE("QIR: Math.Sqrt", "[qir.math][qir.Math.Sqrt]")
 {
@@ -94,29 +96,30 @@ TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
 {
     // Test that the Q# random number generator is a wrapper around the C++ generator:
     size_t times = 1000;
-    while(--times)
+    while (--times)
     {
-        const int64_t qsRndNum = 
-            Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(std::numeric_limits<int64_t>::min(),
-                                                                            std::numeric_limits<int64_t>::max());
-        const int64_t cppRndNum = Quantum::Qis::Internal::GetLastGeneratedRandomI64();  // This call must be done 
-            // _after_ the  Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop().
+        const int64_t qsRndNum = Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(
+            std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+        const int64_t cppRndNum = Quantum::Qis::Internal::
+            GetLastGeneratedRandomI64(); // This call must be done
+                                         // _after_ the
+                                         // Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop().
         REQUIRE(qsRndNum == cppRndNum);
     }
 
     // Make sure the correct exception is thrown if min > max:
     REQUIRE_THROWS_AS(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(10, 5), std::runtime_error);
-        // Returns with exception. Leaks the instances created from the moment of call 
-        // to the moment of exception throw.
-        // TODO: Extract into a separate file compiled with leaks check off.        
+    // Returns with exception. Leaks the instances created from the moment of call
+    // to the moment of exception throw.
+    // TODO: Extract into a separate file compiled with leaks check off.
 
     // Check the exception string:
     try
     {
         (void)Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(10, 5);
-            // Returns with exception. Leaks the instances created from the moment of call 
-            // to the moment of exception throw.
-            // TODO: Extract into a separate file compiled with leaks check off.        
+        // Returns with exception. Leaks the instances created from the moment of call
+        // to the moment of exception throw.
+        // TODO: Extract into a separate file compiled with leaks check off.
     }
     catch (std::runtime_error const& exc)
     {
@@ -124,11 +127,12 @@ TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
     }
 
     // Test equal minimum and maximum:
-    for(int64_t num: { -5, 0, 3 } )
+    for (int64_t num : {-5, 0, 3})
     {
         REQUIRE(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomInt__Interop(num, num) == num);
     }
 
+    // clang-format off
     // There is a strong difference in the opinions about how the random number generator must be tested.
     // More or less agreed-upon items are:
     //  * The test must be 100% deterministic, i.e. must not fail, even with a very low probability. 
@@ -214,35 +218,39 @@ TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
     //         REQUIRE(*iterExp == *iterAct);
     //     }
 
+    // clang-format on
+
 } // TEST_CASE("QIR: Math.DrawRandomInt", "[qir.math][qir.Math.DrawRandomInt]")
 
 TEST_CASE("QIR: Math.DrawRandomDouble", "[qir.math][qir.Math.DrawRandomDouble]")
 {
     // Test that the Q# random number generator is a wrapper around the C++ generator:
     size_t times = 1000;
-    while(--times)
+    while (--times)
     {
-        const double qsRndNum = 
-            Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(std::numeric_limits<double>::min(),
-                                                                               std::numeric_limits<double>::max());
-        const double cppRndNum = Quantum::Qis::Internal::GetLastGeneratedRandomDouble();  // This call must be done 
-            // _after_ the  Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop().
+        const double qsRndNum = Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(
+            std::numeric_limits<double>::min(), std::numeric_limits<double>::max());
+        const double cppRndNum = Quantum::Qis::Internal::
+            GetLastGeneratedRandomDouble(); // This call must be done
+                                            // _after_ the
+                                            // Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop().
         REQUIRE(Close(qsRndNum, cppRndNum));
     }
 
     // Make sure the correct exception is thrown if min > max:
-    REQUIRE_THROWS_AS(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(10.0, 5.0), std::runtime_error);
-        // Returns with exception. Leaks the instances created from the moment of call 
-        // to the moment of exception throw.
-        // TODO: Extract into a separate file compiled with leaks check off.        
+    REQUIRE_THROWS_AS(Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(10.0, 5.0),
+                      std::runtime_error);
+    // Returns with exception. Leaks the instances created from the moment of call
+    // to the moment of exception throw.
+    // TODO: Extract into a separate file compiled with leaks check off.
 
     // Check the exception string:
     try
     {
         (void)Microsoft__Quantum__Testing__QIR__Math__TestDrawRandomDouble__Interop(10.0, 5.0);
-            // Returns with exception. Leaks the instances created from the moment of call 
-            // to the moment of exception throw.
-            // TODO: Extract into a separate file compiled with leaks check off.        
+        // Returns with exception. Leaks the instances created from the moment of call
+        // to the moment of exception throw.
+        // TODO: Extract into a separate file compiled with leaks check off.
     }
     catch (std::runtime_error const& exc)
     {

--- a/src/Qir/Tests/QIR-static/qir-test-other.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-other.cpp
@@ -3,16 +3,16 @@
 
 #include "catch.hpp"
 
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__ParityTest__Interop();                // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntTest__Interop();       // NOLINT
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntFailTest__Interop();   // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__ParityTest__Interop();              // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntTest__Interop();     // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntFailTest__Interop(); // NOLINT
 
 TEST_CASE("QIR: Other.PauliArrayAsIntFail", "[qir.Other][qir.Other.PauliArrayAsIntFail]")
 {
     REQUIRE_THROWS(Microsoft__Quantum__Testing__QIR__Other__PauliArrayAsIntFailTest__Interop());
-        // Returns with exception. Leaks the instances created from the moment of call 
-        // to the moment of exception throw.
-        // TODO: Extract into a separate file compiled with leaks check off.        
+    // Returns with exception. Leaks the instances created from the moment of call
+    // to the moment of exception throw.
+    // TODO: Extract into a separate file compiled with leaks check off.
 }
 
 TEST_CASE("QIR: Other.PauliArrayAsInt", "[qir.Other][qir.Other.PauliArrayAsInt]")

--- a/src/Qir/Tests/QIR-static/qir-test-ouput.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-ouput.cpp
@@ -10,10 +10,10 @@ extern "C" void Microsoft__Quantum__Testing__QIR__Out__MessageTest__Interop(cons
 
 TEST_CASE("QIR: Out.Message", "[qir.Out][qir.Out.Message]")
 {
-    const std::string       testStr1 = "Test String 1";
-    const std::string       testStr2 = "Test String 2";
+    const std::string testStr1 = "Test String 1";
+    const std::string testStr2 = "Test String 2";
 
-    std::ostringstream      outStrStream;
+    std::ostringstream outStrStream;
 
     {
         // Redirect the output from std::cout to outStrStream:

--- a/src/Qir/Tests/QIR-static/qir-test-strings.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-strings.cpp
@@ -5,11 +5,10 @@
 #include "catch.hpp"
 
 
-extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Str__PauliToStringTest__Interop();   // NOLINT
+extern "C" uint64_t Microsoft__Quantum__Testing__QIR__Str__PauliToStringTest__Interop(); // NOLINT
 
 
 TEST_CASE("QIR: Strings", "[qir.Str][qir.Str.PauliToString]")
 {
     REQUIRE(0 == Microsoft__Quantum__Testing__QIR__Str__PauliToStringTest__Interop());
 }
-

--- a/src/Qir/Tests/QIR-tracer/tracer-config.cpp
+++ b/src/Qir/Tests/QIR-tracer/tracer-config.cpp
@@ -12,7 +12,7 @@
 namespace TracerUser
 {
 const std::unordered_map<Microsoft::Quantum::OpId, std::string> g_operationNames = {
-    {0, "X"},     {1, "CX"},  {2, "MCX"},  {3, "Y"},     {4, "CY"},  {5, "MCY"},   {6, "Z"},
-    {7, "CZ"},    {8, "MCZ"}, {19, "Rx"},  {20, "MCRx"}, {21, "Ry"}, {22, "MCRy"}, {23, "Rz"},
-    {24, "MCRz"}, {9, "H"},  {10, "MCH"}, {11, "T"},  {12, "MCT"}, {15, "S"},    {16, "MCS"} /*etc.*/};
+    {0, "X"},     {1, "CX"},  {2, "MCX"},  {3, "Y"},     {4, "CY"},   {5, "MCY"},   {6, "Z"},
+    {7, "CZ"},    {8, "MCZ"}, {19, "Rx"},  {20, "MCRx"}, {21, "Ry"},  {22, "MCRy"}, {23, "Rz"},
+    {24, "MCRz"}, {9, "H"},   {10, "MCH"}, {11, "T"},    {12, "MCT"}, {15, "S"},    {16, "MCS"} /*etc.*/};
 }

--- a/src/Qir/Tests/QIR-tracer/tracer-config.hpp
+++ b/src/Qir/Tests/QIR-tracer/tracer-config.hpp
@@ -17,4 +17,4 @@ extern const std::unordered_map<Microsoft::Quantum::OpId, std::string> g_operati
 
 // Available function in generated QIR
 extern "C" void Microsoft__Quantum__Testing__Tracer__TestCoreIntrinsics__Interop(); // NOLINT
-extern "C" void Microsoft__Quantum__Testing__Tracer__TestMeasurements__Interop(); // NOLINT
+extern "C" void Microsoft__Quantum__Testing__Tracer__TestMeasurements__Interop();   // NOLINT


### PR DESCRIPTION
It is a step two of the three mentioned below:
* Update the `.clang-format` configuration file for `clang-format` tool (enforcing the code style).
* Format the C++ sources according to the `.clang-format` file and update the file itself if needed.
* Enable the `clang-format` tool as a build step.