### PR TITLE
Fix handling and wording for az submission

### DIFF
--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -929,7 +929,7 @@ let ``Submit has required options`` () =
 let ``Submit catches exceptions`` () =
     let given = test "Returns Unit"
     given submitWithErrorTarget
-    |> failsWith "Something went wrong when submitting the program to the Azure Quantum service.
+    |> failsWith "An error occurred when submitting to the Azure Quantum service.
 
                   This machine always has an error."
 

--- a/src/Simulation/EntryPointDriver/Azure/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure/Azure.cs
@@ -207,12 +207,12 @@ namespace Microsoft.Quantum.EntryPointDriver
         {
             void DisplayAzureQuantumException(AzureQuantumException ex) =>
                 DisplayError(
-                    "Something went wrong when submitting the program to the Azure Quantum service.",
+                    "An error occurred when submitting to the Azure Quantum service.",
                     ex.Message);
             
             void DisplayQuantumProcessorTranslationException(QuantumProcessorTranslationException ex) =>
                 DisplayError(
-                    "Something went wrong when performing translation to the intermediate representation used by the target quantum machine.",
+                    "Unable to translate the program for execution on the target quantum machine.",
                     ex.Message);
 
             bool HandleTargetInvocationException(TargetInvocationException ex)


### PR DESCRIPTION
This includes the fix for handling errors during submission to the service (previously #949) and an update to the wording of those error messages (#957)