### PR TITLE
Update namespace summaries and descriptions

### DIFF
--- a/src/Simulation/QSharpFoundation/Diagnostics/Properties/NamespaceInfo.qs
+++ b/src/Simulation/QSharpFoundation/Diagnostics/Properties/NamespaceInfo.qs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-/// # Summary
-/// This namespace contains functions and operations useful for diagnostic
-/// purposes, including assert operations and claim functions.
-namespace Microsoft.Quantum.Diagnostics {}

--- a/src/Simulation/QSharpFoundation/Random/Properties/NamespaceInfo.qs
+++ b/src/Simulation/QSharpFoundation/Random/Properties/NamespaceInfo.qs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// # Summary
+/// This namespace contains functions, operations, and UDTs 
+/// for working with random values and probability distributions.
+namespace Microsoft.Quantum.Random {}

--- a/src/Simulation/TargetDefinitions/Intrinsic/Properties/NamespaceInfo.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/Properties/NamespaceInfo.qs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// # Summary
+/// This namespace contains built-in operations that represent
+/// commonly used quantum gates and measurements.
+///
+/// # Description
+/// To learn more about the operations in this namespace, see 
+/// [The Prelude](xref:microsoft.quantum.libraries.overview.standard.prelude).
+namespace Microsoft.Quantum.Intrinsic {}


### PR DESCRIPTION
This change completes https://github.com/microsoft/QuantumLibraries/issues/483.

* The deleted file is superseded by [the one in the libraries](https://github.com/microsoft/QuantumLibraries/blob/main/Standard/src/Diagnostics/Properties/NamespaceInfo.qs) (we can see it from our current documentation), so removing it reduces confusion around the sources of our docs.