### PR TITLE
Build QIR entry points in series instead of in parallel

### DIFF
--- a/src/Qir/Tools/QirTools.cs
+++ b/src/Qir/Tools/QirTools.cs
@@ -37,15 +37,14 @@ namespace Microsoft.Quantum.Qir.Runtime.Tools
 
             executablesDirectory.Create();
 
-            // Concurrently build an executable for each entry point operation.
-            var tasks = EntryPointLoader.LoadEntryPointOperations(qsharpDll).Select(entryPointOp =>
+            // Build an executable for each entry point operation. The builds must run one at a time because they write
+            // to the same intermediate files.
+            foreach (var entryPointOp in EntryPointLoader.LoadEntryPointOperations(qsharpDll))
             {
                 var exeFileInfo = new FileInfo(Path.Combine(executablesDirectory.FullName, $"{entryPointOp.Name}.exe"));
                 var exe = new QirFullStateExecutable(exeFileInfo, qirContentStream.ToArray());
-                return exe.BuildAsync(entryPointOp, libraryDirectories, includeDirectories);
-            });
-            
-            await Task.WhenAll(tasks);
+                await exe.BuildAsync(entryPointOp, libraryDirectories, includeDirectories);
+            }
 
             // ToDo: Return list of created file names
         }


### PR DESCRIPTION
Running `qir-cli` on a Q# project with multiple entry points fails non-deterministically because each build is trying to write to the same files simultaneously (src/driver.cpp and src/qir.bc). If they run in parallel, they need to use different intermediate files or coordinate somehow. A simple solution for now is to just run the builds in series.