### PR TITLE
Remove llvm-ar from cgmanifest

### DIFF
--- a/src/Qir/Common/Externals/cgmanifest.json
+++ b/src/Qir/Common/Externals/cgmanifest.json
@@ -2,16 +2,6 @@
     "Registrations":[
         {
             "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "llvm-ar.exe",
-                    "Version": "10.0.0",
-                    "DownloadUrl": "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe"
-                }
-            }
-        },
-        {
-            "Component": {
                 "Type": "git",
                 "Git": { 
                     "RepositoryUrl": "https://github.com/catchorg/Catch2", 


### PR DESCRIPTION
In #556 llvm-ar was removed, but it wasn't removed from this file.