### PR TITLE
Add `CX`, `CY` and `CZ` to Type1, Type3 target packages.

### DIFF
--- a/src/Simulation/TargetDefinitions/Decompositions/CCNOTFromCCZ.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CCNOTFromCCZ.qs
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.Intrinsic {
                 H(target);
             }
             apply {
-                Controlled Z([control1, control2], target);
+                CCZ(control1, control2, target);
             }
         }
         controlled (ctls, ...) {

--- a/src/Simulation/TargetDefinitions/Decompositions/CX.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CX.qs
@@ -1,0 +1,39 @@
+namespace Microsoft.Quantum.Canon {
+    open Microsoft.Quantum.Intrinsic;
+
+    /// # Summary
+    /// Applies the controlled-X (CX) gate to a pair of qubits.
+    ///
+    /// # Description
+    /// This operation can be simulated by the unitary matrix
+    /// $$
+    /// \begin{align}
+    ///     \left(\begin{matrix}
+    ///         1 & 0 & 0 & 0 \\\\
+    ///         0 & 1 & 0 & 0 \\\\
+    ///         0 & 0 & 0 & 1 \\\\
+    ///         0 & 0 & 1 & 0
+    ///      \end{matrix}\right)
+    /// \end{align},
+    /// $$
+    /// where rows and columns are organized as in the quantum concepts guide.
+    ///
+    /// # Input
+    /// ## control
+    /// Control qubit for the CX gate.
+    /// ## target
+    /// Target qubit for the CX gate.
+    ///
+    /// # Remarks
+    /// Equivalent to:
+    /// ```qsharp
+    /// Controlled X([control], target);
+    /// ```
+    /// and to:
+    /// ```qsharp
+    /// CNOT(control, target);
+    /// ```
+    operation CX(control : Qubit, target : Qubit) : Unit is Adj + Ctl{
+        CNOT(control, target);
+    }
+}

--- a/src/Simulation/TargetDefinitions/Decompositions/CX.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CX.qs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Intrinsic;
 

--- a/src/Simulation/TargetDefinitions/Decompositions/CYFromCNOT.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CYFromCNOT.qs
@@ -1,0 +1,43 @@
+namespace Microsoft.Quantum.Canon {
+    open Microsoft.Quantum.Intrinsic;
+
+    /// # Summary
+    /// Applies the controlled-Y (CY) gate to a pair of qubits.
+    ///
+    /// # Description
+    /// This operation can be simulated by the unitary matrix
+    /// $$
+    /// \begin{align}
+    ///     1 & 0 & 0 & 0 \\\\
+    ///     0 & 1 & 0 & 0 \\\\
+    ///     0 & 0 & 0 & -i \\\\
+    ///     0 & 0 & i & 0
+    /// \end{align},
+    /// $$
+    /// where rows and columns are organized as in the quantum concepts guide.
+    ///
+    /// # Input
+    /// ## control
+    /// Control qubit for the CY gate.
+    /// ## target
+    /// Target qubit for the CY gate.
+    ///
+    /// # Remarks
+    /// Equivalent to:
+    /// ```qsharp
+    /// Controlled Y([control], target);
+    /// ```
+    operation CY(control : Qubit, target : Qubit) : Unit {
+        body (...) {
+            within {
+                MapPauli(target, PauliX, PauliY);
+            }
+            apply {
+                CNOT(control, target);
+            }
+        }
+        adjoint self;
+        controlled distribute;
+        controlled adjoint self;
+    }
+}

--- a/src/Simulation/TargetDefinitions/Decompositions/CYFromCNOT.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CYFromCNOT.qs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Intrinsic;
 

--- a/src/Simulation/TargetDefinitions/Decompositions/CZFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CZFromSinglyControlled.qs
@@ -1,0 +1,47 @@
+namespace Microsoft.Quantum.Canon {
+    open Microsoft.Quantum.Intrinsic;
+
+    /// # Summary
+    /// Applies the controlled-Z (CZ) gate to a pair of qubits.
+    ///
+    /// # Description
+    /// This operation can be simulated by the unitary matrix
+    /// $$
+    /// \begin{align}
+    ///     1 & 0 & 0 & 0 \\\\
+    ///     0 & 1 & 0 & 0 \\\\
+    ///     0 & 0 & 1 & 0 \\\\
+    ///     0 & 0 & 0 & -1
+    /// \end{align},
+    /// $$
+    /// where rows and columns are organized as in the quantum concepts guide.
+    ///
+    /// # Input
+    /// ## control
+    /// Control qubit for the CZ gate.
+    /// ## target
+    /// Target qubit for the CZ gate.
+    ///
+    /// # Remarks
+    /// Equivalent to:
+    /// ```qsharp
+    /// Controlled Z([control], target);
+    /// ```
+    operation CZ(control : Qubit, target : Qubit) : Unit {
+        body (...) {
+            ApplyControlledZ(control, target);
+        }
+        controlled (ctls, ...) {
+            if (Length(ctls) == 0) {
+                ApplyControlledZ(control, target);
+            }
+            elif (Length(ctls) == 1) {
+                CCZ(ctls[0], control, target);
+            }
+            else {
+                ApplyWithLessControlsA(Controlled CZ, (ctls, (control, target)));
+            }
+        }
+        adjoint self;
+    }
+}

--- a/src/Simulation/TargetDefinitions/Decompositions/CZFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CZFromSinglyControlled.qs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Intrinsic;
 
@@ -32,10 +35,10 @@ namespace Microsoft.Quantum.Canon {
             ApplyControlledZ(control, target);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyControlledZ(control, target);
             }
-            elif (Length(ctls) == 1) {
+            elif Length(ctls) == 1 {
                 CCZ(ctls[0], control, target);
             }
             else {

--- a/src/Simulation/TargetDefinitions/Decompositions/Utils.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/Utils.qs
@@ -99,6 +99,23 @@ namespace Microsoft.Quantum.Intrinsic {
         H(target);
     }
 
+    internal operation CCZ (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+        // [Page 15 of arXiv:1206.0758v3](https://arxiv.org/pdf/1206.0758v3.pdf#page=15)
+        Adjoint T(control1);
+        Adjoint T(control2);
+        CNOT(target, control1);
+        T(control1);
+        CNOT(control2, target);
+        CNOT(control2, control1);
+        T(target);
+        Adjoint T(control1);
+        CNOT(control2, target);
+        CNOT(target, control1);
+        Adjoint T(target);
+        T(control1);
+        CNOT(control2, control1);
+    }
+
     internal function ReducedDyadicFraction (numerator : Int, denominatorPowerOfTwo : Int) : (Int, Int) {
         if (numerator == 0) { return (0,0); }
         mutable num = numerator;

--- a/src/Simulation/TargetDefinitions/Decompositions/YFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/YFromSinglyControlled.qs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Intrinsic {
+    open Microsoft.Quantum.Canon;
 
     /// # Summary
     /// Applies the Pauli $Y$ gate.
@@ -27,19 +28,14 @@ namespace Microsoft.Quantum.Intrinsic {
                 ApplyUncontrolledY(qubit);
             }
             elif (Length(ctls) == 1) {
-                within {
-                    MapPauli(qubit, PauliX, PauliY);
-                }
-                apply {
-                    CNOT(ctls[0], qubit);
-                }
+                CY(ctls[0], qubit);
             }
             elif (Length(ctls) == 2) {
                 within {
                     MapPauli(qubit, PauliZ, PauliY);
                 }
                 apply {
-                    Controlled Z(ctls, qubit);
+                    CCZ(ctls[0], ctls[1], qubit);
                 }
             }
             else {

--- a/src/Simulation/TargetDefinitions/Decompositions/ZFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ZFromSinglyControlled.qs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Intrinsic {
+    open Microsoft.Quantum.Canon;
 
     /// # Summary
     /// Applies the Pauli $Z$ gate.
@@ -30,20 +31,7 @@ namespace Microsoft.Quantum.Intrinsic {
                 ApplyControlledZ(ctls[0], qubit);
             }
             elif (Length(ctls) == 2) {
-                // [Page 15 of arXiv:1206.0758v3](https://arxiv.org/pdf/1206.0758v3.pdf#page=15)
-                Adjoint T(ctls[0]);
-                Adjoint T(ctls[1]);
-                CNOT(qubit, ctls[0]);
-                T(ctls[0]);
-                CNOT(ctls[1], qubit);
-                CNOT(ctls[1], ctls[0]);
-                T(qubit);
-                Adjoint T(ctls[0]);
-                CNOT(ctls[1], qubit);
-                CNOT(qubit, ctls[0]);
-                Adjoint T(qubit);
-                T(ctls[0]);
-                CNOT(ctls[1], ctls[0]);
+                CCZ(ctls[0], ctls[1], qubit);
             }
             else {
                 ApplyWithLessControlsA(Controlled Z, (ctls, qubit));

--- a/src/Simulation/TargetDefinitions/TargetPackages/Type1.Package.props
+++ b/src/Simulation/TargetDefinitions/TargetPackages/Type1.Package.props
@@ -26,6 +26,9 @@
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\AssertOperationsEqualReferenced.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\CCNOTFromCCZ.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\CNOTFromSinglyControlled.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\CX.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\CYFromCNOT.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\CZFromSinglyControlled.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\ExpFracFromExpUtil.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\ExpFromExpUtil.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\ExpUtil.qs" />

--- a/src/Simulation/TargetDefinitions/TargetPackages/Type3.Package.props
+++ b/src/Simulation/TargetDefinitions/TargetPackages/Type3.Package.props
@@ -27,6 +27,9 @@
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\AssertOperationsEqualReferenced.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\CCNOTFromCCZ.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\CNOTFromSinglyControlled.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\CX.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\CYFromCNOT.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\CZFromSinglyControlled.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\ExpFracFromExpUtil.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\ExpFromExpUtil.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\ExpUtil.qs" />


### PR DESCRIPTION
This simplifies the use of controlled Pauli gates to allow for programs that make use of singly controlled gates (or CCNOT) to have reasonable decompositoins without incurring array creation or using the controlled specialization. This leads to better compatibility with the draft spec for the QIR base profile.