### PR TITLE
Extend IQirSubmitter and IQSharpSubmitter interfaces

### DIFF
--- a/src/Simulation/Core/Submitters/EntryPointArgument.cs
+++ b/src/Simulation/Core/Submitters/EntryPointArgument.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Quantum.Runtime.Submitters
+{
+    /// <summary>
+    /// Options for a job submitted to Azure Quantum.
+    /// </summary>
+    public class EntryPointArgument
+    {
+        public string Name { get; }
+
+        public Type Type { get; }
+
+        public object Value { get; }
+
+        public EntryPointArgument(string name, Type type, object value) => (Name, Type, Value) = (name, type, value);
+    }
+}

--- a/src/Simulation/Core/Submitters/IQSharpSubmitter.cs
+++ b/src/Simulation/Core/Submitters/IQSharpSubmitter.cs
@@ -3,8 +3,11 @@
 
 #nullable enable
 
-using Microsoft.Quantum.Simulation.Core;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
+
+using Microsoft.Quantum.Simulation.Core;
 
 namespace Microsoft.Quantum.Runtime.Submitters
 {
@@ -29,6 +32,22 @@ namespace Microsoft.Quantum.Runtime.Submitters
         /// <returns>The submitted job.</returns>
         Task<IQuantumMachineJob> SubmitAsync<TIn, TOut>(
             EntryPointInfo<TIn, TOut> entryPoint, TIn argument, SubmissionOptions options);
+
+        /// <summary>
+        /// Submits a job to execute a Q# program without waiting for execution to complete.
+        /// </summary>
+        /// <typeparam name="TIn">The entry point argument type.</typeparam>
+        /// <typeparam name="TOut">The entry point return type.</typeparam>
+        /// <param name="entryPoint">The entry point information for the submitted program.</param>
+        /// <param name="arguments">List of arguments used to execute the entry point.</param>
+        /// <param name="options">Additional options for the submission.</param>
+        /// <param name="options">QIR bitcode corresponding to the program.</param>
+        /// <returns>The submitted job.</returns>
+        Task<IQuantumMachineJob> SubmitAsync<TIn, TOut>(
+            EntryPointInfo<TIn, TOut> entryPoint,
+            IReadOnlyList<EntryPointArgument> arguments,
+            SubmissionOptions options,
+            Stream qir);
 
         /// <summary>
         /// Validates a Q# program for execution on Azure Quantum.

--- a/src/Simulation/Core/Submitters/IQirSubmitter.cs
+++ b/src/Simulation/Core/Submitters/IQirSubmitter.cs
@@ -31,6 +31,20 @@ namespace Microsoft.Quantum.Runtime.Submitters
             Stream qir, string entryPoint, IReadOnlyList<Argument> arguments, SubmissionOptions options);
 
         /// <summary>
+        /// Submits a job to execute a QIR program without waiting for execution to complete.
+        /// </summary>
+        /// <param name="qir">The QIR program as a byte stream.</param>
+        /// <param name="entryPoint">The fully-qualified name of the entry point to execute.</param>
+        /// <param name="arguments">List of arguments used to execute the entry point.</param>
+        /// <param name="options">Additional options for the submission.</param>
+        /// <returns>The submitted job.</returns>
+        Task<IQuantumMachineJob> SubmitAsync(
+            Stream qir,
+            string entryPoint,
+            IReadOnlyList<EntryPointArgument> arguments, 
+            SubmissionOptions submissionOptions);
+
+        /// <summary>
         /// Validates a QIR program for execution on Azure Quantum.
         /// </summary>
         /// <param name="qir">The QIR program as a byte stream.</param>

--- a/src/Simulation/EntryPointDriver/Mock/NoOpQirSubmitter.cs
+++ b/src/Simulation/EntryPointDriver/Mock/NoOpQirSubmitter.cs
@@ -24,6 +24,12 @@ namespace Microsoft.Quantum.EntryPointDriver.Mock
         public Task<IQuantumMachineJob> SubmitAsync(
             Stream qir, string entryPoint, IReadOnlyList<Argument> arguments, SubmissionOptions options) =>
             Task.FromResult<IQuantumMachineJob>(new ExampleJob());
+        
+        public Task<IQuantumMachineJob> SubmitAsync(
+            Stream qir,
+            string entryPoint,
+            IReadOnlyList<EntryPointArgument> arguments,
+            SubmissionOptions submissionOptions) => Task.FromResult<IQuantumMachineJob>(new ExampleJob());
 
         public string? Validate(
             Stream qir, string entryPoint, IReadOnlyList<Argument> arguments) =>

--- a/src/Simulation/EntryPointDriver/Mock/NoOpSubmitter.cs
+++ b/src/Simulation/EntryPointDriver/Mock/NoOpSubmitter.cs
@@ -28,9 +28,21 @@ namespace Microsoft.Quantum.EntryPointDriver.Mock
             Stream qir, string entryPoint, IReadOnlyList<Argument> arguments, SubmissionOptions options) =>
             Task.FromResult<IQuantumMachineJob>(new ExampleJob());
 
+        public Task<IQuantumMachineJob> SubmitAsync(
+            Stream qir,
+            string entryPoint,
+            IReadOnlyList<EntryPointArgument> arguments,
+            SubmissionOptions submissionOptions) => Task.FromResult<IQuantumMachineJob>(new ExampleJob());
+
         public Task<IQuantumMachineJob> SubmitAsync<TIn, TOut>(
             EntryPointInfo<TIn, TOut> entryPoint, TIn argument, SubmissionOptions options) =>
             Task.FromResult<IQuantumMachineJob>(new ExampleJob());
+
+        public Task<IQuantumMachineJob> SubmitAsync<TIn, TOut>(
+            EntryPointInfo<TIn, TOut> entryPoint,
+            IReadOnlyList<EntryPointArgument> arguments,
+            SubmissionOptions options,
+            Stream qir) => Task.FromResult<IQuantumMachineJob>(new ExampleJob());
 
         public string? Validate<TIn, TOut>(EntryPointInfo<TIn, TOut> entryPoint, TIn argument) => null;
 


### PR DESCRIPTION
This change extends the `IQirSubmitter` and the `IQSharpSubmitter` to support a new QIR submission format.