### PR TITLE
Normalize case of target name when creating Quantum Machine

### DIFF
--- a/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
@@ -24,16 +24,16 @@ namespace Microsoft.Azure.Quantum
             IWorkspace workspace, string targetName, string? storageConnectionString = null)
         {
             // We normalize the case of the provided target name to lower.
-            targetName is null ? null : targetName.ToLowerInvariant();
+            var targetNameNormalized = targetName?.ToLowerInvariant();
 
             var machineName =
-                targetName is null
+                targetNameNormalized is null
                 ? null
-                : targetName.StartsWith("qci.")
+                : targetNameNormalized.StartsWith("qci.")
                 ? "Microsoft.Quantum.Providers.QCI.Targets.QCIQuantumMachine, Microsoft.Quantum.Providers.QCI"
-                : targetName.StartsWith("ionq.")
+                : targetNameNormalized.StartsWith("ionq.")
                 ? "Microsoft.Quantum.Providers.IonQ.Targets.IonQQuantumMachine, Microsoft.Quantum.Providers.IonQ"
-                : targetName.StartsWith("honeywell.")
+                : targetNameNormalized.StartsWith("honeywell.")
                 ? "Microsoft.Quantum.Providers.Honeywell.Targets.HoneywellQuantumMachine, Microsoft.Quantum.Providers.Honeywell"
                 : null;
 
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Quantum
                 ? null
                 : (IQuantumMachine)Activator.CreateInstance(
                     machineType,
-                    targetName,
+                    targetNameNormalized,
                     workspace,
                     storageConnectionString);
         }

--- a/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Azure.Quantum
         public static IQuantumMachine? CreateMachine(
             IWorkspace workspace, string targetName, string? storageConnectionString = null)
         {
+            // We normalize the case of the provided target name to lower.
+            targetName is null ? null : targetName.ToLowerInvariant();
+
             var machineName =
                 targetName is null
                 ? null


### PR DESCRIPTION
This complements the change in the pull request below:
https://github.com/microsoft/qsharp-compiler/pull/1241

By normalizing to lower case the target name, we allow execution even if the target name was provided without matching case.