### PR TITLE
Fix Microsoft.Quantum.Qir.Runtime package

### DIFF
--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\Simulation\Common\AssemblyCommon.props" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION
This change fixes the Microsoft.Quantum.Qir.Runtime package by importing the appropriate AssemblyCommon.props.