### PR TITLE
Fix for CodeQL comparison alerts

### DIFF
--- a/src/Simulation/Native/src/external/cintrin.hpp
+++ b/src/Simulation/Native/src/external/cintrin.hpp
@@ -13,7 +13,7 @@ template <class M, class I>
 inline void permute_qubits_and_matrix(I *delta_list, unsigned n, M & matrix){
 	using Pair = std::pair<std::size_t, std::size_t>;
 	std::vector<Pair> qubits(n);
-	for (size_t i = 0; i < qubits.size(); ++i){
+	for (std::size_t i = 0; i < qubits.size(); ++i){
 		qubits[i].first = i;
 		qubits[i].second = delta_list[i];
 	}

--- a/src/Simulation/Native/src/external/cintrin.hpp
+++ b/src/Simulation/Native/src/external/cintrin.hpp
@@ -24,7 +24,7 @@ inline void permute_qubits_and_matrix(I *delta_list, unsigned n, M & matrix){
 	for (std::size_t i = 0; i < (1ULL << qubits.size()); ++i){
 		for (std::size_t j = 0; j < (1ULL << qubits.size()); ++j){
 			std::size_t old_i=0, old_j=0;
-			for (unsigned k = 0; k < qubits.size(); ++k){
+			for (std::size_t k = 0; k < qubits.size(); ++k){
 				old_i |= ((i >> k)&1ULL) << qubits[k].first;
 				old_j |= ((j >> k)&1ULL) << qubits[k].first;
 			}

--- a/src/Simulation/Native/src/external/cintrin.hpp
+++ b/src/Simulation/Native/src/external/cintrin.hpp
@@ -13,7 +13,7 @@ template <class M, class I>
 inline void permute_qubits_and_matrix(I *delta_list, unsigned n, M & matrix){
 	using Pair = std::pair<std::size_t, std::size_t>;
 	std::vector<Pair> qubits(n);
-	for (unsigned i = 0; i < qubits.size(); ++i){
+	for (size_t i = 0; i < qubits.size(); ++i){
 		qubits[i].first = i;
 		qubits[i].second = delta_list[i];
 	}

--- a/src/Simulation/Native/src/external/fusion.hpp
+++ b/src/Simulation/Native/src/external/fusion.hpp
@@ -150,7 +150,7 @@ public:
 		for (auto& item : items_){
 			auto const& idx = item.get_indices();
 			IndexVector idx2mat(idx.size());
-			for (unsigned i = 0; i < idx.size(); ++i)
+			for (size_t i = 0; i < idx.size(); ++i)
 				idx2mat[i] = static_cast<unsigned>(((std::equal_range(index_list.begin(), index_list.end(), idx[i])).first - index_list.begin()));
 			
 			#pragma omp parallel for schedule(static)

--- a/src/Simulation/Native/src/external/fusion.hpp
+++ b/src/Simulation/Native/src/external/fusion.hpp
@@ -150,7 +150,7 @@ public:
 		for (auto& item : items_){
 			auto const& idx = item.get_indices();
 			IndexVector idx2mat(idx.size());
-			for (size_t i = 0; i < idx.size(); ++i)
+			for (std::size_t i = 0; i < idx.size(); ++i)
 				idx2mat[i] = static_cast<unsigned>(((std::equal_range(index_list.begin(), index_list.end(), idx[i])).first - index_list.begin()));
 			
 			#pragma omp parallel for schedule(static)
@@ -163,13 +163,13 @@ public:
 
 				for (std::size_t i = 0; i < (1ULL<<N); ++i){
 					unsigned local_i = 0;
-					for (size_t l = 0; l < idx.size(); ++l)
+					for (std::size_t l = 0; l < idx.size(); ++l)
 						local_i |= ((i >> idx2mat[l])&1)<<l;
 						
 					Complex res = 0.;
 					for (std::size_t j = 0; j < (1ULL<<idx.size()); ++j){
 						std::size_t locidx = i;
-						for (size_t l = 0; l < idx.size(); ++l)
+						for (std::size_t l = 0; l < idx.size(); ++l)
 							if (((j >> l)&1) != ((i >> idx2mat[l])&1))
 								locidx ^= (1ULL << idx2mat[l]);
 						res += oldcol[locidx] * item.get_matrix()[local_i][j];

--- a/src/Simulation/Native/src/external/fusion.hpp
+++ b/src/Simulation/Native/src/external/fusion.hpp
@@ -154,7 +154,7 @@ public:
 				idx2mat[i] = static_cast<unsigned>(((std::equal_range(index_list.begin(), index_list.end(), idx[i])).first - index_list.begin()));
 			
 			#pragma omp parallel for schedule(static)
-			for (int k = 0; k < (1ULL<<N); ++k){ // loop over big matrix columns
+			for (unsigned long long k = 0; k < (1ULL<<N); ++k){ // loop over big matrix columns
 				// check if column index satisfies control-mask
 				// if not: leave it unchanged
 				std::vector<Complex> oldcol(1ULL<<N);
@@ -163,13 +163,13 @@ public:
 
 				for (std::size_t i = 0; i < (1ULL<<N); ++i){
 					unsigned local_i = 0;
-					for (unsigned l = 0; l < idx.size(); ++l)
+					for (size_t l = 0; l < idx.size(); ++l)
 						local_i |= ((i >> idx2mat[l])&1)<<l;
 						
 					Complex res = 0.;
 					for (std::size_t j = 0; j < (1ULL<<idx.size()); ++j){
 						std::size_t locidx = i;
-						for (unsigned l = 0; l < idx.size(); ++l)
+						for (size_t l = 0; l < idx.size(); ++l)
 							if (((j >> l)&1) != ((i >> idx2mat[l])&1))
 								locidx ^= (1ULL << idx2mat[l]);
 						res += oldcol[locidx] * item.get_matrix()[local_i][j];

--- a/src/Simulation/Native/src/simulator/kernels.hpp
+++ b/src/Simulation/Native/src/simulator/kernels.hpp
@@ -241,7 +241,7 @@ void apply_controlled_exp(
         std::size_t xy_bits = 0;
         std::size_t yz_bits = 0;
         int y_count = 0;
-        for (unsigned i = 0; i < b.size(); ++i)
+        for (std::size_t i = 0; i < b.size(); ++i)
         {
             switch (b[i])
             {
@@ -514,11 +514,11 @@ bool subsytemwavefunction(
     }
 
     // put back to original sorting:
-    for (size_t i = 0; i < qs.size(); ++i)
+    for (std::size_t i = 0; i < qs.size(); ++i)
     {
         if (sorted[i] != qs[i])
         {
-            for (unsigned p = i + 1; p < qs.size(); ++p)
+            for (std::size_t p = i + 1; p < qs.size(); ++p)
             {
                 if (sorted[p] == qs[i])
                 {

--- a/src/Simulation/Native/src/simulator/kernels.hpp
+++ b/src/Simulation/Native/src/simulator/kernels.hpp
@@ -514,7 +514,7 @@ bool subsytemwavefunction(
     }
 
     // put back to original sorting:
-    for (unsigned i = 0; i < qs.size(); ++i)
+    for (size_t i = 0; i < qs.size(); ++i)
     {
         if (sorted[i] != qs[i])
         {

--- a/src/Simulation/Native/src/simulator/simulator.hpp
+++ b/src/Simulation/Native/src/simulator/simulator.hpp
@@ -416,7 +416,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
     void changebasis(std::vector<Gates::Basis> const& bs, std::vector<logical_qubit_id> const& qs, bool back)
     {
         assert(bs.size() == qs.size());
-        for (size_t i = 0; i < bs.size(); ++i)
+        for (std::size_t i = 0; i < bs.size(); ++i)
             changebasis(bs[i], qs[i], back);
     }
 

--- a/src/Simulation/Native/src/simulator/simulator.hpp
+++ b/src/Simulation/Native/src/simulator/simulator.hpp
@@ -416,7 +416,7 @@ class Simulator : public Microsoft::Quantum::Simulator::SimulatorInterface
     void changebasis(std::vector<Gates::Basis> const& bs, std::vector<logical_qubit_id> const& qs, bool back)
     {
         assert(bs.size() == qs.size());
-        for (unsigned i = 0; i < bs.size(); ++i)
+        for (size_t i = 0; i < bs.size(); ++i)
             changebasis(bs[i], qs[i], back);
     }
 

--- a/src/Simulation/Native/src/simulator/wavefunction.hpp
+++ b/src/Simulation/Native/src/simulator/wavefunction.hpp
@@ -431,7 +431,7 @@ class Wavefunction
     std::vector<logical_qubit_id> get_qubit_ids() const
     {
         std::vector<logical_qubit_id> qs;
-        for (unsigned i = 0; i < qubitmap_.size(); i++)
+        for (size_t i = 0; i < qubitmap_.size(); i++)
         {
             if (qubitmap_[i] != invalid_qubit_position())
             {
@@ -533,7 +533,7 @@ class Wavefunction
         positional_qubit_id p = get_qubit_position(q);
         flush();
         kernels::collapse(wfn_, p, getvalue(q), true);
-        for (int i = 0; i < qubitmap_.size(); ++i)
+        for (size_t i = 0; i < qubitmap_.size(); ++i)
             if (qubitmap_[i] > p && qubitmap_[i] != invalid_qubit_position()) qubitmap_[i]--;
         qubitmap_[q] = invalid_qubit_position();
         --num_qubits_;
@@ -589,7 +589,7 @@ class Wavefunction
 
             // For full state injection we can copy the user's wave function into our store and reorder the
             // positions map without doing any math.
-            for (unsigned i = 0; i < qubits.size(); i++)
+            for (size_t i = 0; i < qubits.size(); i++)
             {
                 qubitmap_[qubits[i]] = i;
             }

--- a/src/Simulation/Native/src/simulator/wavefunction.hpp
+++ b/src/Simulation/Native/src/simulator/wavefunction.hpp
@@ -35,7 +35,7 @@ namespace detail
 inline size_t get_register(const std::vector<positional_qubit_id>& ps, size_t basis_vector)
 {
     size_t result = 0;
-    for (unsigned i = 0; i < ps.size(); ++i)
+    for (size_t i = 0; i < ps.size(); ++i)
     {
         result |= ((basis_vector >> ps[i]) & 1) << i;
     }

--- a/src/Simulation/Native/src/simulator/wavefunction.hpp
+++ b/src/Simulation/Native/src/simulator/wavefunction.hpp
@@ -56,7 +56,7 @@ inline size_t set_register(
     assert(basis_vector_in_ps < (1ull << ps.size()));
 
     size_t result = basis_vector_target & ~qmask;
-    for (unsigned i = 0; i < ps.size(); ++i)
+    for (size_t i = 0; i < ps.size(); ++i)
     {
         result |= ((basis_vector_in_ps >> i) & 1) << ps[i];
     }


### PR DESCRIPTION
Fix for alerts from static code analyzer CodeQL, about comparisons between variables of type `unsigned int` and wider types (`size_type` and `unsigned long long`).