### PR TITLE
Extend submitter factory

### DIFF
--- a/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
@@ -23,8 +23,16 @@ namespace Microsoft.Azure.Quantum
         /// </summary>
         private static readonly ImmutableList<SubmitterInfo> QirSubmitters = ImmutableList.Create(
             new SubmitterInfo(
-                new Regex(@"\Amicrosoft\.simulator\.([\w]+\.)*[\w]+\z"),
+                new Regex(@"\Amicrosoft\.simulator\.([\w-_]+\.)*[\w-_]+\z"),
                 "Microsoft.Quantum.Providers.Targets.MicrosoftSimulatorSubmitter, Microsoft.Quantum.Providers.Core",
+                "QirSubmitter"),
+            new SubmitterInfo(
+                new Regex(@"\Aquantinuum\.([\w-_]+\.)*[\w-_]+\z"),
+                "Microsoft.Quantum.Providers.Quantinuum.Targets.QuantinuumQirSubmitter, Microsoft.Quantum.Providers.Honeywell",
+                "QirSubmitter"),
+            new SubmitterInfo(
+                new Regex(@"\Aqci\.([\w-_]+\.)*[\w-_]+\z"),
+                "Microsoft.Quantum.Providers.QCI.Targets.QCIQirSubmitter, Microsoft.Quantum.Providers.QCI",
                 "QirSubmitter"));
 
         private static readonly ImmutableList<SubmitterInfo> QirPayloadGenerators = ImmutableList.Create(

--- a/src/Simulation/EntryPointDriver/Azure/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure/Azure.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.EntryPointDriver
             AzureSettings settings, QSharpSubmission<TIn, TOut> qsSubmission, QirSubmission? qirSubmission)
         {
             LogIfVerbose(settings, settings.ToString());
-
+            LogIfVerbose(settings, $"QIR submission is {((qirSubmission is null) ? "not " : string.Empty)}present.");
             if ((settings.Location is null) && (settings.BaseUri is null))
             {
                 DisplayError($"Either --location or --base-uri must be provided.", null);
@@ -78,16 +78,19 @@ namespace Microsoft.Quantum.EntryPointDriver
             {
                 return SubmitQir(settings, qirSubmitter, qirSubmission);
             }
+            LogIfVerbose(settings, "QIR submitter not found.");
 
             if (QSharpSubmitter(settings) is { } qsSubmitter)
             {
                 return SubmitQSharp(settings, qsSubmitter, qsSubmission);
             }
+            LogIfVerbose(settings, "Q# submitter not found.");
 
             if (QSharpMachine(settings) is { } machine)
             {
                 return SubmitQSharpMachine(settings, machine, qsSubmission);
             }
+            LogIfVerbose(settings, "Q# machine not found.");
 
             if (qirSubmission is null && !(QirSubmitter(settings) is null))
             {

--- a/src/Simulation/EntryPointDriver/Azure/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure/Azure.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.EntryPointDriver
             AzureSettings settings, QSharpSubmission<TIn, TOut> qsSubmission, QirSubmission? qirSubmission)
         {
             LogIfVerbose(settings, settings.ToString());
-            LogIfVerbose(settings, $"QIR submission is {((qirSubmission is null) ? "not " : string.Empty)}present.");
+
             if ((settings.Location is null) && (settings.BaseUri is null))
             {
                 DisplayError($"Either --location or --base-uri must be provided.", null);
@@ -78,19 +78,16 @@ namespace Microsoft.Quantum.EntryPointDriver
             {
                 return SubmitQir(settings, qirSubmitter, qirSubmission);
             }
-            LogIfVerbose(settings, "QIR submitter not found.");
 
             if (QSharpSubmitter(settings) is { } qsSubmitter)
             {
                 return SubmitQSharp(settings, qsSubmitter, qsSubmission);
             }
-            LogIfVerbose(settings, "Q# submitter not found.");
 
             if (QSharpMachine(settings) is { } machine)
             {
                 return SubmitQSharpMachine(settings, machine, qsSubmission);
             }
-            LogIfVerbose(settings, "Q# machine not found.");
 
             if (qirSubmission is null && !(QirSubmitter(settings) is null))
             {


### PR DESCRIPTION
This change extends the submitter factory such that it can create new QIR submitters for standalone executables.