### PR TITLE
Force use of Chocolatey installed clang-11

### DIFF
--- a/src/Qir/Runtime/prerequisites.ps1
+++ b/src/Qir/Runtime/prerequisites.ps1
@@ -9,7 +9,7 @@ if ($Env:ENABLE_QIRRUNTIME -ne "false") {
             !(Get-Command clang-format -ErrorAction SilentlyContinue) -or `
             (Test-Path Env:/AGENT_OS)) {
             choco install llvm --version=11.1.0 --allow-downgrade
-            Write-Host "##vso[task.setvariable variable=PATH;]C:\Program Files\LLVM\bin;$Env:Path"
+            Write-Host "##vso[task.setvariable variable=PATH;]$($env:SystemDrive)\Program Files\LLVM\bin;$Env:PATH"
         }
         if (!(Get-Command ninja -ErrorAction SilentlyContinue)) {
             choco install ninja

--- a/src/Qir/Runtime/prerequisites.ps1
+++ b/src/Qir/Runtime/prerequisites.ps1
@@ -6,9 +6,10 @@
 if ($Env:ENABLE_QIRRUNTIME -ne "false") {
     if (($IsWindows) -or ((Test-Path Env:/AGENT_OS) -and ($Env:AGENT_OS.StartsWith("Win")))) {
         if (!(Get-Command clang        -ErrorAction SilentlyContinue) -or `
-            !(Get-Command clang-format -ErrorAction SilentlyContinue)) {
+            !(Get-Command clang-format -ErrorAction SilentlyContinue) -or `
+            (Test-Path Env:/AGENT_OS)) {
             choco install llvm --version=11.1.0
-            Write-Host "##vso[task.setvariable variable=PATH;]$Env:Path;C:\Program Files\LLVM\bin"
+            Write-Host "##vso[task.setvariable variable=PATH;]C:\Program Files\LLVM\bin;$Env:Path"
         }
         if (!(Get-Command ninja -ErrorAction SilentlyContinue)) {
             choco install ninja

--- a/src/Qir/Runtime/prerequisites.ps1
+++ b/src/Qir/Runtime/prerequisites.ps1
@@ -8,7 +8,7 @@ if ($Env:ENABLE_QIRRUNTIME -ne "false") {
         if (!(Get-Command clang        -ErrorAction SilentlyContinue) -or `
             !(Get-Command clang-format -ErrorAction SilentlyContinue) -or `
             (Test-Path Env:/AGENT_OS)) {
-            choco install llvm --version=11.1.0
+            choco install llvm --version=11.1.0 --allow-downgrade
             Write-Host "##vso[task.setvariable variable=PATH;]C:\Program Files\LLVM\bin;$Env:Path"
         }
         if (!(Get-Command ninja -ErrorAction SilentlyContinue)) {

--- a/src/Qir/qir-utils.ps1
+++ b/src/Qir/qir-utils.ps1
@@ -192,9 +192,10 @@ function Build-CMakeProject {
         $env:CXX = "clang++.exe"
         $env:RC = "clang++.exe"
 
-        if (!(Get-Command clang -ErrorAction SilentlyContinue) -and (choco find --idonly -l llvm) -contains "llvm") {
+        if ((!(Get-Command clang -ErrorAction SilentlyContinue) -and (choco find --idonly -l llvm) -contains "llvm") -or `
+            (Test-Path Env:AGENT_OS)) {
             # LLVM was installed by Chocolatey, so add the install location to the path.
-            $env:PATH += ";$($env:SystemDrive)\Program Files\LLVM\bin"
+            $env:PATH = "$($env:SystemDrive)\Program Files\LLVM\bin;$env:Path"
         }
 
         if (Get-Command clang-tidy -ErrorAction SilentlyContinue) {

--- a/src/Qir/qir-utils.ps1
+++ b/src/Qir/qir-utils.ps1
@@ -193,7 +193,7 @@ function Build-CMakeProject {
         $env:RC = "clang++.exe"
 
         if ((!(Get-Command clang -ErrorAction SilentlyContinue) -and (choco find --idonly -l llvm) -contains "llvm") -or `
-            (Test-Path Env:AGENT_OS)) {
+            (Test-Path Env:/AGENT_OS)) {
             # LLVM was installed by Chocolatey, so add the install location to the path.
             $env:PATH = "$($env:SystemDrive)\Program Files\LLVM\bin;$env:Path"
         }


### PR DESCRIPTION
This will force the install of Clang 11.1.0 by Chocolatey, and then put that version first in the path to ensure it gets used by later build steps.