### PR TITLE
Fixing use of `mutex()` to avoid subtle bug

### DIFF
--- a/src/Simulation/Native/src/simulator/simulator.hpp
+++ b/src/Simulation/Native/src/simulator/simulator.hpp
@@ -131,19 +131,19 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 #define GATE1IMPL(OP)                                                                                                  \
     void OP(logical_qubit_id q)                                                                                        \
     {                                                                                                                  \
-        recursive_lock_type l(mutex());                                                                                \
+        recursive_lock_type l(getmutex());                                                                                \
         psi.apply(Gates::OP(q));                                                                                       \
     }
 #define GATE1CIMPL(OP)                                                                                                 \
     void C##OP(logical_qubit_id c, logical_qubit_id q)                                                                 \
     {                                                                                                                  \
-        recursive_lock_type l(mutex());                                                                                \
+        recursive_lock_type l(getmutex());                                                                                \
         psi.apply_controlled(c, Gates::OP(q));                                                                         \
     }
 #define GATE1MCIMPL(OP)                                                                                                \
     void C##OP(std::vector<logical_qubit_id> const& c, logical_qubit_id q)                                             \
     {                                                                                                                  \
-        recursive_lock_type l(mutex());                                                                                \
+        recursive_lock_type l(getmutex());                                                                                \
         psi.apply_controlled(c, Gates::OP(q));                                                                         \
     }
 #define GATE1(OP) GATE1IMPL(OP) GATE1CIMPL(OP) GATE1MCIMPL(OP)
@@ -167,19 +167,19 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 #define GATE1IMPL(OP)                                                                                                  \
     void OP(double phi, logical_qubit_id q)                                                                            \
     {                                                                                                                  \
-        recursive_lock_type l(mutex());                                                                                \
+        recursive_lock_type l(getmutex());                                                                                \
         psi.apply(Gates::OP(phi, q));                                                                                  \
     }
 #define GATE1CIMPL(OP)                                                                                                 \
     void C##OP(double phi, logical_qubit_id c, logical_qubit_id q)                                                     \
     {                                                                                                                  \
-        recursive_lock_type l(mutex());                                                                                \
+        recursive_lock_type l(getmutex());                                                                                \
         psi.apply_controlled(c, Gates::OP(phi, q));                                                                    \
     }
 #define GATE1MCIMPL(OP)                                                                                                \
     void C##OP(double phi, std::vector<logical_qubit_id> const& c, logical_qubit_id q)                                 \
     {                                                                                                                  \
-        recursive_lock_type l(mutex());                                                                                \
+        recursive_lock_type l(getmutex());                                                                                \
         psi.apply_controlled(c, Gates::OP(phi, q));                                                                    \
     }
 #define GATE1(OP) GATE1IMPL(OP) GATE1CIMPL(OP) GATE1MCIMPL(OP)

--- a/src/Simulation/Native/src/simulator/simulator.hpp
+++ b/src/Simulation/Native/src/simulator/simulator.hpp
@@ -32,7 +32,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     std::size_t random(std::vector<double> const& d)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         std::discrete_distribution<std::size_t> dist(d.begin(), d.end());
         return dist(psi.rng());
     }
@@ -40,7 +40,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
     std::size_t random(std::size_t n, double* d)
     {
         std::discrete_distribution<std::size_t> dist(d, d + n);
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         return dist(psi.rng());
     }
 
@@ -52,7 +52,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
             return 0.0;
         }
 
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         changebasis(bs, qs, true);
         double p = psi.jointprobability(qs);
         changebasis(bs, qs, false);
@@ -61,20 +61,20 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     bool InjectState(const std::vector<logical_qubit_id>& qubits, const std::vector<ComplexType>& amplitudes)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         return psi.inject_state(qubits, amplitudes);
     }
 
     bool isclassical(logical_qubit_id q)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         return psi.isclassical(q);
     }
 
     // allocate and release
     logical_qubit_id allocate()
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         return psi.allocate_qubit();
     }
 
@@ -82,7 +82,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
     {
         std::vector<logical_qubit_id> qubits;
         qubits.reserve(n);
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
 
         for (unsigned i = 0; i < n; ++i)
         {
@@ -93,20 +93,20 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     void allocateQubit(logical_qubit_id q)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         psi.allocate_qubit(q);
     }
 
     void allocateQubit(std::vector<logical_qubit_id> const& qubits)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         for (auto q : qubits)
             psi.allocate_qubit(q);
     }
 
     bool release(logical_qubit_id q)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         flush();
         bool allok = isclassical(q);
         if (allok)
@@ -119,7 +119,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     bool release(std::vector<logical_qubit_id> const& qs)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         bool allok = true;
         for (auto q : qs)
             allok = release(q) && allok;
@@ -196,14 +196,14 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
     // rotations
     void R(Gates::Basis b, double phi, logical_qubit_id q)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         psi.apply(Gates::R(b, phi, q));
     }
 
     // multi-controlled rotations
     void CR(Gates::Basis b, double phi, std::vector<logical_qubit_id> const& c, logical_qubit_id q)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         psi.apply_controlled(c, Gates::R(b, phi, q));
     }
 
@@ -219,7 +219,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
         logical_qubit_id somequbit = qs.front();
         removeIdentities(bs, qs);
 
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         if (bs.size() == 0)
             CR(Gates::PauliI, -2. * phi, cs, somequbit);
         else if (bs.size() == 1)
@@ -230,7 +230,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     void Exp(std::vector<Gates::Basis> const& bs, double phi, std::vector<logical_qubit_id> const& qs)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         CExp(bs, phi, std::vector<logical_qubit_id>(), qs);
     }
 
@@ -238,14 +238,14 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     bool M(logical_qubit_id q)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         return psi.measure(q);
     }
 
     std::vector<bool> MultiM(std::vector<logical_qubit_id> const& qs)
     {
         // ***TODO*** optimized implementation
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         std::vector<bool> res;
         for (auto q : qs)
             res.push_back(psi.measure(q));
@@ -254,7 +254,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     bool Measure(std::vector<Gates::Basis> bs, std::vector<logical_qubit_id> qs)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         removeIdentities(bs, qs);
         // ***TODO*** optimized kernels
         changebasis(bs, qs, true);
@@ -265,34 +265,34 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     void seed(unsigned s)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         psi.seed(s);
     }
     void reset()
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         psi.reset();
     }
 
     unsigned num_qubits() const
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         return psi.num_qubits();
     }
     void flush()
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         psi.flush();
     }
     ComplexType const* data() const
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         return psi.data().data();
     }
 
     void dump(bool (*callback)(size_t, double, double))
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         flush();
 
         auto wfn = psi.data();
@@ -315,7 +315,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
 
     void dumpIds(void (*callback)(logical_qubit_id))
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         flush();
 
         std::vector<logical_qubit_id> qubits = psi.get_qubit_ids();
@@ -381,13 +381,13 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
         assert(std::accumulate(test.begin(), test.end(), 0u) == table_size);
 #endif
 
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         psi.permute_basis(qs, table_size, permutation_table, adjoint);
     }
 
     bool subsytemwavefunction(std::vector<logical_qubit_id> const& qs, WavefunctionStorage& qubitswfn, double tolerance)
     {
-        recursive_lock_type l(mutex());
+        recursive_lock_type l(getmutex());
         flush();
         return psi.subsytemwavefunction(qs, qubitswfn, tolerance);
     }

--- a/src/Simulation/Native/src/simulator/simulatorinterface.hpp
+++ b/src/Simulation/Native/src/simulator/simulatorinterface.hpp
@@ -124,7 +124,7 @@ class SimulatorInterface
         throw std::runtime_error("this simulator does not support permutation oracle emulation");
     };
 
-    recursive_mutex_type& mutex() const
+    recursive_mutex_type& getmutex() const
     {
         return *mutex_ptr;
     }


### PR DESCRIPTION
This change fixes what seems to be a subtle bug in the syncrhonization mechanisms for the simulator. In particular, we have seen intermediate failures in the simulator tests that seem to be the result of a simulator thread stepping on another thread. As @kuzminrobin pointed out in https://github.com/microsoft/qsharp-runtime/pull/710#discussion_r646051059, this could be due to the fact that the mutex access method, `mutex()` has the same signature as the standard constructor for mutex. This could mean that if the compilation environment has a `using namespace std;` anwhere in it that the calls to `mutex()` would allocate a fresh mutex rather than access the member mutex, meaning none of the threads are synchronized as expected. This avoid the problem by renaming the accessor to `getmutex()`.