### PR TITLE
Fix link to Binder to use new URL format

### DIFF
--- a/src/Qir/Tests/QIR-dynamic/qsharp/qir-test-assert.qs
+++ b/src/Qir/Tests/QIR-dynamic/qsharp/qir-test-assert.qs
@@ -172,7 +172,7 @@ namespace Microsoft.Quantum.Testing.QIR  {
     // Multiple qubits:
 
     // Quantum Katas, Joint Measurement Workbook,
-    //  https://mybinder.org/v2/gh/microsoft/QuantumKatas/HEAD?filepath=JointMeasurements%2FWorkbook_JointMeasurements.ipynb
+    //  https://mybinder.org/v2/gh/microsoft/QuantumKatas/main?urlpath=/notebooks/JointMeasurements%2FWorkbook_JointMeasurements.ipynb
 
     //  Task 1. Single-qubit measurement
     //  Task 2. Parity measurement


### PR DESCRIPTION
See https://discourse.jupyter.org/t/mybinder-org-using-jupyterlab-by-default/10715 for the announcement of the breaking change; old URL formats with filepath give 404 error.