### PR TITLE
Azure Quantum client: Add environment variable to set User-Agent prefix

### DIFF
--- a/src/Azure/Azure.Quantum.Client.Test/WorkspaceTest.cs
+++ b/src/Azure/Azure.Quantum.Client.Test/WorkspaceTest.cs
@@ -195,6 +195,9 @@ Tests will be marked as Inconclusive if the pre-reqs are not correctly setup.";
                 Assert.Inconclusive(SETUP);
             }
 
+            var options = new QuantumJobClientOptions();
+            options.Diagnostics.ApplicationId = Environment.GetEnvironmentVariable("AZURE_QUANTUM_NET_APPID") ?? "ClientTests";
+
             var credential = Authentication.CredentialFactory.CreateCredential(Authentication.CredentialType.Default);
 
             return new Workspace(
@@ -202,8 +205,8 @@ Tests will be marked as Inconclusive if the pre-reqs are not correctly setup.";
                 resourceGroupName: System.Environment.GetEnvironmentVariable("AZUREQUANTUM_WORKSPACE_RG"),
                 workspaceName: System.Environment.GetEnvironmentVariable("AZUREQUANTUM_WORKSPACE_NAME"),
                 location: System.Environment.GetEnvironmentVariable("AZUREQUANTUM_WORKSPACE_LOCATION"),
-                credential: credential,
-                userAgentPrefix: "ClientTests");
+                options: options,
+                credential: credential);
         }
 
         private static JobDetails CreateJobDetails(string jobId, string containerUri = null, string inputUri = null)

--- a/src/Azure/Azure.Quantum.Client.Test/WorkspaceTest.cs
+++ b/src/Azure/Azure.Quantum.Client.Test/WorkspaceTest.cs
@@ -195,9 +195,6 @@ Tests will be marked as Inconclusive if the pre-reqs are not correctly setup.";
                 Assert.Inconclusive(SETUP);
             }
 
-            var options = new QuantumJobClientOptions();
-            options.Diagnostics.ApplicationId = "ClientTests";
-
             var credential = Authentication.CredentialFactory.CreateCredential(Authentication.CredentialType.Default);
 
             return new Workspace(
@@ -205,8 +202,8 @@ Tests will be marked as Inconclusive if the pre-reqs are not correctly setup.";
                 resourceGroupName: System.Environment.GetEnvironmentVariable("AZUREQUANTUM_WORKSPACE_RG"),
                 workspaceName: System.Environment.GetEnvironmentVariable("AZUREQUANTUM_WORKSPACE_NAME"),
                 location: System.Environment.GetEnvironmentVariable("AZUREQUANTUM_WORKSPACE_LOCATION"),
-                options: options,
-                credential: credential);
+                credential: credential,
+                userAgentPrefix: "ClientTests");
         }
 
         private static JobDetails CreateJobDetails(string jobId, string containerUri = null, string inputUri = null)

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -40,8 +40,7 @@ namespace Microsoft.Azure.Quantum
             string workspaceName,
             string location,
             TokenCredential credential = null,
-            QuantumJobClientOptions options = default,
-            string userAgentPrefix = null)
+            QuantumJobClientOptions options = default)
         {
             // Required parameters:
             Ensure.NotNullOrWhiteSpace(subscriptionId, nameof(subscriptionId));
@@ -52,7 +51,7 @@ namespace Microsoft.Azure.Quantum
             // Optional parameters:
             credential ??= CredentialFactory.CreateCredential(CredentialType.Default, subscriptionId);
             options ??= new QuantumJobClientOptions();
-            options.Diagnostics.ApplicationId = userAgentPrefix 
+            options.Diagnostics.ApplicationId = options.Diagnostics.ApplicationId
                                                 ?? Environment.GetEnvironmentVariable("AZURE_QUANTUM_NET_APPID");
 
             this.ResourceGroupName = resourceGroupName;

--- a/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
+++ b/src/Azure/Azure.Quantum.Client/JobManagement/Workspace.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Azure.Quantum
             string workspaceName,
             string location,
             TokenCredential credential = null,
-            QuantumJobClientOptions options = default)
+            QuantumJobClientOptions options = default,
+            string userAgentPrefix = null)
         {
             // Required parameters:
             Ensure.NotNullOrWhiteSpace(subscriptionId, nameof(subscriptionId));
@@ -51,6 +52,8 @@ namespace Microsoft.Azure.Quantum
             // Optional parameters:
             credential ??= CredentialFactory.CreateCredential(CredentialType.Default, subscriptionId);
             options ??= new QuantumJobClientOptions();
+            options.Diagnostics.ApplicationId = userAgentPrefix 
+                                                ?? Environment.GetEnvironmentVariable("AZURE_QUANTUM_NET_APPID");
 
             this.ResourceGroupName = resourceGroupName;
             this.WorkspaceName = workspaceName;


### PR DESCRIPTION
Fallback the optional `QuantumJobClientOptions.Diagnostics.ApplicationId` to the environment variable `AZURE_QUANTUM_NET_APPID` to set the User-Agent prefix (useful for hosted environments).

Also gave preference to use the `AZURE_QUANTUM_NET_APPID` env var in the unit tests and fallback to the static value "ClientTests".