### PR TITLE
Update target package intrinsic names

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "Microsoft.Quantum.Sdk": "0.18.2107151063-beta"
+        "Microsoft.Quantum.Sdk": "0.18.2108156289-beta"
     }
 }

--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.18.2107151063-beta" />
+    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.18.2108156289-beta" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
+++ b/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.18.2107151063-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.18.2108156289-beta" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
   </ItemGroup>
 

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyControlledX.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyControlledX.qs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// CNOT(control, target);
     /// ```
-    @TargetInstruction("cnot")
+    @TargetInstruction("cnot__body")
     internal operation ApplyControlledX (control : Qubit, target : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyControlledZ.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyControlledZ.qs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// Controlled Z([control], target);
     /// ```
-    @TargetInstruction("cz")
+    @TargetInstruction("cz__body")
     internal operation ApplyControlledZ (control : Qubit, target : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledH.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledH.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
-    @TargetInstruction("h")
+    @TargetInstruction("h__body")
     internal operation ApplyUncontrolledH (qubit : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRx.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRx.qs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// R(PauliX, theta, qubit);
     /// ```
-    @TargetInstruction("rx")
+    @TargetInstruction("rx__body")
     internal operation ApplyUncontrolledRx (theta : Double, qubit : Qubit) : Unit {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRy.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRy.qs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// R(PauliY, theta, qubit);
     /// ```
-    @TargetInstruction("ry")
+    @TargetInstruction("ry__body")
     internal operation ApplyUncontrolledRy (theta : Double, qubit : Qubit) : Unit {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRz.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRz.qs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// R(PauliZ, theta, qubit);
     /// ```
-    @TargetInstruction("rz")
+    @TargetInstruction("rz__body")
     internal operation ApplyUncontrolledRz (theta : Double, qubit : Qubit) : Unit {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledS.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledS.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
-    @TargetInstruction("s")
+    @TargetInstruction("s__body")
     internal operation ApplyUncontrolledS (qubit : Qubit) : Unit {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledSAdj.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledSAdj.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
-    @TargetInstruction("sadj")
+    @TargetInstruction("s__adj")
     internal operation ApplyUncontrolledSAdj (qubit : Qubit) : Unit {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledSWAP.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledSWAP.qs
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// CNOT(qubit2, qubit1);
     /// CNOT(qubit1, qubit2);
     /// ```
-    @TargetInstruction("swap")
+    @TargetInstruction("swap__body")
     operation ApplyUncontrolledSWAP (qubit1 : Qubit, qubit2 : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledT.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledT.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
-    @TargetInstruction("t")
+    @TargetInstruction("t__body")
     internal operation ApplyUncontrolledT (qubit : Qubit) : Unit {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledTAdj.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledTAdj.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
-    @TargetInstruction("tadj")
+    @TargetInstruction("t__adj")
     internal operation ApplyUncontrolledTAdj (qubit : Qubit) : Unit {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledX.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledX.qs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
-    @TargetInstruction("x")
+    @TargetInstruction("x__body")
     internal operation ApplyUncontrolledX (qubit : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledY.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledY.qs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
-    @TargetInstruction("y")
+    @TargetInstruction("y__body")
     internal operation ApplyUncontrolledY (qubit : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledZ.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledZ.qs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
-    @TargetInstruction("z")
+    @TargetInstruction("z__body")
     internal operation ApplyUncontrolledZ (qubit : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Intrinsic/IsingXX.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/IsingXX.qs
@@ -25,7 +25,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The first qubit input to the gate.
     /// ## qubit1
     /// The second qubit input to the gate.
-    @TargetInstruction("xx")
     internal operation IsingXX (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/IsingYY.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/IsingYY.qs
@@ -25,7 +25,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The first qubit input to the gate.
     /// ## qubit1
     /// The second qubit input to the gate.
-    @TargetInstruction("yy")
     internal operation IsingYY (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body intrinsic;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/IsingZZ.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/IsingZZ.qs
@@ -25,7 +25,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The first qubit input to the gate.
     /// ## qubit1
     /// The second qubit input to the gate.
-    @TargetInstruction("zz")
     internal operation IsingZZ (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body intrinsic;
     }


### PR DESCRIPTION
This updates the custom instruction names set by the `TargetInstruction` attribute in the Type1, Type2, and Type3 target packages so that they match the naming conventions in the QIR spec. This will avoid unnecessary duplication of instructions, such as `__quantum__qis__x__body` vs `__quantum__qis__x`.