### PR TITLE
Excluded temporary copy of SparseQuantumSimulator dynamic library in .gitignore.

### DIFF
--- a/src/Simulation/Native/.gitignore
+++ b/src/Simulation/Native/.gitignore
@@ -10,3 +10,6 @@ foo*
 CMakeFiles/
 CMakeCache.txt
 *.so
+win10/SparseQuantumSimulator.dll
+osx/libSparseQuantumSimulator.dylib
+linux/libSparseQuantumSimulator.so


### PR DESCRIPTION
The native part of the Sparse Simulator is copied to near the native part of the Full-State Simulator (and native libs like OpenMP) for subsequent packaging. I'm excluding those temporary copies in `.gitignore`.