### PR TITLE
Revert "Enabled listing the sparse simulator in the command line help."

### DIFF
--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Quantum.EntryPointDriver
                 suggestions: new[]
                 {
                     this.settings.QuantumSimulatorName,
-                    this.settings.SparseSimulatorName,
+                    // this.settings.SparseSimulatorName, // uncomment to enable listing the sparse simulator in the command line help
                     this.settings.ToffoliSimulatorName,
                     this.settings.ResourcesEstimatorName,
                     this.settings.DefaultSimulatorName


### PR DESCRIPTION
Reverts microsoft/qsharp-runtime#952 which wasn't to be merged until March release.