### PR TITLE
Clarify BoolArrayAsBigInt behavior for negative numbers

### DIFF
--- a/src/Simulation/QSharpFoundation/Convert/Convert.qs
+++ b/src/Simulation/QSharpFoundation/Convert/Convert.qs
@@ -85,9 +85,18 @@ namespace Microsoft.Quantum.Convert {
     /// The 0 element of the array is the least significant bit of the big integer.
     /// # Remarks
     /// See [C# BigInteger constructor](https://docs.microsoft.com/dotnet/api/system.numerics.biginteger.-ctor?view=netframework-4.7.2#System_Numerics_BigInteger__ctor_System_Int64_) for more details.
+    /// Note that the Boolean array is padded of the right with `false` values to a length that is a multiple of 8, 
+    /// and then treated as a little-endian notation of a positive or negative number following two's complement semantics.
+    ///
+    /// # Example
+    /// ```qsharp
+    /// let bi1 = BoolArrayAsBigInt([true, false, true]);        // Padded to 10100000 -> 5
+    /// let bi2 = BoolArrayAsBigInt([false, false, false, false, false, false, false, true]); // Not padded -> -128
+    /// ```
     function BoolArrayAsBigInt(a : Bool[]) : BigInt {
         body intrinsic;
     }
+
 
     /// # Summary
     /// Converts a given boolean value to an equivalent string representation.


### PR DESCRIPTION
Fix https://github.com/microsoft/QuantumLibraries/issues/390.