### PR TITLE
Include and library dirs for OpenMP

### DIFF
--- a/src/Simulation/Simulators/SparseSimulator/Native/CMakeLists.txt
+++ b/src/Simulation/Simulators/SparseSimulator/Native/CMakeLists.txt
@@ -17,6 +17,8 @@ if(OpenMP_CXX_FOUND)
 	if (OpenMP_CXX_VERSION_MAJOR GREATER_EQUAL 3)
 		target_compile_definitions(SparseQuantumSimulator PRIVATE DOMP_GE_V3=1)
 	endif()
+	target_include_directories(SparseQuantumSimulator PUBLIC ${OpenMP_CXX_INCLUDE_DIRS})
+ 	target_link_libraries(SparseQuantumSimulator PUBLIC ${OpenMP_CXX_LIBRARIES})
 endif()
 
 # Windows adds a special dllexport command which must be defined


### PR DESCRIPTION
On Mac the OpenMP headers are not in default libraries and paths need to be added explicitly.

See also: https://github.com/sam-jaques/qsharp-runtime/pull/5/files