### PR TITLE
Enabled listing the sparse simulator in the command line help.

### DIFF
--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Quantum.EntryPointDriver
                 suggestions: new[]
                 {
                     this.settings.QuantumSimulatorName,
-                    // this.settings.SparseSimulatorName, // uncomment to enable listing the sparse simulator in the command line help
+                    this.settings.SparseSimulatorName,
                     this.settings.ToffoliSimulatorName,
                     this.settings.ResourcesEstimatorName,
                     this.settings.DefaultSimulatorName


### PR DESCRIPTION
**Related (but CI-independent) PR(s):**
* quantum-docs-private: [Added the SparseSimulator to the docs](https://github.com/MicrosoftDocs/quantum-docs-private/pull/728)
* iqsharp: [Add magic command and QSharpCallable method](https://github.com/microsoft/iqsharp/pull/587)