### PR TITLE
Creating LLVM runtime IR

### DIFF
--- a/src/Qir/Runtime/CMakeLists.txt
+++ b/src/Qir/Runtime/CMakeLists.txt
@@ -8,8 +8,9 @@ project(qirruntime)
 # specify the C++ standard, compiler and other tools
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
+
+include(${CMAKE_SOURCE_DIR}/cmake/LlvmIr.cmake)
 
 # Always use available Spectre mitigations where available
 if (NOT APPLE)
@@ -32,5 +33,7 @@ set(common_includes "${PROJECT_SOURCE_DIR}/../Common/Include")
 
 include(qir_cmake_include)
 
+
 add_subdirectory(lib)
 add_subdirectory(unittests)
+

--- a/src/Qir/Runtime/cmake/LlvmIr.cmake
+++ b/src/Qir/Runtime/cmake/LlvmIr.cmake
@@ -1,0 +1,68 @@
+function (microsoft_add_ir_library)
+  set(prefix "IR")
+
+  set(flags "")
+  set(singleValues TARGET OUTPUT)
+  set(multiValues SOURCES INCLUDES)
+
+  include(CMakeParseArguments)
+  cmake_parse_arguments(${prefix}
+                   "${flags}"
+                   "${singleValues}"
+                   "${multiValues}"
+                    ${ARGN})
+
+  list(LENGTH IR_UNPARSED_ARGUMENTS SIZE)
+  list(GET IR_UNPARSED_ARGUMENTS 0 IR_TARGET)
+  if(SIZE GREATER 1)
+    list(GET IR_UNPARSED_ARGUMENTS 1 IR_OUTPUT)
+  endif()
+
+
+  set(include_flags "")
+  foreach(flag IN ITEMS  ${IR_INCLUDES})
+    set(include_flags "${include_flags}"  "-I${flag}")
+  endforeach()
+
+  set(output_files "")
+  foreach(source IN ITEMS ${IR_SOURCES})
+    set(outputfile "${CMAKE_CURRENT_BINARY_DIR}/${source}.ll" )
+    set(inputfile "${CMAKE_CURRENT_SOURCE_DIR}/${source}" )
+
+    add_custom_command(OUTPUT ${outputfile}
+        COMMAND clang++ # TODO: Use CMAKE_CXX_COMPILER
+        ARGS ${include_flags} ${CMAKE_CXX_FLAGS} "-S" "-emit-llvm" "-fPIC" "-o" ${outputfile} ${inputfile}
+      )
+
+    set(output_files ${output_files} ${outputfile} )    
+  endforeach()
+
+  add_custom_target(${IR_TARGET}
+                DEPENDS ${output_files})
+
+  SET(${IR_OUTPUT}  "${output_files}" CACHE INTERNAL ${IR_OUTPUT})
+endfunction ()
+
+
+function (microsoft_link_ir)
+  set(prefix "LINK")
+
+  set(flags "")
+  set(singleValues TARGET OUTPUT)
+  set(multiValues DEPENDS SOURCES)
+  cmake_parse_arguments(${prefix}
+                   "${flags}"
+                   "${singleValues}"
+                   "${multiValues}"
+                  ${ARGN})
+
+  add_custom_command(OUTPUT ${LINK_OUTPUT}
+                     COMMAND llvm-link 
+                     ARGS "-S" "-o" ${LINK_OUTPUT} ${LINK_SOURCES}
+                     DEPENDS ${LINK_DEPENDS}
+                     COMMAND_EXPAND_LISTS)
+
+  add_custom_target(${LINK_TARGET}
+                    DEPENDS ${LINK_OUTPUT})
+
+endfunction()

--- a/src/Qir/Runtime/lib/QIR/CMakeLists.txt
+++ b/src/Qir/Runtime/lib/QIR/CMakeLists.txt
@@ -23,6 +23,7 @@ set(rt_sup_source_files
 
 # Produce object lib we'll use to create a shared lib (so/dll) later on
 add_library(qir-rt-support-obj OBJECT ${rt_sup_source_files})
+
 target_source_from_qir(qir-rt-support-obj bridge-rt.ll)
 target_include_directories(qir-rt-support-obj PUBLIC 
     ${public_includes}   
@@ -30,6 +31,14 @@ target_include_directories(qir-rt-support-obj PUBLIC
 )
 set_property(TARGET qir-rt-support-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(qir-rt-support-obj PRIVATE EXPORT_QIR_API)
+
+
+#+++++++++++++++++++++++++++++++++++++
+# qir-rt as LLVM IR
+#+++++++++++++++++++++++++++++++++++++
+microsoft_add_ir_library(qir-rt-support-obj-ir qir-rt-support-obj-ir-files SOURCES ${rt_sup_source_files} INCLUDES ${public_includes} ${common_includes})
+
+
 
 #+++++++++++++++++++++++++++++++++++++
 # qir-qis
@@ -55,3 +64,20 @@ install(TARGETS Microsoft.Quantum.Qir.Runtime
   LIBRARY DESTINATION "${CMAKE_BINARY_DIR}/bin"
   ARCHIVE DESTINATION "${CMAKE_BINARY_DIR}/bin"
 )
+
+
+#+++++++++++++++++++++++++++++++++++++
+# qir-rt combined LLVM IR 
+#+++++++++++++++++++++++++++++++++++++
+
+microsoft_link_ir(
+    TARGET runtime-qir
+    OUTPUT "runtime.ll"
+    DEPENDS qir-rt-support-obj-ir
+    SOURCES ${qir-rt-support-obj-ir-files}
+)
+
+
+
+
+


### PR DESCRIPTION

## Dependencies
This PR has no dependencies.

## Changelog
- CMake module to add C++ IR libraries
- Targets for QIR Runtime to generate `runtime.ll`

## Example

From the build directory, run 
```
ninja runtime-qir
```
This generates a `runtime.ll` which contains LLVM IR for the runtime.