### PR TITLE
Update QIR Runtime to use QubitIdType

### DIFF
--- a/src/Qir/Common/Include/SimulatorStub.hpp
+++ b/src/Qir/Common/Include/SimulatorStub.hpp
@@ -13,101 +13,101 @@ namespace Quantum
         : public IRuntimeDriver
         , public IQuantumGateSet
     {
-        Qubit AllocateQubit() override
+        QubitIdType AllocateQubit() override
         {
             throw std::logic_error("not_implemented: AllocateQubit");
         }
-        void ReleaseQubit(Qubit /* qubit */) override
+        void ReleaseQubit(QubitIdType /* qubit */) override
         {
             throw std::logic_error("not_implemented: ReleaseQubit");
         }
-        virtual std::string QubitToString(Qubit /* qubit */) override
+        virtual std::string QubitToString(QubitIdType /* qubit */) override
         {
             throw std::logic_error("not_implemented: QubitToString");
         }
-        void X(Qubit /*target*/) override
+        void X(QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: X");
         }
-        void Y(Qubit /*target*/) override
+        void Y(QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: Y");
         }
-        void Z(Qubit /* target */) override
+        void Z(QubitIdType /* target */) override
         {
             throw std::logic_error("not_implemented: Z");
         }
-        void H(Qubit /*target*/) override
+        void H(QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: H");
         }
-        void S(Qubit /*target*/) override
+        void S(QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: S");
         }
-        void T(Qubit /*target*/) override
+        void T(QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: T");
         }
-        void R(PauliId /* axis */, Qubit /* target */, double /* theta */) override
+        void R(PauliId /* axis */, QubitIdType /* target */, double /* theta */) override
         {
             throw std::logic_error("not_implemented: R");
         }
-        void Exp(long /* numTargets */, PauliId* /* paulis */, Qubit* /* targets */, double /* theta */) override
+        void Exp(long /* numTargets */, PauliId* /* paulis */, QubitIdType* /* targets */, double /* theta */) override
         {
             throw std::logic_error("not_implemented: Exp");
         }
-        void ControlledX(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledX(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: ControlledX");
         }
-        void ControlledY(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledY(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: ControlledY");
         }
-        void ControlledZ(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledZ(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: ControlledZ");
         }
-        void ControlledH(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledH(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: ControlledH");
         }
-        void ControlledS(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledS(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: ControlledS");
         }
-        void ControlledT(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledT(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: ControlledT");
         }
-        void ControlledR(long /*numControls*/, Qubit* /*controls*/, PauliId /*axis*/, Qubit /*target*/,
+        void ControlledR(long /*numControls*/, QubitIdType* /*controls*/, PauliId /*axis*/, QubitIdType /*target*/,
                          double /*theta*/) override
         {
             throw std::logic_error("not_implemented: ControlledR");
         }
-        void ControlledExp(long /*numControls*/, Qubit* /*controls*/, long /*numTargets*/, PauliId* /*paulis*/,
-                           Qubit* /*targets*/, double /*theta*/) override
+        void ControlledExp(long /*numControls*/, QubitIdType* /*controls*/, long /*numTargets*/, PauliId* /*paulis*/,
+                           QubitIdType* /*targets*/, double /*theta*/) override
         {
             throw std::logic_error("not_implemented: ControlledExp");
         }
-        void AdjointS(Qubit /*target*/) override
+        void AdjointS(QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: AdjointS");
         }
-        void AdjointT(Qubit /*target*/) override
+        void AdjointT(QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: AdjointT");
         }
-        void ControlledAdjointS(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledAdjointS(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: ControlledAdjointS");
         }
-        void ControlledAdjointT(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledAdjointT(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("not_implemented: ControlledAdjointT");
         }
-        Result Measure(long /*numBases*/, PauliId* /*bases*/, long /*numTargets*/, Qubit* /*targets*/) override
+        Result Measure(long /*numBases*/, PauliId* /*bases*/, long /*numTargets*/, QubitIdType* /*targets*/) override
         {
             throw std::logic_error("not_implemented: Measure");
         }

--- a/src/Qir/Runtime/lib/QIR/QubitManager.cpp
+++ b/src/Qir/Runtime/lib/QIR/QubitManager.cpp
@@ -70,8 +70,7 @@ namespace Quantum
         firstElement              = id;           // The new element is now the first in the chain.
     }
 
-    CQubitManager::QubitIdType CQubitManager::QubitListInSharedArray::TakeQubitFromFront(
-        QubitIdType* sharedQbitStatusArray)
+    QubitIdType CQubitManager::QubitListInSharedArray::TakeQubitFromFront(QubitIdType* sharedQbitStatusArray)
     {
         FailIf(sharedQbitStatusArray == nullptr, "Shared status array is not provided.");
 
@@ -241,14 +240,14 @@ namespace Quantum
                                                                 sharedQubitStatusArray);
     }
 
-    Qubit CQubitManager::Allocate()
+    QubitIdType CQubitManager::Allocate()
     {
         QubitIdType newQubitId = AllocateQubitId();
         FailIf(newQubitId == NoneMarker, "Not enough qubits.");
-        return CreateQubitObject(newQubitId);
+        return newQubitId;
     }
 
-    void CQubitManager::Allocate(Qubit* qubitsToAllocate, int32_t qubitCountToAllocate)
+    void CQubitManager::Allocate(QubitIdType* qubitsToAllocate, QubitIdType qubitCountToAllocate)
     {
         if (qubitCountToAllocate == 0)
         {
@@ -258,76 +257,73 @@ namespace Quantum
         FailIf(qubitsToAllocate == nullptr, "No array provided for qubits to be allocated.");
 
         // Consider optimization for initial allocation of a large array at once
-        for (int32_t i = 0; i < qubitCountToAllocate; i++)
+        for (QubitIdType i = 0; i < qubitCountToAllocate; i++)
         {
             QubitIdType newQubitId = AllocateQubitId();
             if (newQubitId == NoneMarker)
             {
-                for (int32_t k = 0; k < i; k++)
+                for (QubitIdType k = 0; k < i; k++)
                 {
                     Release(qubitsToAllocate[k]);
                 }
                 FailNow("Not enough qubits.");
             }
-            qubitsToAllocate[i] = CreateQubitObject(newQubitId);
+            qubitsToAllocate[i] = newQubitId;
         }
     }
 
-    void CQubitManager::Release(Qubit qubit)
+    void CQubitManager::Release(QubitIdType qubit)
     {
         FailIf(!IsValidQubit(qubit), "Qubit is not valid.");
-        ReleaseQubitId(QubitToId(qubit));
-        DeleteQubitObject(qubit);
+        ReleaseQubitId(qubit);
     }
 
-    void CQubitManager::Release(Qubit* qubitsToRelease, int32_t qubitCountToRelease)
+    void CQubitManager::Release(QubitIdType* qubitsToRelease, QubitIdType qubitCountToRelease)
     {
         if (qubitCountToRelease == 0)
         {
             return;
         }
-        FailIf(qubitCountToRelease < 0, "Cannot release negative number of qubits.");
         FailIf(qubitsToRelease == nullptr, "No array provided with qubits to be released.");
 
-        for (int32_t i = 0; i < qubitCountToRelease; i++)
+        for (QubitIdType i = 0; i < qubitCountToRelease; i++)
         {
             Release(qubitsToRelease[i]);
-            qubitsToRelease[i] = nullptr;
+            qubitsToRelease[i] = 0;
         }
     }
 
-    Qubit CQubitManager::Borrow()
+    QubitIdType CQubitManager::Borrow()
     {
         // We don't support true borrowing/returning at the moment.
         return Allocate();
     }
 
-    void CQubitManager::Borrow(Qubit* qubitsToBorrow, int32_t qubitCountToBorrow)
+    void CQubitManager::Borrow(QubitIdType* qubitsToBorrow, QubitIdType qubitCountToBorrow)
     {
         // We don't support true borrowing/returning at the moment.
         return Allocate(qubitsToBorrow, qubitCountToBorrow);
     }
 
-    void CQubitManager::Return(Qubit qubit)
+    void CQubitManager::Return(QubitIdType qubit)
     {
         // We don't support true borrowing/returning at the moment.
         Release(qubit);
     }
 
-    void CQubitManager::Return(Qubit* qubitsToReturn, int32_t qubitCountToReturn)
+    void CQubitManager::Return(QubitIdType* qubitsToReturn, QubitIdType qubitCountToReturn)
     {
         // We don't support true borrowing/returning at the moment.
         Release(qubitsToReturn, qubitCountToReturn);
     }
 
-    void CQubitManager::Disable(Qubit qubit)
+    void CQubitManager::Disable(QubitIdType qubit)
     {
         FailIf(!IsValidQubit(qubit), "Qubit is not valid.");
-        QubitIdType id = QubitToId(qubit);
 
         // We can only disable explicitly allocated qubits that were not borrowed.
-        FailIf(!IsExplicitlyAllocatedId(id), "Cannot disable qubit that is not explicitly allocated.");
-        sharedQubitStatusArray[id] = DisabledMarker;
+        FailIf(!IsExplicitlyAllocatedId(qubit), "Cannot disable qubit that is not explicitly allocated.");
+        sharedQubitStatusArray[qubit] = DisabledMarker;
 
         disabledQubitCount++;
         FailIf(disabledQubitCount <= 0, "Incorrect disabled qubit count.");
@@ -335,16 +331,15 @@ namespace Quantum
         FailIf(allocatedQubitCount < 0, "Incorrect allocated qubit count.");
     }
 
-    void CQubitManager::Disable(Qubit* qubitsToDisable, int32_t qubitCountToDisable)
+    void CQubitManager::Disable(QubitIdType* qubitsToDisable, QubitIdType qubitCountToDisable)
     {
         if (qubitCountToDisable == 0)
         {
             return;
         }
-        FailIf(qubitCountToDisable < 0, "Cannot disable negative number of qubits.");
         FailIf(qubitsToDisable == nullptr, "No array provided with qubits to be disabled.");
 
-        for (int32_t i = 0; i < qubitCountToDisable; i++)
+        for (QubitIdType i = 0; i < qubitCountToDisable; i++)
         {
             Disable(qubitsToDisable[i]);
         }
@@ -371,53 +366,24 @@ namespace Quantum
     }
 
 
-    bool CQubitManager::IsValidQubit(Qubit qubit) const
+    bool CQubitManager::IsValidQubit(QubitIdType qubit) const
     {
-        return IsValidId(QubitToId(qubit));
+        return IsValidId(qubit);
     }
 
-    bool CQubitManager::IsDisabledQubit(Qubit qubit) const
+    bool CQubitManager::IsDisabledQubit(QubitIdType qubit) const
     {
-        return IsValidQubit(qubit) && IsDisabledId(QubitToId(qubit));
+        return IsValidQubit(qubit) && IsDisabledId(qubit);
     }
 
-    bool CQubitManager::IsExplicitlyAllocatedQubit(Qubit qubit) const
+    bool CQubitManager::IsExplicitlyAllocatedQubit(QubitIdType qubit) const
     {
-        return IsValidQubit(qubit) && IsExplicitlyAllocatedId(QubitToId(qubit));
+        return IsValidQubit(qubit) && IsExplicitlyAllocatedId(qubit);
     }
 
     bool CQubitManager::IsFreeQubitId(QubitIdType id) const
     {
         return IsValidId(id) && IsFreeId(id);
-    }
-
-    CQubitManager::QubitIdType CQubitManager::GetQubitId(Qubit qubit) const
-    {
-        FailIf(!IsValidQubit(qubit), "Not a valid qubit.");
-        return QubitToId(qubit);
-    }
-
-
-    Qubit CQubitManager::CreateQubitObject(QubitIdType id)
-    {
-        // Make sure the static_cast won't overflow:
-        FailIf(id < 0 || id >= MaximumQubitCapacity, "Qubit id is out of range.");
-        intptr_t pointerSizedId = static_cast<intptr_t>(id);
-        return reinterpret_cast<Qubit>(pointerSizedId);
-    }
-
-    void CQubitManager::DeleteQubitObject(Qubit /*qubit*/)
-    {
-        // Do nothing. By default we store qubit Id in place of a pointer to a qubit.
-    }
-
-    CQubitManager::QubitIdType CQubitManager::QubitToId(Qubit qubit) const
-    {
-        intptr_t pointerSizedId = reinterpret_cast<intptr_t>(qubit);
-        // Make sure the static_cast won't overflow:
-        FailIf(pointerSizedId < 0 || pointerSizedId > std::numeric_limits<QubitIdType>::max(),
-               "Qubit id is out of range.");
-        return static_cast<QubitIdType>(pointerSizedId);
     }
 
     void CQubitManager::EnsureCapacity(QubitIdType requestedCapacity)
@@ -444,7 +410,7 @@ namespace Quantum
         freeQubitsInAreas[0].FreeQubitsReuseAllowed.MoveAllQubitsFrom(newFreeQubits, sharedQubitStatusArray);
     }
 
-    CQubitManager::QubitIdType CQubitManager::TakeFreeQubitId()
+    QubitIdType CQubitManager::TakeFreeQubitId()
     {
         // First we try to take qubit from the current (innermost) area.
         QubitIdType id = freeQubitsInAreas.PeekBack().FreeQubitsReuseAllowed.TakeQubitFromFront(sharedQubitStatusArray);
@@ -476,7 +442,7 @@ namespace Quantum
         return id;
     }
 
-    CQubitManager::QubitIdType CQubitManager::AllocateQubitId()
+    QubitIdType CQubitManager::AllocateQubitId()
     {
         QubitIdType newQubitId = TakeFreeQubitId();
         if (newQubitId == NoneMarker && mayExtendCapacity)
@@ -491,7 +457,7 @@ namespace Quantum
 
     void CQubitManager::ReleaseQubitId(QubitIdType id)
     {
-        FailIf(id < 0 || id >= qubitCapacity, "Internal Error: Cannot release an invalid qubit.");
+        FailIf(id >= qubitCapacity, "Internal Error: Cannot release an invalid qubit.");
         if (IsDisabledId(id))
         {
             // Nothing to do. Qubit will stay disabled.

--- a/src/Qir/Runtime/lib/QIR/QubitManager.cpp
+++ b/src/Qir/Runtime/lib/QIR/QubitManager.cpp
@@ -457,7 +457,7 @@ namespace Quantum
 
     void CQubitManager::ReleaseQubitId(QubitIdType id)
     {
-        FailIf(id >= qubitCapacity, "Internal Error: Cannot release an invalid qubit.");
+        FailIf(id < 0 || id >= qubitCapacity, "Internal Error: Cannot release an invalid qubit.");
         if (IsDisabledId(id))
         {
             // Nothing to do. Qubit will stay disabled.

--- a/src/Qir/Runtime/lib/QIR/arrays.cpp
+++ b/src/Qir/Runtime/lib/QIR/arrays.cpp
@@ -43,7 +43,7 @@ int QirArray::Release()
     {
         if (ownsQubits)
         {
-            delete[](reinterpret_cast<Qubit*>(this->buffer));
+            delete[](reinterpret_cast<QubitIdType*>(this->buffer));
         }
         else
         {
@@ -62,10 +62,10 @@ QirArray::QirArray(TItemCount qubitsCount)
 {
     if (this->count > 0)
     {
-        Qubit* qbuffer = new Qubit[count];
+        QubitIdType* qbuffer = new QubitIdType[count];
         for (TItemCount i = 0; i < count; i++)
         {
-            qbuffer[i] = __quantum__rt__qubit_allocate();
+            qbuffer[i] = reinterpret_cast<QubitIdType>(__quantum__rt__qubit_allocate());
         }
         this->buffer = reinterpret_cast<char*>(qbuffer);
     }
@@ -263,10 +263,10 @@ extern "C"
         assert(qa->ownsQubits);
         if (qa->ownsQubits)
         {
-            Qubit* qubits = reinterpret_cast<Qubit*>(qa->buffer);
+            QubitIdType* qubits = reinterpret_cast<QubitIdType*>(qa->buffer);
             for (QirArray::TItemCount i = 0; i < qa->count; i++)
             {
-                __quantum__rt__qubit_release(qubits[i]);
+                __quantum__rt__qubit_release(reinterpret_cast<QUBIT*>(qubits[i]));
             }
         }
 

--- a/src/Qir/Runtime/lib/QIR/delegated.cpp
+++ b/src/Qir/Runtime/lib/QIR/delegated.cpp
@@ -45,12 +45,12 @@ extern "C"
 
     QUBIT* __quantum__rt__qubit_allocate()
     {
-        return Microsoft::Quantum::GlobalContext()->GetDriver()->AllocateQubit();
+        return reinterpret_cast<QUBIT*>(Microsoft::Quantum::GlobalContext()->GetDriver()->AllocateQubit());
     }
 
     void __quantum__rt__qubit_release(QUBIT* qubit)
     {
-        Microsoft::Quantum::GlobalContext()->GetDriver()->ReleaseQubit(qubit);
+        Microsoft::Quantum::GlobalContext()->GetDriver()->ReleaseQubit(reinterpret_cast<QubitIdType>(qubit));
     }
 
     QUBIT* __quantum__rt__qubit_borrow()
@@ -149,7 +149,9 @@ extern "C"
     // Returns a string representation of the qubit.
     QirString* __quantum__rt__qubit_to_string(QUBIT* qubit) // NOLINT
     {
-        return __quantum__rt__string_create(
-            Microsoft::Quantum::GlobalContext()->GetDriver()->QubitToString(qubit).c_str());
+        return __quantum__rt__string_create(Microsoft::Quantum::GlobalContext()
+                                                ->GetDriver()
+                                                ->QubitToString(reinterpret_cast<QubitIdType>(qubit))
+                                                .c_str());
     }
 }

--- a/src/Qir/Runtime/lib/QSharpCore/intrinsics.cpp
+++ b/src/Qir/Runtime/lib/QSharpCore/intrinsics.cpp
@@ -43,7 +43,7 @@ extern "C"
 
         std::vector<PauliId> pauliIds = ExtractPauliIds(paulis);
         GateSet()->Exp((long)(paulis->count), reinterpret_cast<PauliId*>(pauliIds.data()),
-                       reinterpret_cast<Qubit*>(qubits->buffer), angle);
+                       reinterpret_cast<QubitIdType*>(qubits->buffer), angle);
     }
 
     void __quantum__qis__exp__adj(QirArray* paulis, double angle, QirArray* qubits)
@@ -56,9 +56,9 @@ extern "C"
         assert(args->paulis->count == args->targets->count);
 
         std::vector<PauliId> pauliIds = ExtractPauliIds(args->paulis);
-        GateSet()->ControlledExp((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer),
+        GateSet()->ControlledExp((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
                                  (long)(args->paulis->count), reinterpret_cast<PauliId*>(pauliIds.data()),
-                                 reinterpret_cast<Qubit*>(args->targets->buffer), args->angle);
+                                 reinterpret_cast<QubitIdType*>(args->targets->buffer), args->angle);
     }
 
     void __quantum__qis__exp__ctladj(QirArray* ctls, QirExpTuple* args)
@@ -70,14 +70,15 @@ extern "C"
         __quantum__qis__exp__ctl(ctls, &updatedArgs);
     }
 
-    void __quantum__qis__h__body(Qubit qubit)
+    void __quantum__qis__h__body(QUBIT* qubit)
     {
-        GateSet()->H(qubit);
+        GateSet()->H(reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__h__ctl(QirArray* ctls, Qubit qubit)
+    void __quantum__qis__h__ctl(QirArray* ctls, QUBIT* qubit)
     {
-        GateSet()->ControlledH((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledH((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                               reinterpret_cast<QubitIdType>(qubit));
     }
 
     Result __quantum__qis__measure__body(QirArray* paulis, QirArray* qubits)
@@ -87,12 +88,12 @@ extern "C"
 
         std::vector<PauliId> pauliIds = ExtractPauliIds(paulis);
         return GateSet()->Measure((long)(count), reinterpret_cast<PauliId*>(pauliIds.data()), (long)(count),
-                                  reinterpret_cast<Qubit*>(qubits->buffer));
+                                  reinterpret_cast<QubitIdType*>(qubits->buffer));
     }
 
     void __quantum__qis__r__body(PauliId axis, double angle, QUBIT* qubit)
     {
-        GateSet()->R(axis, qubit, angle);
+        GateSet()->R(axis, reinterpret_cast<QubitIdType>(qubit), angle);
     }
 
     void __quantum__qis__r__adj(PauliId axis, double angle, QUBIT* qubit)
@@ -102,83 +103,90 @@ extern "C"
 
     void __quantum__qis__r__ctl(QirArray* ctls, QirRTuple* args)
     {
-        GateSet()->ControlledR((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), args->pauli, args->target,
-                               args->angle);
+        GateSet()->ControlledR((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer), args->pauli,
+                               reinterpret_cast<QubitIdType>(args->target), args->angle);
     }
 
     void __quantum__qis__r__ctladj(QirArray* ctls, QirRTuple* args)
     {
-        GateSet()->ControlledR((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), args->pauli, args->target,
-                               -(args->angle));
+        GateSet()->ControlledR((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer), args->pauli,
+                               reinterpret_cast<QubitIdType>(args->target), -(args->angle));
     }
 
-    void __quantum__qis__s__body(Qubit qubit)
+    void __quantum__qis__s__body(QUBIT* qubit)
     {
-        GateSet()->S(qubit);
+        GateSet()->S(reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__s__adj(Qubit qubit)
+    void __quantum__qis__s__adj(QUBIT* qubit)
     {
-        GateSet()->AdjointS(qubit);
+        GateSet()->AdjointS(reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__s__ctl(QirArray* ctls, Qubit qubit)
+    void __quantum__qis__s__ctl(QirArray* ctls, QUBIT* qubit)
     {
-        GateSet()->ControlledS((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledS((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                               reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__s__ctladj(QirArray* ctls, Qubit qubit)
+    void __quantum__qis__s__ctladj(QirArray* ctls, QUBIT* qubit)
     {
-        GateSet()->ControlledAdjointS((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledAdjointS((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                                      reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__t__body(Qubit qubit)
+    void __quantum__qis__t__body(QUBIT* qubit)
     {
-        GateSet()->T(qubit);
+        GateSet()->T(reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__t__adj(Qubit qubit)
+    void __quantum__qis__t__adj(QUBIT* qubit)
     {
-        GateSet()->AdjointT(qubit);
+        GateSet()->AdjointT(reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__t__ctl(QirArray* ctls, Qubit qubit)
+    void __quantum__qis__t__ctl(QirArray* ctls, QUBIT* qubit)
     {
-        GateSet()->ControlledT((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledT((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                               reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__t__ctladj(QirArray* ctls, Qubit qubit)
+    void __quantum__qis__t__ctladj(QirArray* ctls, QUBIT* qubit)
     {
-        GateSet()->ControlledAdjointT((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledAdjointT((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                                      reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__x__body(Qubit qubit)
+    void __quantum__qis__x__body(QUBIT* qubit)
     {
-        GateSet()->X(qubit);
+        GateSet()->X(reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__x__ctl(QirArray* ctls, Qubit qubit)
+    void __quantum__qis__x__ctl(QirArray* ctls, QUBIT* qubit)
     {
-        GateSet()->ControlledX((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledX((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                               reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__y__body(Qubit qubit)
+    void __quantum__qis__y__body(QUBIT* qubit)
     {
-        GateSet()->Y(qubit);
+        GateSet()->Y(reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__y__ctl(QirArray* ctls, Qubit qubit)
+    void __quantum__qis__y__ctl(QirArray* ctls, QUBIT* qubit)
     {
-        GateSet()->ControlledY((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledY((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                               reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__z__body(Qubit qubit)
+    void __quantum__qis__z__body(QUBIT* qubit)
     {
-        GateSet()->Z(qubit);
+        GateSet()->Z(reinterpret_cast<QubitIdType>(qubit));
     }
 
-    void __quantum__qis__z__ctl(QirArray* ctls, Qubit qubit)
+    void __quantum__qis__z__ctl(QirArray* ctls, QUBIT* qubit)
     {
-        GateSet()->ControlledZ((long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), qubit);
+        GateSet()->ControlledZ((long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                               reinterpret_cast<QubitIdType>(qubit));
     }
 }

--- a/src/Qir/Runtime/lib/QSharpFoundation/AssertMeasurement.cpp
+++ b/src/Qir/Runtime/lib/QSharpFoundation/AssertMeasurement.cpp
@@ -41,7 +41,7 @@ extern "C"
         }
 
         if (!GetDiagnostics()->AssertProbability((long)qubits->count, paulis.data(),
-                                                 reinterpret_cast<Qubit*>(qubits->GetItemPointer(0)), prob, tol,
+                                                 reinterpret_cast<QubitIdType*>(qubits->GetItemPointer(0)), prob, tol,
                                                  nullptr))
         {
             __quantum__rt__fail(msg);

--- a/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
@@ -232,7 +232,7 @@ namespace Quantum
 
         virtual std::string QubitToString(QubitIdType q) override
         {
-            return std::to_string(GetQubitId(q));
+            return std::to_string(q);
         }
 
         void DumpMachine(const void* location) override;

--- a/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/FullstateSimulator.cpp
@@ -136,13 +136,13 @@ namespace Quantum
         // the QuantumSimulator expects contiguous ids, starting from 0
         std::unique_ptr<CQubitManager> qubitManager;
 
-        unsigned GetQubitId(Qubit qubit) const
+        unsigned GetQubitId(QubitIdType qubit) const
         {
-            // Qubit manager uses unsigned range of int32_t for qubit ids.
-            return static_cast<unsigned>(qubitManager->GetQubitId(qubit));
+            // Qubit manager uses unsigned range of intptr_t for qubit ids.
+            return static_cast<unsigned>(qubit);
         }
 
-        std::vector<unsigned> GetQubitIds(long num, Qubit* qubits) const
+        std::vector<unsigned> GetQubitIds(long num, QubitIdType* qubits) const
         {
             std::vector<unsigned> ids;
             ids.reserve((size_t)num);
@@ -177,12 +177,12 @@ namespace Quantum
             return proc;
         }
 
-        void UnmarkAsMeasuredSingleQubit(Qubit q)
+        void UnmarkAsMeasuredSingleQubit(QubitIdType q)
         {
             isMeasured[GetQubitId(q)] = false;
         }
 
-        void UnmarkAsMeasuredQubitList(long num, Qubit* qubit)
+        void UnmarkAsMeasuredQubitList(long num, QubitIdType* qubit)
         {
             for (const auto& id : GetQubitIds(num, qubit))
             {
@@ -230,7 +230,7 @@ namespace Quantum
             dump(this->simulatorId, callback);
         }
 
-        virtual std::string QubitToString(Qubit q) override
+        virtual std::string QubitToString(QubitIdType q) override
         {
             return std::to_string(GetQubitId(q));
         }
@@ -238,14 +238,14 @@ namespace Quantum
         void DumpMachine(const void* location) override;
         void DumpRegister(const void* location, const QirArray* qubits) override;
 
-        Qubit AllocateQubit() override
+        QubitIdType AllocateQubit() override
         {
             typedef void (*TAllocateQubit)(unsigned, unsigned);
             static TAllocateQubit allocateQubit = reinterpret_cast<TAllocateQubit>(this->GetProc("allocateQubit"));
 
-            Qubit q     = qubitManager->Allocate(); // Allocate qubit in qubit manager.
-            unsigned id = GetQubitId(q);            // Get its id.
-            allocateQubit(this->simulatorId, id);   // Allocate it in the simulator.
+            QubitIdType q = qubitManager->Allocate(); // Allocate qubit in qubit manager.
+            unsigned id   = GetQubitId(q);            // Get its id.
+            allocateQubit(this->simulatorId, id);     // Allocate it in the simulator.
             if (isMeasured.size() < id + 1)
             {
                 isMeasured.resize(id + 1, false);
@@ -253,7 +253,7 @@ namespace Quantum
             return q;
         }
 
-        void ReleaseQubit(Qubit q) override
+        void ReleaseQubit(QubitIdType q) override
         {
             typedef bool (*TReleaseQubit)(unsigned, unsigned);
             static TReleaseQubit releaseQubit = reinterpret_cast<TReleaseQubit>(this->GetProc("release"));
@@ -286,7 +286,7 @@ namespace Quantum
             qubitManager->EndRestrictedReuseArea();
         }
 
-        Result Measure(long numBases, PauliId bases[], long numTargets, Qubit targets[]) override
+        Result Measure(long numBases, PauliId bases[], long numTargets, QubitIdType targets[]) override
         {
             assert(numBases == numTargets);
             typedef unsigned (*TMeasure)(unsigned, unsigned, unsigned*, unsigned*);
@@ -329,14 +329,14 @@ namespace Quantum
             return (r1 == r2);
         }
 
-        void X(Qubit q) override
+        void X(QubitIdType q) override
         {
             static TSingleQubitGate op = reinterpret_cast<TSingleQubitGate>(this->GetProc("X"));
             op(this->simulatorId, GetQubitId(q));
             UnmarkAsMeasuredSingleQubit(q);
         }
 
-        void ControlledX(long numControls, Qubit controls[], Qubit target) override
+        void ControlledX(long numControls, QubitIdType controls[], QubitIdType target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCX"));
             std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
@@ -345,14 +345,14 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void Y(Qubit q) override
+        void Y(QubitIdType q) override
         {
             static TSingleQubitGate op = reinterpret_cast<TSingleQubitGate>(this->GetProc("Y"));
             op(this->simulatorId, GetQubitId(q));
             UnmarkAsMeasuredSingleQubit(q);
         }
 
-        void ControlledY(long numControls, Qubit controls[], Qubit target) override
+        void ControlledY(long numControls, QubitIdType controls[], QubitIdType target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCY"));
             std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
@@ -361,14 +361,14 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void Z(Qubit q) override
+        void Z(QubitIdType q) override
         {
             static TSingleQubitGate op = reinterpret_cast<TSingleQubitGate>(this->GetProc("Z"));
             op(this->simulatorId, GetQubitId(q));
             UnmarkAsMeasuredSingleQubit(q);
         }
 
-        void ControlledZ(long numControls, Qubit controls[], Qubit target) override
+        void ControlledZ(long numControls, QubitIdType controls[], QubitIdType target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCZ"));
             std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
@@ -377,14 +377,14 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void H(Qubit q) override
+        void H(QubitIdType q) override
         {
             static TSingleQubitGate op = reinterpret_cast<TSingleQubitGate>(this->GetProc("H"));
             op(this->simulatorId, GetQubitId(q));
             UnmarkAsMeasuredSingleQubit(q);
         }
 
-        void ControlledH(long numControls, Qubit controls[], Qubit target) override
+        void ControlledH(long numControls, QubitIdType controls[], QubitIdType target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCH"));
             std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
@@ -393,14 +393,14 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void S(Qubit q) override
+        void S(QubitIdType q) override
         {
             static TSingleQubitGate op = reinterpret_cast<TSingleQubitGate>(this->GetProc("S"));
             op(this->simulatorId, GetQubitId(q));
             UnmarkAsMeasuredSingleQubit(q);
         }
 
-        void ControlledS(long numControls, Qubit controls[], Qubit target) override
+        void ControlledS(long numControls, QubitIdType controls[], QubitIdType target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCS"));
             std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
@@ -409,14 +409,14 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void AdjointS(Qubit q) override
+        void AdjointS(QubitIdType q) override
         {
             static TSingleQubitGate op = reinterpret_cast<TSingleQubitGate>(this->GetProc("AdjS"));
             op(this->simulatorId, GetQubitId(q));
             UnmarkAsMeasuredSingleQubit(q);
         }
 
-        void ControlledAdjointS(long numControls, Qubit controls[], Qubit target) override
+        void ControlledAdjointS(long numControls, QubitIdType controls[], QubitIdType target) override
         {
             static TSingleQubitControlledGate op =
                 reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCAdjS"));
@@ -426,14 +426,14 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void T(Qubit q) override
+        void T(QubitIdType q) override
         {
             static TSingleQubitGate op = reinterpret_cast<TSingleQubitGate>(this->GetProc("T"));
             op(this->simulatorId, GetQubitId(q));
             UnmarkAsMeasuredSingleQubit(q);
         }
 
-        void ControlledT(long numControls, Qubit controls[], Qubit target) override
+        void ControlledT(long numControls, QubitIdType controls[], QubitIdType target) override
         {
             static TSingleQubitControlledGate op = reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCT"));
             std::vector<unsigned> ids            = GetQubitIds(numControls, controls);
@@ -442,14 +442,14 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void AdjointT(Qubit q) override
+        void AdjointT(QubitIdType q) override
         {
             static TSingleQubitGate op = reinterpret_cast<TSingleQubitGate>(this->GetProc("AdjT"));
             op(this->simulatorId, GetQubitId(q));
             UnmarkAsMeasuredSingleQubit(q);
         }
 
-        void ControlledAdjointT(long numControls, Qubit controls[], Qubit target) override
+        void ControlledAdjointT(long numControls, QubitIdType controls[], QubitIdType target) override
         {
             static TSingleQubitControlledGate op =
                 reinterpret_cast<TSingleQubitControlledGate>(this->GetProc("MCAdjT"));
@@ -459,7 +459,7 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void R(PauliId axis, Qubit target, double theta) override
+        void R(PauliId axis, QubitIdType target, double theta) override
         {
             typedef unsigned (*TR)(unsigned, unsigned, double, unsigned);
             static TR r = reinterpret_cast<TR>(this->GetProc("R"));
@@ -468,7 +468,8 @@ namespace Quantum
             UnmarkAsMeasuredSingleQubit(target);
         }
 
-        void ControlledR(long numControls, Qubit controls[], PauliId axis, Qubit target, double theta) override
+        void ControlledR(long numControls, QubitIdType controls[], PauliId axis, QubitIdType target,
+                         double theta) override
         {
             typedef unsigned (*TMCR)(unsigned, unsigned, double, unsigned, unsigned*, unsigned);
             static TMCR cr = reinterpret_cast<TMCR>(this->GetProc("MCR"));
@@ -479,7 +480,7 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        void Exp(long numTargets, PauliId paulis[], Qubit targets[], double theta) override
+        void Exp(long numTargets, PauliId paulis[], QubitIdType targets[], double theta) override
         {
             typedef unsigned (*TExp)(unsigned, unsigned, unsigned*, double, unsigned*);
             static TExp exp                      = reinterpret_cast<TExp>(this->GetProc("Exp"));
@@ -489,8 +490,8 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numTargets, targets);
         }
 
-        void ControlledExp(long numControls, Qubit controls[], long numTargets, PauliId paulis[], Qubit targets[],
-                           double theta) override
+        void ControlledExp(long numControls, QubitIdType controls[], long numTargets, PauliId paulis[],
+                           QubitIdType targets[], double theta) override
         {
             typedef unsigned (*TMCExp)(unsigned, unsigned, unsigned*, double, unsigned, unsigned*, unsigned*);
             static TMCExp cexp                   = reinterpret_cast<TMCExp>(this->GetProc("MCExp"));
@@ -503,13 +504,14 @@ namespace Quantum
             UnmarkAsMeasuredQubitList(numControls, controls);
         }
 
-        bool Assert(long numTargets, PauliId* bases, Qubit* targets, Result result, const char* failureMessage) override
+        bool Assert(long numTargets, PauliId* bases, QubitIdType* targets, Result result,
+                    const char* failureMessage) override
         {
             const double probabilityOfZero = AreEqualResults(result, UseZero()) ? 1.0 : 0.0;
             return AssertProbability(numTargets, bases, targets, probabilityOfZero, 1e-10, failureMessage);
         }
 
-        bool AssertProbability(long numTargets, PauliId bases[], Qubit targets[], double probabilityOfZero,
+        bool AssertProbability(long numTargets, PauliId bases[], QubitIdType targets[], double probabilityOfZero,
                                double precision, const char* /*failureMessage*/) override
         {
             typedef double (*TOp)(unsigned id, unsigned n, int* b, unsigned* q);
@@ -565,7 +567,7 @@ namespace Quantum
             {
                 outStream << "; ";
             }
-            outStream << (uintptr_t)((reinterpret_cast<Qubit*>(qubits->GetItemPointer(0)))[idx]);
+            outStream << (uintptr_t)((reinterpret_cast<QubitIdType*>(qubits->GetItemPointer(0)))[idx]);
         }
         outStream << ':' << std::endl;
 
@@ -581,7 +583,7 @@ namespace Quantum
                                             const QirArray* qubits)
     {
         std::vector<unsigned> ids =
-            GetQubitIds((long)(qubits->count), reinterpret_cast<Qubit*>(qubits->GetItemPointer(0)));
+            GetQubitIds((long)(qubits->count), reinterpret_cast<QubitIdType*>(qubits->GetItemPointer(0)));
         static TDumpQubitsToLocationAPI dumpQubitsToLocation =
             reinterpret_cast<TDumpQubitsToLocationAPI>(this->GetProc("DumpQubitsToLocation"));
         return dumpQubitsToLocation(this->simulatorId, (unsigned)(qubits->count), ids.data(), callback, location);

--- a/src/Qir/Runtime/lib/Simulators/ToffoliSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/ToffoliSimulator.cpp
@@ -73,7 +73,7 @@ namespace Quantum
             return retVal;
         }
 
-        void ReleaseQubit(QubitIdType qubit) override
+        void ReleaseQubit([[maybe_unused]] QubitIdType qubit) override
         {
             assert((qubit + 1) == this->nextQubitId);
             assert(!this->states.at(static_cast<size_t>(qubit)));

--- a/src/Qir/Runtime/lib/Simulators/ToffoliSimulator.cpp
+++ b/src/Qir/Runtime/lib/Simulators/ToffoliSimulator.cpp
@@ -23,8 +23,7 @@ namespace Quantum
         , public IQuantumGateSet
         , public IDiagnostics
     {
-        using QubitId       = uint64_t;
-        QubitId nextQubitId = 0;
+        QubitIdType nextQubitId = 0;
 
         // State of a qubit is represented by a bit in states indexed by qubit's id,
         // bits 0 and 1 correspond to |0> and |1> states respectively.
@@ -34,11 +33,6 @@ namespace Quantum
         // pointers to avoid allocation and deallocation.
         Result zero = reinterpret_cast<Result>(0xface0000);
         Result one  = reinterpret_cast<Result>(0xface1000);
-
-        static uint64_t GetQubitId(Qubit qubit)
-        {
-            return (uint64_t)qubit;
-        }
 
       public:
         CToffoliSimulator()           = default;
@@ -70,34 +64,32 @@ namespace Quantum
             return one;
         }
 
-        Qubit AllocateQubit() override
+        QubitIdType AllocateQubit() override
         {
-            Qubit retVal = (Qubit)(uintptr_t)(this->nextQubitId);
+            QubitIdType retVal = this->nextQubitId;
             ++(this->nextQubitId);
-            assert(this->nextQubitId < std::numeric_limits<QubitId>::max()); // Check aginast the risk of overflow.
+            assert(this->nextQubitId < std::numeric_limits<QubitIdType>::max()); // Check aginast the risk of overflow.
             this->states.emplace_back(false);
             return retVal;
         }
 
-        void ReleaseQubit(Qubit qubit) override
+        void ReleaseQubit(QubitIdType qubit) override
         {
-            [[maybe_unused]] const uint64_t id = GetQubitId(qubit);
-            assert((id + 1) == this->nextQubitId);
-            assert(!this->states.at(id));
+            assert((qubit + 1) == this->nextQubitId);
+            assert(!this->states.at(static_cast<size_t>(qubit)));
             --(this->nextQubitId);
             this->states.pop_back();
         }
 
-        std::string QubitToString(Qubit qubit) override
+        std::string QubitToString(QubitIdType qubit) override
         {
-            const uint64_t id = GetQubitId(qubit);
-            return std::to_string(id) + ":" + (this->states.at(id) ? "1" : "0");
+            return std::to_string(qubit) + ":" + (this->states.at(static_cast<size_t>(qubit)) ? "1" : "0");
         }
 
         ///
         /// Implementation of IDiagnostics
         ///
-        bool Assert(long numTargets, PauliId* bases, Qubit* targets, Result result,
+        bool Assert(long numTargets, PauliId* bases, QubitIdType* targets, Result result,
                     const char* /* failureMessage */) override
         {
             // Measurements in Toffoli simulator don't change the state.
@@ -105,7 +97,7 @@ namespace Quantum
             return AreEqualResults(result, Measure(numTargets, bases, numTargets, targets));
         }
 
-        bool AssertProbability(long numTargets, PauliId bases[], Qubit targets[], double probabilityOfZero,
+        bool AssertProbability(long numTargets, PauliId bases[], QubitIdType targets[], double probabilityOfZero,
                                double precision, const char* /* failureMessage */) override
         {
             assert(precision >= 0);
@@ -135,17 +127,17 @@ namespace Quantum
         ///
         /// Implementation of IQuantumGateSet
         ///
-        void X(Qubit qubit) override
+        void X(QubitIdType qubit) override
         {
-            this->states.at(GetQubitId(qubit)).flip();
+            this->states.at(static_cast<size_t>(qubit)).flip();
         }
 
-        void ControlledX(long numControls, Qubit* const controls, Qubit qubit) override
+        void ControlledX(long numControls, QubitIdType* const controls, QubitIdType qubit) override
         {
             bool allControlsSet = true;
             for (long i = 0; i < numControls; i++)
             {
-                if (!this->states.at(GetQubitId(controls[i])))
+                if (!this->states.at(static_cast<size_t>(controls[i])))
                 {
                     allControlsSet = false;
                     break;
@@ -154,12 +146,12 @@ namespace Quantum
 
             if (allControlsSet)
             {
-                this->states.at(GetQubitId(qubit)).flip();
+                this->states.at(static_cast<size_t>(qubit)).flip();
             }
         }
 
 
-        Result Measure(long numBases, PauliId bases[], long /* numTargets */, Qubit targets[]) override
+        Result Measure(long numBases, PauliId bases[], long /* numTargets */, QubitIdType targets[]) override
         {
             bool odd = false;
             for (long i = 0; i < numBases; i++)
@@ -170,7 +162,7 @@ namespace Quantum
                 }
                 if (bases[i] == PauliId_Z)
                 {
-                    odd ^= (this->states.at(GetQubitId(targets[i])));
+                    odd ^= (this->states.at(static_cast<size_t>(targets[i])));
                 }
             }
             return odd ? one : zero;
@@ -180,77 +172,77 @@ namespace Quantum
         //
         // The rest of the gate set Toffoli simulator doesn't support
         //
-        void Y(Qubit /*target*/) override
+        void Y(QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void Z(Qubit /*target*/) override
+        void Z(QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void H(Qubit /*target*/) override
+        void H(QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void S(Qubit /*target*/) override
+        void S(QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void T(Qubit /*target*/) override
+        void T(QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void R(PauliId /* axis */, Qubit /*target*/, double /* theta */) override
+        void R(PauliId /* axis */, QubitIdType /*target*/, double /* theta */) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void Exp(long /* numTargets */, PauliId* /* paulis */, Qubit* /*targets*/, double /* theta */) override
+        void Exp(long /* numTargets */, PauliId* /* paulis */, QubitIdType* /*targets*/, double /* theta */) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledY(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledY(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledZ(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledZ(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledH(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledH(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledS(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledS(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledT(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledT(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledR(long /*numControls*/, Qubit* /*controls*/, PauliId /*axis*/, Qubit /*target*/,
+        void ControlledR(long /*numControls*/, QubitIdType* /*controls*/, PauliId /*axis*/, QubitIdType /*target*/,
                          double /*theta*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledExp(long /*numControls*/, Qubit* /*controls*/, long /*numTargets*/, PauliId* /*paulis*/,
-                           Qubit* /*targets*/, double /* theta */) override
+        void ControlledExp(long /*numControls*/, QubitIdType* /*controls*/, long /*numTargets*/, PauliId* /*paulis*/,
+                           QubitIdType* /*targets*/, double /* theta */) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void AdjointS(Qubit /*target*/) override
+        void AdjointS(QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void AdjointT(Qubit /*target*/) override
+        void AdjointT(QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledAdjointS(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledAdjointS(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }
-        void ControlledAdjointT(long /*numControls*/, Qubit* /*controls*/, Qubit /*target*/) override
+        void ControlledAdjointT(long /*numControls*/, QubitIdType* /*controls*/, QubitIdType /*target*/) override
         {
             throw std::logic_error("operation_not_supported");
         }

--- a/src/Qir/Runtime/lib/Tracer/tracer-qis.cpp
+++ b/src/Qir/Runtime/lib/Tracer/tracer-qis.cpp
@@ -20,28 +20,28 @@ extern "C"
     {
     }
 
-    void __quantum__qis__swap(Qubit /*q1*/, Qubit /*q2*/) // NOLINT
+    void __quantum__qis__swap(QUBIT* /*q1*/, QUBIT* /*q2*/) // NOLINT
     {
     }
 
-    void __quantum__qis__single_qubit_op(int32_t id, int32_t duration, Qubit target) // NOLINT
+    void __quantum__qis__single_qubit_op(int32_t id, int32_t duration, QUBIT* target) // NOLINT
     {
-        (void)tracer->TraceSingleQubitOp(id, duration, target);
+        (void)tracer->TraceSingleQubitOp(id, duration, reinterpret_cast<QubitIdType>(target));
     }
-    void __quantum__qis__single_qubit_op_ctl(int32_t id, int32_t duration, QirArray* ctls, Qubit target) // NOLINT
+    void __quantum__qis__single_qubit_op_ctl(int32_t id, int32_t duration, QirArray* ctls, QUBIT* target) // NOLINT
     {
-        (void)tracer->TraceMultiQubitOp(id, duration, (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer), 1,
-                                        &target);
+        (void)tracer->TraceMultiQubitOp(id, duration, (long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                                        1, reinterpret_cast<QubitIdType*>(&target));
     }
     void __quantum__qis__multi_qubit_op(int32_t id, int32_t duration, QirArray* targets) // NOLINT
     {
         (void)tracer->TraceMultiQubitOp(id, duration, 0, nullptr, (long)(targets->count),
-                                        reinterpret_cast<Qubit*>(targets->buffer));
+                                        reinterpret_cast<QubitIdType*>(targets->buffer));
     }
     void __quantum__qis__multi_qubit_op_ctl(int32_t id, int32_t duration, QirArray* ctls, QirArray* targets) // NOLINT
     {
-        (void)tracer->TraceMultiQubitOp(id, duration, (long)(ctls->count), reinterpret_cast<Qubit*>(ctls->buffer),
-                                        (long)(targets->count), reinterpret_cast<Qubit*>(targets->buffer));
+        (void)tracer->TraceMultiQubitOp(id, duration, (long)(ctls->count), reinterpret_cast<QubitIdType*>(ctls->buffer),
+                                        (long)(targets->count), reinterpret_cast<QubitIdType*>(targets->buffer));
     }
 
     void __quantum__qis__inject_barrier(int32_t id, int32_t duration) // NOLINT
@@ -51,13 +51,13 @@ extern "C"
 
     RESULT* __quantum__qis__single_qubit_measure(int32_t id, int32_t duration, QUBIT* q) // NOLINT
     {
-        return tracer->TraceSingleQubitMeasurement(id, duration, q);
+        return tracer->TraceSingleQubitMeasurement(id, duration, reinterpret_cast<QubitIdType>(q));
     }
 
     RESULT* __quantum__qis__joint_measure(int32_t id, int32_t duration, QirArray* qs) // NOLINT
     {
         return tracer->TraceMultiQubitMeasurement(id, duration, (long)(qs->count),
-                                                  reinterpret_cast<Qubit*>(qs->buffer));
+                                                  reinterpret_cast<QubitIdType*>(qs->buffer));
     }
 
     void __quantum__qis__apply_conditionally( // NOLINT

--- a/src/Qir/Runtime/lib/Tracer/tracer-qis.hpp
+++ b/src/Qir/Runtime/lib/Tracer/tracer-qis.hpp
@@ -11,11 +11,11 @@ extern "C"
 {
     QIR_SHARED_API void __quantum__qis__on_operation_start(int64_t /* id */); // NOLINT
     QIR_SHARED_API void __quantum__qis__on_operation_end(int64_t /* id */);   // NOLINT
-    QIR_SHARED_API void __quantum__qis__swap(Qubit /*q1*/, Qubit /*q2*/);     // NOLINT
+    QIR_SHARED_API void __quantum__qis__swap(QUBIT* /*q1*/, QUBIT* /*q2*/);   // NOLINT
 
-    QIR_SHARED_API void __quantum__qis__single_qubit_op(int32_t id, int32_t duration, Qubit target); // NOLINT
-    QIR_SHARED_API void __quantum__qis__single_qubit_op_ctl(                                         // NOLINT
-        int32_t id, int32_t duration, QirArray* ctls, Qubit target);
+    QIR_SHARED_API void __quantum__qis__single_qubit_op(int32_t id, int32_t duration, QUBIT* target); // NOLINT
+    QIR_SHARED_API void __quantum__qis__single_qubit_op_ctl(                                          // NOLINT
+        int32_t id, int32_t duration, QirArray* ctls, QUBIT* target);
     QIR_SHARED_API void __quantum__qis__multi_qubit_op(int32_t id, int32_t duration, QirArray* targets); // NOLINT
     QIR_SHARED_API void __quantum__qis__multi_qubit_op_ctl(                                              // NOLINT
         int32_t id, int32_t duration, QirArray* ctls, QirArray* targets);

--- a/src/Qir/Runtime/lib/Tracer/tracer.cpp
+++ b/src/Qir/Runtime/lib/Tracer/tracer.cpp
@@ -37,22 +37,22 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer's IRuntimeDriver implementation
     //------------------------------------------------------------------------------------------------------------------
-    Qubit CTracer::AllocateQubit()
+    QubitIdType CTracer::AllocateQubit()
     {
         size_t qubit = qubits.size();
         qubits.emplace_back(QubitState{});
-        return reinterpret_cast<Qubit>(qubit);
+        return static_cast<QubitIdType>(qubit);
     }
 
-    void CTracer::ReleaseQubit(Qubit /*qubit*/)
+    void CTracer::ReleaseQubit(QubitIdType /*qubit*/)
     {
         // nothing for now
     }
 
     // TODO: what would be meaningful information we could printout for a qubit?
-    std::string CTracer::QubitToString(Qubit q)
+    std::string CTracer::QubitToString(QubitIdType q)
     {
-        size_t qubitIndex        = reinterpret_cast<size_t>(q);
+        size_t qubitIndex        = static_cast<size_t>(q);
         const QubitState& qstate = this->UseQubit(q);
 
         std::stringstream str(std::to_string(qubitIndex));
@@ -107,7 +107,7 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer::FindLayerToInsertOperationInto
     //------------------------------------------------------------------------------------------------------------------
-    LayerId CTracer::FindLayerToInsertOperationInto(Qubit q, Duration opDuration) const
+    LayerId CTracer::FindLayerToInsertOperationInto(QubitIdType q, Duration opDuration) const
     {
         const QubitState& qstate = this->UseQubit(q);
 
@@ -160,7 +160,7 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer::UpdateQubitState
     //------------------------------------------------------------------------------------------------------------------
-    void CTracer::UpdateQubitState(Qubit q, LayerId layer, Duration opDuration)
+    void CTracer::UpdateQubitState(QubitIdType q, LayerId layer, Duration opDuration)
     {
         QubitState& qstate = this->UseQubit(q);
         for (OpId idPending : qstate.pendingZeroDurationOps)
@@ -178,7 +178,7 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer::TraceSingleQubitOp
     //------------------------------------------------------------------------------------------------------------------
-    LayerId CTracer::TraceSingleQubitOp(OpId id, Duration opDuration, Qubit target)
+    LayerId CTracer::TraceSingleQubitOp(OpId id, Duration opDuration, QubitIdType target)
     {
         this->seenOps.insert(id);
 
@@ -207,8 +207,8 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer::TraceMultiQubitOp
     //------------------------------------------------------------------------------------------------------------------
-    LayerId CTracer::TraceMultiQubitOp(OpId id, Duration opDuration, long nFirstGroup, Qubit* firstGroup,
-                                       long nSecondGroup, Qubit* secondGroup)
+    LayerId CTracer::TraceMultiQubitOp(OpId id, Duration opDuration, long nFirstGroup, QubitIdType* firstGroup,
+                                       long nSecondGroup, QubitIdType* secondGroup)
     {
         assert(nFirstGroup >= 0);
         assert(nSecondGroup > 0);
@@ -270,7 +270,7 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer::TraceSingleQubitMeasurement
     //------------------------------------------------------------------------------------------------------------------
-    Result CTracer::TraceSingleQubitMeasurement(OpId id, Duration duration, Qubit target)
+    Result CTracer::TraceSingleQubitMeasurement(OpId id, Duration duration, QubitIdType target)
     {
         LayerId layerId = this->TraceSingleQubitOp(id, duration, target);
         return reinterpret_cast<Result>(layerId);
@@ -279,7 +279,7 @@ namespace Quantum
     //------------------------------------------------------------------------------------------------------------------
     // CTracer::TraceMultiQubitMeasurement
     //------------------------------------------------------------------------------------------------------------------
-    Result CTracer::TraceMultiQubitMeasurement(OpId id, Duration duration, long nTargets, Qubit* targets)
+    Result CTracer::TraceMultiQubitMeasurement(OpId id, Duration duration, long nTargets, QubitIdType* targets)
     {
         LayerId layerId = this->TraceMultiQubitOp(id, duration, 0, nullptr, nTargets, targets);
         return reinterpret_cast<Result>(layerId);

--- a/src/Qir/Runtime/lib/Tracer/tracer.hpp
+++ b/src/Qir/Runtime/lib/Tracer/tracer.hpp
@@ -96,21 +96,21 @@ namespace Quantum
         std::unordered_set<OpId> seenOps;
 
       private:
-        QubitState& UseQubit(Qubit q)
+        QubitState& UseQubit(QubitIdType q)
         {
-            size_t qubitIndex = reinterpret_cast<size_t>(q);
+            size_t qubitIndex = static_cast<size_t>(q);
             assert(qubitIndex < this->qubits.size());
             return this->qubits[qubitIndex];
         }
-        const QubitState& UseQubit(Qubit q) const
+        const QubitState& UseQubit(QubitIdType q) const
         {
-            size_t qubitIndex = reinterpret_cast<size_t>(q);
+            size_t qubitIndex = static_cast<size_t>(q);
             assert(qubitIndex < this->qubits.size());
             return this->qubits[qubitIndex];
         }
 
         // If no appropriate layer found, returns `REQUESTNEW`.
-        LayerId FindLayerToInsertOperationInto(Qubit q, Duration opDuration) const;
+        LayerId FindLayerToInsertOperationInto(QubitIdType q, Duration opDuration) const;
 
         // Returns the index of the created layer.
         LayerId CreateNewLayer(Duration minRequiredDuration);
@@ -119,7 +119,7 @@ namespace Quantum
         void AddOperationToLayer(OpId id, LayerId layer);
 
         // Update the qubit state with the new layer information.
-        void UpdateQubitState(Qubit q, LayerId layer, Duration opDuration);
+        void UpdateQubitState(QubitIdType q, LayerId layer, Duration opDuration);
 
         // Considers global barriers and conditional fences to find the fence currently in effect.
         LayerId GetEffectiveFence() const;
@@ -147,9 +147,9 @@ namespace Quantum
         // -------------------------------------------------------------------------------------------------------------
         // IRuntimeDriver interface
         // -------------------------------------------------------------------------------------------------------------
-        Qubit AllocateQubit() override;
-        void ReleaseQubit(Qubit qubit) override;
-        std::string QubitToString(Qubit qubit) override;
+        QubitIdType AllocateQubit() override;
+        void ReleaseQubit(QubitIdType qubit) override;
+        std::string QubitToString(QubitIdType qubit) override;
         void ReleaseResult(Result result) override;
 
         bool AreEqualResults(Result /*r1*/, Result /*r2*/) override
@@ -171,12 +171,12 @@ namespace Quantum
         // qubits into the same array. To avoid the copy, the tracer provides a method that takes two groups of qubits,
         // where the first one can be empty or can be viewed as the set of controls.
         // -------------------------------------------------------------------------------------------------------------
-        LayerId TraceSingleQubitOp(OpId id, Duration duration, Qubit target);
-        LayerId TraceMultiQubitOp(OpId id, Duration duration, long nFirstGroup, Qubit* firstGroup, long nSecondGroup,
-                                  Qubit* secondGroup);
+        LayerId TraceSingleQubitOp(OpId id, Duration duration, QubitIdType target);
+        LayerId TraceMultiQubitOp(OpId id, Duration duration, long nFirstGroup, QubitIdType* firstGroup,
+                                  long nSecondGroup, QubitIdType* secondGroup);
 
-        Result TraceSingleQubitMeasurement(OpId id, Duration duration, Qubit target);
-        Result TraceMultiQubitMeasurement(OpId id, Duration duration, long nTargets, Qubit* targets);
+        Result TraceSingleQubitMeasurement(OpId id, Duration duration, QubitIdType target);
+        Result TraceMultiQubitMeasurement(OpId id, Duration duration, long nTargets, QubitIdType* targets);
         LayerId GetLayerIdOfSourceMeasurement(Result r) const
         {
             return reinterpret_cast<LayerId>(r);

--- a/src/Qir/Runtime/public/CoreTypes.hpp
+++ b/src/Qir/Runtime/public/CoreTypes.hpp
@@ -33,7 +33,7 @@
 // is a unique type in the QIR.
 
 class QUBIT;
-typedef QUBIT* Qubit; // Not a pointer to a memory location, just an integer - qubit id.
+typedef intptr_t QubitIdType;
 
 class RESULT;
 typedef RESULT* Result; // TODO(rokuzmin): Replace with `typedef uintXX_t Result`, where XX is 8|16|32|64.

--- a/src/Qir/Runtime/public/CoreTypes.hpp
+++ b/src/Qir/Runtime/public/CoreTypes.hpp
@@ -26,8 +26,8 @@
   dereferenced in client's code.
 ==============================================================================*/
 
-// Although "Qubit" type is declared as a pointer to "QUBIT", it never points to an actual memory
-// and is never intended to be dereferenced anywhere - in the client code or in the runtime.
+// Although QIR uses an opaque pointer to the type "QUBIT", it never points to an actual memory
+// and is never intended to be dereferenced anywhere - in the client code or in our runtime.
 // Runtime always operates in terms of qubit ids, which are integers. Qubit ids are casted
 // to this pointer type and stored as pointer values. This is done to ensure that qubit type
 // is a unique type in the QIR.

--- a/src/Qir/Runtime/public/QSharpSimApi_I.hpp
+++ b/src/Qir/Runtime/public/QSharpSimApi_I.hpp
@@ -20,34 +20,35 @@ namespace Quantum
         IQuantumGateSet() = default;
 
         // Elementary operatons
-        virtual void X(Qubit target)                                                       = 0;
-        virtual void Y(Qubit target)                                                       = 0;
-        virtual void Z(Qubit target)                                                       = 0;
-        virtual void H(Qubit target)                                                       = 0;
-        virtual void S(Qubit target)                                                       = 0;
-        virtual void T(Qubit target)                                                       = 0;
-        virtual void R(PauliId axis, Qubit target, double theta)                           = 0;
-        virtual void Exp(long numTargets, PauliId paulis[], Qubit targets[], double theta) = 0;
+        virtual void X(QubitIdType target)                                                       = 0;
+        virtual void Y(QubitIdType target)                                                       = 0;
+        virtual void Z(QubitIdType target)                                                       = 0;
+        virtual void H(QubitIdType target)                                                       = 0;
+        virtual void S(QubitIdType target)                                                       = 0;
+        virtual void T(QubitIdType target)                                                       = 0;
+        virtual void R(PauliId axis, QubitIdType target, double theta)                           = 0;
+        virtual void Exp(long numTargets, PauliId paulis[], QubitIdType targets[], double theta) = 0;
 
         // Multicontrolled operations
-        virtual void ControlledX(long numControls, Qubit controls[], Qubit target)                             = 0;
-        virtual void ControlledY(long numControls, Qubit controls[], Qubit target)                             = 0;
-        virtual void ControlledZ(long numControls, Qubit controls[], Qubit target)                             = 0;
-        virtual void ControlledH(long numControls, Qubit controls[], Qubit target)                             = 0;
-        virtual void ControlledS(long numControls, Qubit controls[], Qubit target)                             = 0;
-        virtual void ControlledT(long numControls, Qubit controls[], Qubit target)                             = 0;
-        virtual void ControlledR(long numControls, Qubit controls[], PauliId axis, Qubit target, double theta) = 0;
-        virtual void ControlledExp(long numControls, Qubit controls[], long numTargets, PauliId paulis[],
-                                   Qubit targets[], double theta)                                              = 0;
+        virtual void ControlledX(long numControls, QubitIdType controls[], QubitIdType target) = 0;
+        virtual void ControlledY(long numControls, QubitIdType controls[], QubitIdType target) = 0;
+        virtual void ControlledZ(long numControls, QubitIdType controls[], QubitIdType target) = 0;
+        virtual void ControlledH(long numControls, QubitIdType controls[], QubitIdType target) = 0;
+        virtual void ControlledS(long numControls, QubitIdType controls[], QubitIdType target) = 0;
+        virtual void ControlledT(long numControls, QubitIdType controls[], QubitIdType target) = 0;
+        virtual void ControlledR(long numControls, QubitIdType controls[], PauliId axis, QubitIdType target,
+                                 double theta)                                                 = 0;
+        virtual void ControlledExp(long numControls, QubitIdType controls[], long numTargets, PauliId paulis[],
+                                   QubitIdType targets[], double theta)                        = 0;
 
         // Adjoint operations
-        virtual void AdjointS(Qubit target)                                               = 0;
-        virtual void AdjointT(Qubit target)                                               = 0;
-        virtual void ControlledAdjointS(long numControls, Qubit controls[], Qubit target) = 0;
-        virtual void ControlledAdjointT(long numControls, Qubit controls[], Qubit target) = 0;
+        virtual void AdjointS(QubitIdType target)                                                     = 0;
+        virtual void AdjointT(QubitIdType target)                                                     = 0;
+        virtual void ControlledAdjointS(long numControls, QubitIdType controls[], QubitIdType target) = 0;
+        virtual void ControlledAdjointT(long numControls, QubitIdType controls[], QubitIdType target) = 0;
 
         // Results
-        virtual Result Measure(long numBases, PauliId bases[], long numTargets, Qubit targets[]) = 0;
+        virtual Result Measure(long numBases, PauliId bases[], long numTargets, QubitIdType targets[]) = 0;
 
       private:
         IQuantumGateSet& operator=(const IQuantumGateSet&) = delete;
@@ -72,12 +73,12 @@ namespace Quantum
         virtual void DumpRegister(const void* location, const QirArray* qubits) = 0;
 
         // Both Assert methods return `true`, if the assert holds, `false` otherwise.
-        virtual bool Assert(long numTargets, PauliId bases[], Qubit targets[], Result result,
+        virtual bool Assert(long numTargets, PauliId bases[], QubitIdType targets[], Result result,
                             const char* failureMessage) = 0; // TODO: The `failureMessage` is not used, consider
                                                              // removing. The `bool` is returned.
 
-        virtual bool AssertProbability(long numTargets, PauliId bases[], Qubit targets[], double probabilityOfZero,
-                                       double precision,
+        virtual bool AssertProbability(long numTargets, PauliId bases[], QubitIdType targets[],
+                                       double probabilityOfZero, double precision,
                                        const char* failureMessage) = 0; // TODO: The `failureMessage` is not used,
                                                                         // consider removing. The `bool` is returned.
 

--- a/src/Qir/Runtime/public/QirRuntimeApi_I.hpp
+++ b/src/Qir/Runtime/public/QirRuntimeApi_I.hpp
@@ -19,11 +19,11 @@ namespace Quantum
         IRuntimeDriver() = default;
 
         // Doesn't necessarily provide insight into the state of the qubit (for that look at IDiagnostics)
-        virtual std::string QubitToString(Qubit qubit) = 0;
+        virtual std::string QubitToString(QubitIdType qubit) = 0;
 
         // Qubit management
-        virtual Qubit AllocateQubit()          = 0;
-        virtual void ReleaseQubit(Qubit qubit) = 0;
+        virtual QubitIdType AllocateQubit()          = 0;
+        virtual void ReleaseQubit(QubitIdType qubit) = 0;
 
         virtual void ReleaseResult(Result result)          = 0;
         virtual bool AreEqualResults(Result r1, Result r2) = 0;

--- a/src/Qir/Runtime/public/QubitManager.hpp
+++ b/src/Qir/Runtime/public/QubitManager.hpp
@@ -26,14 +26,12 @@ namespace Quantum
     class QIR_SHARED_API CQubitManager
     {
       public:
-        using QubitIdType = ::int32_t;
-
         // We want status array to be reasonably large.
         constexpr static QubitIdType DefaultQubitCapacity = 8;
 
-        // Indexes in the status array can potentially be in range 0 .. QubitIdType.MaxValue-1.
-        // This gives maximum capacity as QubitIdType.MaxValue. Actual configured capacity may be less than this.
-        // Index equal to QubitIdType.MaxValue doesn't exist and is reserved for 'NoneMarker' - list terminator.
+        // Indexes in the status array can potentially be in range 0 .. QubitId.MaxValue-1.
+        // This gives maximum capacity as QubitId.MaxValue. Actual configured capacity may be less than this.
+        // Index equal to QubitId.MaxValue doesn't exist and is reserved for 'NoneMarker' - list terminator.
         constexpr static QubitIdType MaximumQubitCapacity = std::numeric_limits<QubitIdType>::max();
 
       public:
@@ -52,47 +50,45 @@ namespace Quantum
         // Allocate a qubit. Extend capacity if necessary and possible.
         // Fail if the qubit cannot be allocated.
         // Computation complexity is O(number of nested restricted reuse areas) worst case, O(1) amortized cost.
-        Qubit Allocate();
+        QubitIdType Allocate();
         // Allocate qubitCountToAllocate qubits and store them in the provided array.
         // Extend manager capacity if necessary and possible.
         // Fail without allocating any qubits if the qubits cannot be allocated.
         // Caller is responsible for providing array of sufficient size to hold qubitCountToAllocate.
-        void Allocate(Qubit* qubitsToAllocate, int32_t qubitCountToAllocate);
+        void Allocate(QubitIdType* qubitsToAllocate, QubitIdType qubitCountToAllocate);
 
         // Releases a given qubit.
-        void Release(Qubit qubit);
+        void Release(QubitIdType qubit);
         // Releases qubitCountToRelease qubits in the provided array.
         // Caller is responsible for managing memory used by the array itself
         // (i.e. delete[] array if it was dynamically allocated).
-        void Release(Qubit* qubitsToRelease, int32_t qubitCountToRelease);
+        void Release(QubitIdType* qubitsToRelease, QubitIdType qubitCountToRelease);
 
         // Borrow (We treat borrowing as allocation currently)
-        Qubit Borrow();
-        void Borrow(Qubit* qubitsToBorrow, int32_t qubitCountToBorrow);
+        QubitIdType Borrow();
+        void Borrow(QubitIdType* qubitsToBorrow, QubitIdType qubitCountToBorrow);
         // Return (We treat returning as release currently)
-        void Return(Qubit qubit);
-        void Return(Qubit* qubitsToReturn, int32_t qubitCountToReturn);
+        void Return(QubitIdType qubit);
+        void Return(QubitIdType* qubitsToReturn, QubitIdType qubitCountToReturn);
 
         // Disables a given qubit.
         // Once a qubit is disabled it can never be "enabled" or reallocated.
-        void Disable(Qubit qubit);
+        void Disable(QubitIdType qubit);
         // Disables a set of given qubits.
         // Once a qubit is disabled it can never be "enabled" or reallocated.
-        void Disable(Qubit* qubitsToDisable, int32_t qubitCountToDisable);
+        void Disable(QubitIdType* qubitsToDisable, QubitIdType qubitCountToDisable);
 
-        bool IsValidQubit(Qubit qubit) const;
-        bool IsDisabledQubit(Qubit qubit) const;
-        bool IsExplicitlyAllocatedQubit(Qubit qubit) const;
+        bool IsValidQubit(QubitIdType qubit) const;
+        bool IsDisabledQubit(QubitIdType qubit) const;
+        bool IsExplicitlyAllocatedQubit(QubitIdType qubit) const;
         bool IsFreeQubitId(QubitIdType id) const;
-
-        QubitIdType GetQubitId(Qubit qubit) const;
 
         // Qubit counts:
 
         // Number of qubits that are disabled. When an explicitly allocated qubit
         // gets disabled, it is removed from allocated count and is added to
         // disabled count immediately. Subsequent Release doesn't affect counts.
-        int32_t GetDisabledQubitCount() const
+        QubitIdType GetDisabledQubitCount() const
         {
             return disabledQubitCount;
         }
@@ -100,7 +96,7 @@ namespace Quantum
         // Number of qubits that are explicitly allocated. This counter gets
         // increased on allocation of a qubit and decreased on release of a qubit.
         // Note that we treat borrowing as allocation now.
-        int32_t GetAllocatedQubitCount() const
+        QubitIdType GetAllocatedQubitCount() const
         {
             return allocatedQubitCount;
         }
@@ -110,13 +106,13 @@ namespace Quantum
         // for qubits that may be potentially added in future via capacity extension.
         // If qubit manager may extend capacity and reuse is discouraged, released
         // qubits still increase this number even though they cannot be reused.
-        int32_t GetFreeQubitCount() const
+        QubitIdType GetFreeQubitCount() const
         {
             return freeQubitCount;
         }
 
         // Total number of qubits that are currently tracked by this qubit manager.
-        int32_t GetQubitCapacity() const
+        QubitIdType GetQubitCapacity() const
         {
             return qubitCapacity;
         }
@@ -124,26 +120,6 @@ namespace Quantum
         {
             return mayExtendCapacity;
         }
-
-      protected:
-        // May be overriden to create a custom Qubit object.
-        // When not overriden, it just stores qubit Id in place of a pointer to a qubit.
-        // id: unique qubit id
-        // Returns a newly instantiated qubit.
-        virtual Qubit CreateQubitObject(QubitIdType id);
-
-        // May be overriden to delete a custom Qubit object.
-        // Must be overriden if CreateQubitObject is overriden.
-        // When not overriden, it does nothing.
-        // qubit: pointer to QUBIT
-        virtual void DeleteQubitObject(Qubit qubit);
-
-        // May be overriden to get a qubit id from a custom qubit object.
-        // Must be overriden if CreateQubitObject is overriden.
-        // When not overriden, it just reinterprets pointer to qubit as a qubit id.
-        // qubit: pointer to QUBIT
-        // Returns id of a qubit pointed to by qubit.
-        virtual QubitIdType QubitToId(Qubit qubit) const;
 
       private:
         // The end of free lists are marked with NoneMarker value. It is used like null for pointers.
@@ -268,9 +244,9 @@ namespace Quantum
         CRestrictedReuseAreaStack freeQubitsInAreas;
 
         // Counts:
-        int32_t disabledQubitCount  = 0;
-        int32_t allocatedQubitCount = 0;
-        int32_t freeQubitCount      = 0;
+        QubitIdType disabledQubitCount  = 0;
+        QubitIdType allocatedQubitCount = 0;
+        QubitIdType freeQubitCount      = 0;
     };
 
 } // namespace Quantum

--- a/src/Qir/Runtime/unittests/QirRuntimeTests.cpp
+++ b/src/Qir/Runtime/unittests/QirRuntimeTests.cpp
@@ -985,7 +985,7 @@ struct AdjointsTestSimulator : public SimulatorStub
 
     QubitIdType AllocateQubit() override
     {
-        return static_cast<QubitIdType>(++this->lastId);
+        return ++this->lastId;
     }
     void ReleaseQubit(QubitIdType /*qubit*/) override
     {

--- a/src/Qir/Runtime/unittests/QirRuntimeTests.cpp
+++ b/src/Qir/Runtime/unittests/QirRuntimeTests.cpp
@@ -979,7 +979,7 @@ TEST_CASE("Tuples: copy elision", "[qir_support]")
 // Adjoints for R and Exp are implemented by qis, so let's check they at least do the angle invertion in adjoints.
 struct AdjointsTestSimulator : public SimulatorStub
 {
-    QubitIdType lastId      = -1;
+    QubitIdType lastId   = -1;
     double rotationAngle = 0.0;
     double exponentAngle = 0.0;
 

--- a/src/Qir/Runtime/unittests/QirRuntimeTests.cpp
+++ b/src/Qir/Runtime/unittests/QirRuntimeTests.cpp
@@ -979,7 +979,7 @@ TEST_CASE("Tuples: copy elision", "[qir_support]")
 // Adjoints for R and Exp are implemented by qis, so let's check they at least do the angle invertion in adjoints.
 struct AdjointsTestSimulator : public SimulatorStub
 {
-    intptr_t lastId      = -1;
+    QubitIdType lastId      = -1;
     double rotationAngle = 0.0;
     double exponentAngle = 0.0;
 

--- a/src/Qir/Runtime/unittests/ToffoliTests.cpp
+++ b/src/Qir/Runtime/unittests/ToffoliTests.cpp
@@ -11,10 +11,10 @@
 
 using namespace Microsoft::Quantum;
 
-static Result MZ(IQuantumGateSet* iqa, Qubit q)
+static Result MZ(IQuantumGateSet* iqa, QubitIdType q)
 {
     PauliId pauliZ[1] = {PauliId_Z};
-    Qubit qs[1]       = {q};
+    QubitIdType qs[1] = {q};
     return iqa->Measure(1, pauliZ, 1, qs);
 }
 
@@ -24,11 +24,11 @@ TEST_CASE("Basis vector", "[toffoli]")
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     constexpr int n = 1000;
-    std::vector<Qubit> qubits;
+    std::vector<QubitIdType> qubits;
     qubits.reserve(n);
     for (int i = 0; i < n; i++)
     {
-        Qubit q = sim->AllocateQubit();
+        QubitIdType q = sim->AllocateQubit();
         qubits.push_back(q);
         if ((i & 0x1) == 1)
         {
@@ -37,7 +37,7 @@ TEST_CASE("Basis vector", "[toffoli]")
     }
 
     long sum = 0;
-    for (Qubit q : qubits)
+    for (QubitIdType q : qubits)
     {
         if (sim->GetResultValue(MZ(iqa, q)) == Result_One)
         {
@@ -52,7 +52,7 @@ TEST_CASE("Controlled X", "[toffoli]")
     std::unique_ptr<IRuntimeDriver> sim = CreateToffoliSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q[4];
+    QubitIdType q[4];
     q[0] = sim->AllocateQubit();
     q[1] = sim->AllocateQubit();
     q[2] = sim->AllocateQubit();
@@ -97,7 +97,7 @@ TEST_CASE("Measure and assert probability", "[toffoli]")
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
     const int count = 3;
-    Qubit qs[count];
+    QubitIdType qs[count];
     for (int i = 0; i < count; i++)
     {
         qs[i] = sim->AllocateQubit();

--- a/src/Qir/Runtime/unittests/TracerTests.cpp
+++ b/src/Qir/Runtime/unittests/TracerTests.cpp
@@ -16,9 +16,9 @@ TEST_CASE("Layering distinct single-qubit operations of non-zero durations", "[t
 {
     std::shared_ptr<CTracer> tr = CreateTracer(3 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 1, q1)); // L(0,3) should be created
     CHECK(0 == tr->TraceSingleQubitOp(2, 2, q1)); // add the op into L(0,3)
@@ -46,9 +46,9 @@ TEST_CASE("Layering single-qubit operations of zero duration", "[tracer]")
 {
     std::shared_ptr<CTracer> tr = CreateTracer(3 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 1, q1));       // L(0,3) should be created
     CHECK(0 == tr->TraceSingleQubitOp(2, 0, q1));       // add the op into L(0,3)
@@ -66,18 +66,18 @@ TEST_CASE("Layering distinct controlled single-qubit operations", "[tracer]")
 {
     std::shared_ptr<CTracer> tr = CreateTracer(3 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
-    Qubit q4 = tr->AllocateQubit();
-    Qubit q5 = tr->AllocateQubit();
-    Qubit q6 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
+    QubitIdType q4 = tr->AllocateQubit();
+    QubitIdType q5 = tr->AllocateQubit();
+    QubitIdType q6 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceMultiQubitOp(1, 1, 1 /*nFirst*/, &q1 /*first*/, 1 /*nSecond*/, &q2 /*second*/));
     CHECK(0 == tr->TraceMultiQubitOp(2, 2, 0 /*nFirst*/, nullptr /*first*/, 1 /*nSecond*/, &q2 /*second*/));
     // q2 now is at the limit of the layer duration
 
-    Qubit qs12[2] = {q1, q2};
+    QubitIdType qs12[2] = {q1, q2};
     CHECK(1 == tr->TraceMultiQubitOp(3, 1, 0 /*nFirst*/, nullptr /*first*/, 2 /*nSecond*/, qs12 /*second*/));
     CHECK(1 == tr->TraceMultiQubitOp(4, 1, 1 /*nFirst*/, &q2 /*first*/, 1 /*nSecond*/, &q3 /*second*/));
     // because of q2, both ops should have been added to a new layer, which now "catches" q1, q2, q3
@@ -93,7 +93,7 @@ TEST_CASE("Layering distinct controlled single-qubit operations", "[tracer]")
     CHECK(0 == tr->TraceSingleQubitOp(9, 1, q5));
     // should fall through to the first layer
 
-    Qubit qs46[2] = {q4, q6};
+    QubitIdType qs46[2] = {q4, q6};
     CHECK(1 == tr->TraceMultiQubitOp(10, 1, 2 /*nFirst*/, qs46 /*first*/, 1 /*nSecond*/, &q5 /*second*/));
     // because of the controls, should be added into the second layer
 
@@ -122,9 +122,9 @@ TEST_CASE("Operations with same id are counted together", "[tracer]")
 {
     std::shared_ptr<CTracer> tr = CreateTracer(3 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
 
     // All of these ops should fit into a single layer L(0,3)
     tr->TraceSingleQubitOp(1, 1, q1);
@@ -147,10 +147,10 @@ TEST_CASE("Global barrier", "[tracer]")
 {
     std::shared_ptr<CTracer> tr = CreateTracer(2 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
-    Qubit q4 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
+    QubitIdType q4 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 4, q1)); // L(0,4) created
     CHECK(0 == tr->TraceSingleQubitOp(2, 1, q4)); // added to L(0,4)
@@ -199,17 +199,17 @@ TEST_CASE("Layering measurements", "[tracer]")
 {
     std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
-    Qubit q4 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
+    QubitIdType q4 = tr->AllocateQubit();
 
     CHECK(0 == tr->GetLayerIdOfSourceMeasurement(tr->TraceSingleQubitMeasurement(1, 1, q1)));
-    Qubit qs12[2] = {q1, q2};
+    QubitIdType qs12[2] = {q1, q2};
     CHECK(1 == tr->GetLayerIdOfSourceMeasurement(tr->TraceMultiQubitMeasurement(2, 1, 2, qs12)));
     CHECK(0 == tr->TraceSingleQubitOp(3, 1, q4));
     CHECK(0 == tr->GetLayerIdOfSourceMeasurement(tr->TraceSingleQubitMeasurement(4, 1, q3)));
-    Qubit qs23[2] = {q2, q3};
+    QubitIdType qs23[2] = {q2, q3};
     CHECK(2 == tr->GetLayerIdOfSourceMeasurement(tr->TraceMultiQubitMeasurement(5, 1, 2, qs23)));
     CHECK(1 == tr->TraceSingleQubitOp(3, 1, q4));
 }
@@ -218,8 +218,8 @@ TEST_CASE("Conditionals: noops", "[tracer][tracer.conditionals]")
 {
     std::shared_ptr<CTracer> tr = CreateTracer(3 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 3, q1));
     CHECK(1 == tr->TraceSingleQubitOp(1, 3, q1));
@@ -242,9 +242,9 @@ TEST_CASE("Conditionals: a new layer because of the fence", "[tracer][tracer.con
 {
     std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 1, q1));
     Result r = tr->TraceSingleQubitMeasurement(1, 1, q1);
@@ -262,9 +262,9 @@ TEST_CASE("Conditionals: single fence", "[tracer][tracer.conditionals]")
 {
     std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 1, q1));
     Result r = tr->TraceSingleQubitMeasurement(1, 1, q1);
@@ -287,9 +287,9 @@ TEST_CASE("Conditionals: fence from two result arrays", "[tracer][tracer.conditi
 {
     std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 1, q1));
     Result r1 = tr->TraceSingleQubitMeasurement(1, 1, q1);
@@ -311,11 +311,11 @@ TEST_CASE("Conditionals: nested fence is later than parent", "[tracer][tracer.co
 {
     std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
-    Qubit q4 = tr->AllocateQubit();
-    Qubit q5 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
+    QubitIdType q4 = tr->AllocateQubit();
+    QubitIdType q5 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 1, q1));
     Result r1 = tr->TraceSingleQubitMeasurement(1, 1, q1);
@@ -342,11 +342,11 @@ TEST_CASE("Conditionals: nested fence is earlier than parent", "[tracer][tracer.
 {
     std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
-    Qubit q4 = tr->AllocateQubit();
-    Qubit q5 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
+    QubitIdType q4 = tr->AllocateQubit();
+    QubitIdType q5 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 1, q1));
     Result r1 = tr->TraceSingleQubitMeasurement(1, 1, q1);
@@ -372,11 +372,11 @@ TEST_CASE("Conditionals: fences and barriers", "[tracer][tracer.conditionals]")
 {
     std::shared_ptr<CTracer> tr = CreateTracer(1 /*layer duration*/);
 
-    Qubit q1 = tr->AllocateQubit();
-    Qubit q2 = tr->AllocateQubit();
-    Qubit q3 = tr->AllocateQubit();
-    Qubit q4 = tr->AllocateQubit();
-    Qubit q5 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
+    QubitIdType q2 = tr->AllocateQubit();
+    QubitIdType q3 = tr->AllocateQubit();
+    QubitIdType q4 = tr->AllocateQubit();
+    QubitIdType q5 = tr->AllocateQubit();
 
     CHECK(0 == tr->TraceSingleQubitOp(1, 1, q1));
     Result r1 = tr->TraceSingleQubitMeasurement(1, 1, q1);
@@ -403,7 +403,7 @@ TEST_CASE("Output: to string", "[tracer]")
     std::unordered_map<OpId, std::string> opNames = {{1, "X"}, {2, "Y"}, {3, "Z"}, {4, "b"}};
     std::shared_ptr<CTracer> tr                   = CreateTracer(1 /*layer duration*/, opNames);
 
-    Qubit q1 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
     tr->TraceSingleQubitOp(3, 1, q1);
     tr->TraceSingleQubitOp(5, 1, q1);
     tr->InjectGlobalBarrier(4, 2);
@@ -450,7 +450,7 @@ TEST_CASE("Output: to file", "[tracer]")
     std::unordered_map<OpId, std::string> opNames = {{1, "X"}, {2, "Y"}, {3, "Z"}, {4, "b"}};
     std::shared_ptr<CTracer> tr                   = CreateTracer(1 /*layer duration*/, opNames);
 
-    Qubit q1 = tr->AllocateQubit();
+    QubitIdType q1 = tr->AllocateQubit();
     tr->TraceSingleQubitOp(3, 1, q1);
     tr->TraceSingleQubitOp(5, 1, q1);
     tr->InjectGlobalBarrier(4, 2);

--- a/src/Qir/Tests/FullstateSimulator/FullstateSimulatorTests.cpp
+++ b/src/Qir/Tests/FullstateSimulator/FullstateSimulatorTests.cpp
@@ -18,15 +18,15 @@ using namespace std;
 
 // The tests rely on the implementation detail of CFullstateSimulator that the qubits are nothing more but contiguously
 // incremented ids.
-static unsigned GetQubitId(Qubit q)
+static unsigned GetQubitId(QubitIdType q)
 {
-    return static_cast<unsigned>(reinterpret_cast<size_t>(q));
+    return static_cast<unsigned>(static_cast<size_t>(q));
 }
 
-static Result MZ(IQuantumGateSet* iqa, Qubit q)
+static Result MZ(IQuantumGateSet* iqa, QubitIdType q)
 {
     PauliId pauliZ[1] = {PauliId_Z};
-    Qubit qs[1]       = {q};
+    QubitIdType qs[1] = {q};
     return iqa->Measure(1, pauliZ, 1, qs);
 }
 
@@ -34,8 +34,8 @@ TEST_CASE("Fullstate simulator: allocate qubits", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
 
-    Qubit q0 = sim->AllocateQubit();
-    Qubit q1 = sim->AllocateQubit();
+    QubitIdType q0 = sim->AllocateQubit();
+    QubitIdType q1 = sim->AllocateQubit();
     REQUIRE(GetQubitId(q0) == 0);
     REQUIRE(GetQubitId(q1) == 1);
     sim->ReleaseQubit(q0);
@@ -45,10 +45,10 @@ TEST_CASE("Fullstate simulator: allocate qubits", "[fullstate_simulator]")
 TEST_CASE("Fullstate simulator: multiple instances", "[fullstate_simulator]")
 {
     std::unique_ptr<IRuntimeDriver> sim1 = CreateFullstateSimulator();
-    Qubit q1                             = sim1->AllocateQubit();
+    QubitIdType q1                       = sim1->AllocateQubit();
 
     std::unique_ptr<IRuntimeDriver> sim2 = CreateFullstateSimulator();
-    Qubit q2                             = sim2->AllocateQubit();
+    QubitIdType q2                       = sim2->AllocateQubit();
 
     REQUIRE(GetQubitId(q1) == 0);
     REQUIRE(GetQubitId(q2) == 0);
@@ -62,8 +62,8 @@ TEST_CASE("Fullstate simulator: X and measure", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q   = sim->AllocateQubit();
-    Result r1 = MZ(iqa, q);
+    QubitIdType q = sim->AllocateQubit();
+    Result r1     = MZ(iqa, q);
     REQUIRE(Result_Zero == sim->GetResultValue(r1));
     REQUIRE(sim->AreEqualResults(r1, sim->UseZero()));
 
@@ -82,8 +82,8 @@ TEST_CASE("Fullstate simulator: X, M, reuse, M", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q   = sim->AllocateQubit();
-    Result r1 = MZ(iqa, q);
+    QubitIdType q = sim->AllocateQubit();
+    Result r1     = MZ(iqa, q);
     REQUIRE(Result_Zero == sim->GetResultValue(r1));
     REQUIRE(sim->AreEqualResults(r1, sim->UseZero()));
 
@@ -96,8 +96,8 @@ TEST_CASE("Fullstate simulator: X, M, reuse, M", "[fullstate_simulator]")
     sim->ReleaseResult(r1);
     sim->ReleaseResult(r2);
 
-    Qubit qq  = sim->AllocateQubit();
-    Result r3 = MZ(iqa, qq);
+    QubitIdType qq = sim->AllocateQubit();
+    Result r3      = MZ(iqa, qq);
     // Allocated qubit should always be in |0> state even though we released
     // q in |1> state, and qq is likely reusing the same underlying qubit as q.
     REQUIRE(Result_Zero == sim->GetResultValue(r3));
@@ -112,8 +112,8 @@ TEST_CASE("Fullstate simulator: measure Bell state", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q1 = sim->AllocateQubit();
-    Qubit q2 = sim->AllocateQubit();
+    QubitIdType q1 = sim->AllocateQubit();
+    QubitIdType q2 = sim->AllocateQubit();
 
     iqa->H(q1);
     iqa->ControlledX(1, &q1, q2);
@@ -131,7 +131,7 @@ TEST_CASE("Fullstate simulator: ZZ measure", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q[2];
+    QubitIdType q[2];
     PauliId paulis[2] = {PauliId_Z, PauliId_Z};
 
     q[0] = sim->AllocateQubit();
@@ -158,7 +158,7 @@ TEST_CASE("Fullstate simulator: assert probability", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit qs[2];
+    QubitIdType qs[2];
     qs[0] = sim->AllocateQubit();
     qs[1] = sim->AllocateQubit();
     iqa->X(qs[0]);
@@ -188,7 +188,7 @@ TEST_CASE("Fullstate simulator: toffoli", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit qs[3];
+    QubitIdType qs[3];
     for (int i = 0; i < 3; i++)
     {
         qs[i] = sim->AllocateQubit();
@@ -216,7 +216,7 @@ TEST_CASE("Fullstate simulator: SSZ=Id", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q = sim->AllocateQubit();
+    QubitIdType q = sim->AllocateQubit();
 
     bool identitySSZ = true;
     for (int i = 0; i < 100 && identitySSZ; i++)
@@ -238,7 +238,7 @@ TEST_CASE("Fullstate simulator: TTSAdj=Id", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q = sim->AllocateQubit();
+    QubitIdType q = sim->AllocateQubit();
 
     bool identityTTSAdj = true;
     for (int i = 0; i < 100 && identityTTSAdj; i++)
@@ -260,7 +260,7 @@ TEST_CASE("Fullstate simulator: TTAdj=Id", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q = sim->AllocateQubit();
+    QubitIdType q = sim->AllocateQubit();
 
     bool identityTTadj = true;
     for (int i = 0; i < 100 && identityTTadj; i++)
@@ -282,7 +282,7 @@ TEST_CASE("Fullstate simulator: R", "[fullstate_simulator]")
     std::unique_ptr<IRuntimeDriver> sim = CreateFullstateSimulator();
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
 
-    Qubit q       = sim->AllocateQubit();
+    QubitIdType q = sim->AllocateQubit();
     bool identity = true;
     for (int i = 0; i < 100 && identity; i++)
     {
@@ -307,7 +307,7 @@ TEST_CASE("Fullstate simulator: exponents", "[fullstate_simulator]")
     IQuantumGateSet* iqa                = dynamic_cast<IQuantumGateSet*>(sim.get());
     const int n                         = 5;
 
-    Qubit qs[n];
+    QubitIdType qs[n];
     for (int i = 0; i < n; i++)
     {
         qs[i] = sim->AllocateQubit();
@@ -336,7 +336,7 @@ TEST_CASE("Fullstate simulator: get qubit state of Bell state", "[fullstate_simu
     const int n        = 3;
     static double norm = 0.0;
 
-    Qubit qs[n];
+    QubitIdType qs[n];
     for (int i = 0; i < n; i++)
     {
         qs[i] = sim->AllocateQubit();

--- a/src/Qir/Tests/QIR-static/qir-driver.cpp
+++ b/src/Qir/Tests/QIR-static/qir-driver.cpp
@@ -20,8 +20,8 @@
 #include "catch.hpp"
 
 // Identifiers exposed externally:
-extern "C" void __quantum__qis__k__body(Qubit q);                    // NOLINT
-extern "C" void __quantum__qis__k__ctl(QirArray* controls, Qubit q); // NOLINT
+extern "C" void __quantum__qis__k__body(QUBIT* q);                    // NOLINT
+extern "C" void __quantum__qis__k__ctl(QirArray* controls, QUBIT* q); // NOLINT
 
 // Used by a couple test simulators. Catch's REQUIRE macro doesn't deal well with static class members so making it
 // into a global constant.
@@ -73,7 +73,7 @@ struct QubitsResultsTestSimulator : public Microsoft::Quantum::SimulatorStub
     vector<int> qubits;           // released, or |0>, or |1> states (no entanglement allowed)
     vector<int> results = {0, 1}; // released, or Zero(0) or One(1)
 
-    uint64_t GetQubitId(Qubit qubit) const
+    uint64_t GetQubitId(QubitIdType qubit) const
     {
         const uint64_t id = (uint64_t)qubit;
         REQUIRE(id < this->qubits.size());
@@ -89,20 +89,20 @@ struct QubitsResultsTestSimulator : public Microsoft::Quantum::SimulatorStub
         return id;
     }
 
-    Qubit AllocateQubit() override
+    QubitIdType AllocateQubit() override
     {
         qubits.push_back(0);
-        return reinterpret_cast<Qubit>(this->qubits.size() - 1);
+        return static_cast<QubitIdType>(this->qubits.size() - 1);
     }
 
-    void ReleaseQubit(Qubit qubit) override
+    void ReleaseQubit(QubitIdType qubit) override
     {
         const uint64_t id = GetQubitId(qubit);
         REQUIRE(this->qubits[id] != RELEASED); // no double-release
         this->qubits[id] = RELEASED;
     }
 
-    void X(Qubit qubit) override
+    void X(QubitIdType qubit) override
     {
         const uint64_t id = GetQubitId(qubit);
         REQUIRE(this->qubits[id] != RELEASED); // the qubit must be alive
@@ -110,7 +110,7 @@ struct QubitsResultsTestSimulator : public Microsoft::Quantum::SimulatorStub
     }
 
     Result Measure([[maybe_unused]] long numBases, PauliId* /* bases */, long /* numTargets */,
-                   Qubit targets[]) override
+                   QubitIdType targets[]) override
     {
         assert(numBases == 1 && "QubitsResultsTestSimulator doesn't support joint measurements");
 
@@ -224,34 +224,34 @@ struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
 {
     std::vector<int> qubits;
 
-    uint64_t GetQubitId(Qubit qubit) const
+    uint64_t GetQubitId(QubitIdType qubit) const
     {
         const uint64_t id = (uint64_t)qubit;
         REQUIRE(id < this->qubits.size());
         return id;
     }
 
-    Qubit AllocateQubit() override
+    QubitIdType AllocateQubit() override
     {
         this->qubits.push_back(0);
-        return reinterpret_cast<Qubit>(this->qubits.size() - 1);
+        return static_cast<QubitIdType>(this->qubits.size() - 1);
     }
 
-    void ReleaseQubit(Qubit qubit) override
+    void ReleaseQubit(QubitIdType qubit) override
     {
         const uint64_t id = GetQubitId(qubit);
         REQUIRE(this->qubits[id] != RELEASED);
         this->qubits[id] = RELEASED;
     }
 
-    void X(Qubit qubit) override
+    void X(QubitIdType qubit) override
     {
         const uint64_t id = GetQubitId(qubit);
         REQUIRE(this->qubits[id] != RELEASED); // the qubit must be alive
         this->qubits[id] = 1 - this->qubits[id];
     }
 
-    void ControlledX(long numControls, Qubit controls[], Qubit qubit) override
+    void ControlledX(long numControls, QubitIdType controls[], QubitIdType qubit) override
     {
         for (long i = 0; i < numControls; i++)
         {
@@ -266,7 +266,7 @@ struct FunctorsTestSimulator : public Microsoft::Quantum::SimulatorStub
     }
 
     Result Measure([[maybe_unused]] long numBases, PauliId* /* bases */, long /* numTargets */,
-                   Qubit targets[]) override
+                   QubitIdType targets[]) override
     {
         assert(numBases == 1 && "FunctorsTestSimulator doesn't support joint measurements");
 
@@ -300,15 +300,16 @@ static int g_cKCalls                    = 0;
 static int g_cKCallsControlled          = 0;
 extern "C" void Microsoft__Quantum__Testing__QIR__TestFunctors__Interop();       // NOLINT
 extern "C" void Microsoft__Quantum__Testing__QIR__TestFunctorsNoArgs__Interop(); // NOLINT
-extern "C" void __quantum__qis__k__body(Qubit q)                                 // NOLINT
+extern "C" void __quantum__qis__k__body(QUBIT* q)                                // NOLINT
 {
     g_cKCalls++;
-    g_ctrqapi->X(q);
+    g_ctrqapi->X(reinterpret_cast<QubitIdType>(q));
 }
-extern "C" void __quantum__qis__k__ctl(QirArray* controls, Qubit q) // NOLINT
+extern "C" void __quantum__qis__k__ctl(QirArray* controls, QUBIT* q) // NOLINT
 {
     g_cKCallsControlled++;
-    g_ctrqapi->ControlledX((long)(controls->count), reinterpret_cast<Qubit*>(controls->buffer), q);
+    g_ctrqapi->ControlledX((long)(controls->count), reinterpret_cast<QubitIdType*>(controls->buffer),
+                           reinterpret_cast<QubitIdType>(q));
 }
 TEST_CASE("QIR: application of nested controlled functor", "[qir][qir.functor]")
 {

--- a/src/Qir/Tests/QIR-static/qir-test-conditionals.cpp
+++ b/src/Qir/Tests/QIR-static/qir-test-conditionals.cpp
@@ -56,36 +56,37 @@ struct ConditionalsTestSimulator : public Microsoft::Quantum::SimulatorStub
         return out.str();
     }
 
-    Qubit AllocateQubit() override
+    QubitIdType AllocateQubit() override
     {
-        return nullptr;
+        return 0;
     }
-    void ReleaseQubit(Qubit /*qubit*/) override
+    void ReleaseQubit(QubitIdType /*qubit*/) override
     {
     }
 
-    void X(Qubit) override
+    void X(QubitIdType) override
     {
         this->xCallbacks.push_back(this->nGateCallback);
         this->nGateCallback++;
     }
-    void ControlledX(long /* numControls */, Qubit* /* controls */, Qubit /* qubit */) override
+    void ControlledX(long /* numControls */, QubitIdType* /* controls */, QubitIdType /* qubit */) override
     {
         this->cxCallbacks.push_back(this->nGateCallback);
         this->nGateCallback++;
     }
-    void Y(Qubit) override
+    void Y(QubitIdType) override
     {
         this->otherCallbacks.push_back(this->nGateCallback);
         this->nGateCallback++;
     }
-    void ControlledY(long /* numControls */, Qubit* /* controls */, Qubit /* qubit */) override
+    void ControlledY(long /* numControls */, QubitIdType* /* controls */, QubitIdType /* qubit */) override
     {
         this->otherCallbacks.push_back(this->nGateCallback);
         this->nGateCallback++;
     }
 
-    Result Measure(long /* numBases */, PauliId* /* bases */, long /* numTargets */, Qubit* /* targets */) override
+    Result Measure(long /* numBases */, PauliId* /* bases */, long /* numTargets */,
+                   QubitIdType* /* targets */) override
     {
         assert(this->nextMeasureResult < this->mockMeasurements.size() &&
                "ConditionalsTestSimulator isn't set up correctly");


### PR DESCRIPTION
This updates the QIR Runtime to use a consistent type for qubit ids, `typedef intptr_t QubitIdType;`. All APIs that correspond to the QIR spec continue to use opaque pointer type `QUBIT*` and then immediately cast to `QubitIdType` for use internally. Of note, the Qubit Manager uses negative values for special meaning when tracking qubits in use, so the unsigned `uintptr_t` is not compatible.

This is part 1 of the change. The update of the native simulator and corresponding C# types from `unsigned` to `intptr_t` will be part of a separate change.