### PR TITLE
Use single dash for single letter command line options in QIR driver generator

### DIFF
--- a/src/Qir/Tests/Tools/QirDriverGeneratorTests.cs
+++ b/src/Qir/Tests/Tools/QirDriverGeneratorTests.cs
@@ -182,49 +182,54 @@ namespace Tests.Microsoft.Quantum.Qir.Runtime.Tools
         }
 
         [Theory]
-        [MemberData(nameof(GenerateCommandLineArgumentsData))]
+        [MemberData(nameof(CommandLineArgumentsData))]
         public void GenerateCommandLineArguments(string expected, ExecutionInformation info)
         {
             var generator = new QirFullStateDriverGenerator(false);
             Assert.Equal(expected, generator.GetCommandLineArguments(info));
         }
 
-        public static IEnumerable<object[]> GenerateCommandLineArgumentsData()
+        public static IEnumerable<object[]> CommandLineArgumentsData
         {
-            static object[] TestCase(
-                string expected, List<Parameter> parameters, Dictionary<string, ArgumentValue> arguments) =>
-                new object[]
-                {
-                    expected,
-                    new ExecutionInformation
+            get
+            {
+                static object[] TestCase(
+                    string expected, List<Parameter> parameters, Dictionary<string, ArgumentValue> arguments) =>
+                    new object[]
                     {
-                        EntryPoint = new EntryPointOperation { Parameters = parameters },
-                        ArgumentValues = arguments
-                    }
-                };
+                        expected,
+                        new ExecutionInformation
+                        {
+                            EntryPoint = new EntryPointOperation { Parameters = parameters },
+                            ArgumentValues = arguments
+                        }
+                    };
 
-            yield return TestCase(
-                "--foo 5",
-                new List<Parameter> { new Parameter { Name = "foo", Position = 0, Type = DataType.IntegerType } },
-                new Dictionary<string, ArgumentValue> { ["foo"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 } });
+                yield return TestCase(
+                    "--foo 5",
+                    new List<Parameter> { new Parameter { Name = "foo", Position = 0, Type = DataType.IntegerType } },
+                    new Dictionary<string, ArgumentValue>
+                        { ["foo"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 } });
 
-            yield return TestCase(
-                "-n 5",
-                new List<Parameter> { new Parameter { Name = "n", Position = 0, Type = DataType.IntegerType } },
-                new Dictionary<string, ArgumentValue> { ["n"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 } });
+                yield return TestCase(
+                    "-n 5",
+                    new List<Parameter> { new Parameter { Name = "n", Position = 0, Type = DataType.IntegerType } },
+                    new Dictionary<string, ArgumentValue>
+                        { ["n"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 } });
 
-            yield return TestCase(
-                "--foo 5 --bar \"abc\"",
-                new List<Parameter>
-                {
-                    new Parameter { Name = "bar", Position = 1, Type = DataType.StringType },
-                    new Parameter { Name = "foo", Position = 0, Type = DataType.IntegerType }
-                },
-                new Dictionary<string, ArgumentValue>
-                {
-                    ["bar"] = new ArgumentValue { Type = DataType.StringType, String = "abc" },
-                    ["foo"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 }
-                });
+                yield return TestCase(
+                    "--foo 5 --bar \"abc\"",
+                    new List<Parameter>
+                    {
+                        new Parameter { Name = "bar", Position = 1, Type = DataType.StringType },
+                        new Parameter { Name = "foo", Position = 0, Type = DataType.IntegerType }
+                    },
+                    new Dictionary<string, ArgumentValue>
+                    {
+                        ["bar"] = new ArgumentValue { Type = DataType.StringType, String = "abc" },
+                        ["foo"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 }
+                    });
+            }
         }
     }
 }

--- a/src/Qir/Tests/Tools/QirDriverGeneratorTests.cs
+++ b/src/Qir/Tests/Tools/QirDriverGeneratorTests.cs
@@ -180,5 +180,51 @@ namespace Tests.Microsoft.Quantum.Qir.Runtime.Tools
             Assert.Equal(verificationCppSourceCode, generatedCppSourceCode);
             generatedStream.Close();
         }
+
+        [Theory]
+        [MemberData(nameof(GenerateCommandLineArgumentsData))]
+        public void GenerateCommandLineArguments(string expected, ExecutionInformation info)
+        {
+            var generator = new QirFullStateDriverGenerator(false);
+            Assert.Equal(expected, generator.GetCommandLineArguments(info));
+        }
+
+        public static IEnumerable<object[]> GenerateCommandLineArgumentsData()
+        {
+            static object[] TestCase(
+                string expected, List<Parameter> parameters, Dictionary<string, ArgumentValue> arguments) =>
+                new object[]
+                {
+                    expected,
+                    new ExecutionInformation
+                    {
+                        EntryPoint = new EntryPointOperation { Parameters = parameters },
+                        ArgumentValues = arguments
+                    }
+                };
+
+            yield return TestCase(
+                "--foo 5",
+                new List<Parameter> { new Parameter { Name = "foo", Position = 0, Type = DataType.IntegerType } },
+                new Dictionary<string, ArgumentValue> { ["foo"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 } });
+
+            yield return TestCase(
+                "-n 5",
+                new List<Parameter> { new Parameter { Name = "n", Position = 0, Type = DataType.IntegerType } },
+                new Dictionary<string, ArgumentValue> { ["n"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 } });
+
+            yield return TestCase(
+                "--foo 5 --bar \"abc\"",
+                new List<Parameter>
+                {
+                    new Parameter { Name = "bar", Position = 1, Type = DataType.StringType },
+                    new Parameter { Name = "foo", Position = 0, Type = DataType.IntegerType }
+                },
+                new Dictionary<string, ArgumentValue>
+                {
+                    ["bar"] = new ArgumentValue { Type = DataType.StringType, String = "abc" },
+                    ["foo"] = new ArgumentValue { Type = DataType.IntegerType, Integer = 5 }
+                });
+        }
     }
 }

--- a/src/Qir/Tools/Driver/QirCppDriverGenerator.cs
+++ b/src/Qir/Tools/Driver/QirCppDriverGenerator.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Quantum.Qir.Runtime.Tools.Driver
 
         public string GetCommandLineArguments(ExecutionInformation executionInformation)
         {
-            string Argument(Parameter param)
+            string ToArgument(Parameter param)
             {
                 var prefix = param.Name.Length > 1 ? "--" : "-";
                 var value = GetArgumentValueString(param, executionInformation.ArgumentValues[param.Name]);
@@ -41,7 +41,7 @@ namespace Microsoft.Quantum.Qir.Runtime.Tools.Driver
             }
 
             var parameters = executionInformation.EntryPoint.Parameters.OrderBy(param => param.Position);
-            return string.Join(" ", parameters.Select(Argument));
+            return string.Join(" ", parameters.Select(ToArgument));
         }
 
         private static string GetArgumentValueString(Parameter argument, ArgumentValue argumentValue)

--- a/src/Qir/Tools/Driver/QirCppDriverGenerator.cs
+++ b/src/Qir/Tools/Driver/QirCppDriverGenerator.cs
@@ -33,20 +33,15 @@ namespace Microsoft.Quantum.Qir.Runtime.Tools.Driver
 
         public string GetCommandLineArguments(ExecutionInformation executionInformation)
         {
-            // Sort arguments by position.
-            var sortedArguments = executionInformation.EntryPoint.Parameters.OrderBy(arg => arg.Position);
-            var argumentBuilder = new StringBuilder();
-            foreach (var arg in sortedArguments)
+            string Argument(Parameter param)
             {
-                if (argumentBuilder.Length != 0)
-                {
-                    argumentBuilder.Append(' ');
-                }
-
-                argumentBuilder.Append($"--{arg.Name}").Append(' ').Append(GetArgumentValueString(arg, executionInformation.ArgumentValues[arg.Name]));
+                var prefix = param.Name.Length > 1 ? "--" : "-";
+                var value = GetArgumentValueString(param, executionInformation.ArgumentValues[param.Name]);
+                return $"{prefix}{param.Name} {value}";
             }
 
-            return argumentBuilder.ToString();
+            var parameters = executionInformation.EntryPoint.Parameters.OrderBy(param => param.Position);
+            return string.Join(" ", parameters.Select(Argument));
         }
 
         private static string GetArgumentValueString(Parameter argument, ArgumentValue argumentValue)


### PR DESCRIPTION
This fixes an issue when using the full state simulator in Azure, where the generated entry point expects `-x` but it is invoked with the argument string `--x`.