### PR TITLE
Make `QirFullStateExecutable` constructor public again

### DIFF
--- a/src/Qir/Tools/Executable/QirFullStateExecutable.cs
+++ b/src/Qir/Tools/Executable/QirFullStateExecutable.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Qir.Runtime.Tools.Executable
 
         public override IList<DirectoryInfo> LibraryDirectories { get; } = new List<DirectoryInfo>();
 
-        internal QirFullStateExecutable(FileInfo executableFile, byte[] qirBitcode, bool debug, ILogger? logger = null)
+        public QirFullStateExecutable(FileInfo executableFile, byte[] qirBitcode, bool debug, ILogger? logger = null)
             : base(executableFile, qirBitcode, new QirFullStateDriverGenerator(debug), logger)
         {
             var thisModulePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);


### PR DESCRIPTION
In #807, I made the constructor for `QirFullStateExecutable` internal, which was a mistake because it needs to be called by the Azure Quantum service.