### PR TITLE
Refactoring decompositions for hardware patterns

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "Microsoft.Quantum.Sdk": "0.24.203411-beta"
+        "Microsoft.Quantum.Sdk": "0.24.205218-beta"
     }
 }

--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.201332" />
+    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.205218-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
+++ b/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.203411-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.205218-beta" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
   </ItemGroup>
 

--- a/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.201332" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.205218-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/TargetDefinitions/Decompositions/CCNOTFromCCZ.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CCNOTFromCCZ.qs
@@ -30,7 +30,52 @@ namespace Microsoft.Quantum.Intrinsic {
             }
         }
         controlled (ctls, ...) {
-            Controlled X (ctls + [control1, control2], target);
+            if Length(ctls) == 0 {
+                CCNOT(control1, control2, target);
+            }
+            elif Length(ctls) == 1 {
+                Controlled X([ctls[0], control1, control2], target);
+            }
+            elif Length(ctls) == 2 {
+                Controlled X([ctls[0], ctls[1], control1, control2], target);
+            }
+            elif Length(ctls) == 3 {
+                Controlled X([ctls[0], ctls[1], ctls[2], control1, control2], target);
+            }
+            elif Length(ctls) == 4 {
+                Controlled X([ctls[0], ctls[1], ctls[2], ctls[3], control1, control2], target);
+            }
+            elif Length(ctls) == 5 {
+                Controlled X([ctls[0], ctls[1], ctls[2], ctls[3], ctls[4], control1, control2], target);
+            }
+            elif Length(ctls) == 6 {
+                Controlled X([ctls[0], ctls[1], ctls[2], ctls[3], ctls[4], ctls[5], control1, control2], target);
+            }
+            elif Length(ctls) == 7 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    Controlled X([temp, ctls[2], ctls[3], ctls[4], ctls[5], ctls[6], control1, control2], target);
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                }
+                apply {
+                    Controlled X([temps[0], temps[1], ctls[4], ctls[5], ctls[6], ctls[7], control1, control2], target);
+                }
+            }
+            else {
+                fail "Too many control qubits specified to CCNOT gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled X, (ctls, qubit));
+            }
         }
         adjoint self;
     }

--- a/src/Simulation/TargetDefinitions/Decompositions/CNOTFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CNOTFromSinglyControlled.qs
@@ -35,14 +35,44 @@ namespace Microsoft.Quantum.Intrinsic {
             ApplyControlledX(control, target);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyControlledX(control, target);
             }
-            elif (Length(ctls) == 1) {
+            elif Length(ctls) == 1 {
                 CCNOT(ctls[0], control, target);
             }
+            elif Length(ctls) == 2 {
+                Controlled X([ctls[0], ctls[1], control], target);
+            }
+            elif Length(ctls) == 3 {
+                Controlled X([ctls[0], ctls[1], ctls[2], control], target);
+            }
+            elif Length(ctls) == 4 {
+                Controlled X([ctls[0], ctls[1], ctls[2], ctls[3], control], target);
+            }
+            elif Length(ctls) == 5 {
+                Controlled X([ctls[0], ctls[1], ctls[2], ctls[3], ctls[4], control], target);
+            }
+            elif Length(ctls) == 6 {
+                Controlled X([ctls[0], ctls[1], ctls[2], ctls[3], ctls[4], ctls[5], control], target);
+            }
+            elif Length(ctls) == 7 {
+                Controlled X([ctls[0], ctls[1], ctls[2], ctls[3], ctls[4], ctls[5], ctls[6], control], target);
+            }
+            elif Length(ctls) == 8 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    Controlled X([temp, ctls[2], ctls[3], ctls[4], ctls[5], ctls[6], ctls[7], control], target);
+                }
+            }
             else {
-                ApplyWithLessControlsA(Controlled CNOT, (ctls, (control, target)));
+                fail "Too many control qubits specified to CNOT gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled X, (ctls, qubit));
             }
         }
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Decompositions/CZFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CZFromSinglyControlled.qs
@@ -41,8 +41,95 @@ namespace Microsoft.Quantum.Canon {
             elif Length(ctls) == 1 {
                 CCZ(ctls[0], control, target);
             }
+            elif Length(ctls) == 2 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    CCZ(temp, control, target);
+                }
+            }
+            elif Length(ctls) == 3 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], control, temps[1]);
+                }
+                apply {
+                    CCZ(temps[0], temps[1], target);
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    CCZ(temps[2], control, target);
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], control, temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                }
+                apply {
+                    CCZ(temps[2], temps[3], target);
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    CCZ(temps[4], control, target);
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], control, temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                }
+                apply {
+                    CCZ(temps[4], temps[5], target);
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[7];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                    PhaseCCX(temps[4], temps[5], temps[6]);
+                }
+                apply {
+                    CCZ(temps[6], control, target);
+                }
+            }
             else {
-                ApplyWithLessControlsA(Controlled CZ, (ctls, (control, target)));
+                fail "Too many control qubits specified to CZ gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled Z, (ctls, qubit));
             }
         }
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Decompositions/ExpFracFromExpUtil.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ExpFracFromExpUtil.qs
@@ -52,4 +52,17 @@ namespace Microsoft.Quantum.Intrinsic {
             ExpFrac(paulis, -numerator, power, qubits);
         }
     }
+
+    internal operation ApplyGlobalPhaseFracWithR1Frac (numerator : Int, power : Int) : Unit is Adj + Ctl {
+        body (...) {}
+        controlled (ctrls, ...) {
+            let numControls =  Length(ctrls);
+            if (numControls > 0 ) {
+                // Invoke Controlled R1Frac, which will recursively call back into ApplyGlobalPhase.
+                // Each time the controls is one shorter, until it is empty and the recursion stops.
+                Controlled R1Frac(ctrls[1 .. numControls - 1], (numerator, power, ctrls[0]));
+            }
+        }
+    }
+
 }

--- a/src/Simulation/TargetDefinitions/Decompositions/HFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/HFromSinglyControlled.qs
@@ -24,22 +24,113 @@ namespace Microsoft.Quantum.Intrinsic {
             ApplyUncontrolledH(qubit);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledH(qubit);
             }
-            elif (Length(ctls) == 1) {
-                within{
-                    S(qubit);
-                    H(qubit);
-                    T(qubit);
-                } apply {
-                    CNOT(ctls[0], qubit);
+            elif Length(ctls) == 1 {
+                CH(ctls[0], qubit);
+            }
+            elif Length(ctls) == 2 {
+                CCH(ctls[0], ctls[1], qubit);
+            }
+            elif Length(ctls) == 3 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    CCH(temp, ctls[2], qubit);
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                }
+                apply {
+                    CCH(temps[0], temps[1], qubit);
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    CCH(temps[2], ctls[4], qubit);
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                }
+                apply {
+                    CCH(temps[2], temps[3], qubit);
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    CCH(temps[4], ctls[6], qubit);
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                }
+                apply {
+                    CCH(temps[4], temps[5], qubit);
                 }
             }
             else {
-                ApplyWithLessControlsA(Controlled H, (ctls, qubit));
+                fail "Too many control qubits specified to H gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled H, (ctls, qubit));
             }
         }
         adjoint self;
+    }
+
+    internal operation CH(control : Qubit, target : Qubit) : Unit is Adj {
+        within {
+            S(target);
+            H(target);
+            T(target);
+        }
+        apply {
+            CNOT(control, target);
+        }
+    }
+
+    internal operation CCH(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+        within {
+            S(target);
+            H(target);
+            T(target);
+        }
+        apply {
+            CCNOT(control1, control2, target);
+        }
     }
 }

--- a/src/Simulation/TargetDefinitions/Decompositions/RFromSinglyControlledR1.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RFromSinglyControlledR1.qs
@@ -43,12 +43,35 @@ namespace Microsoft.Quantum.Intrinsic {
     internal operation ApplyGlobalPhase (theta : Double) : Unit is Ctl + Adj {
         body (...) {}
         controlled (ctls, (...)) {
-            if (Length(ctls) > 0) {
-                let qubit = ctls[0];
-                let rest = ctls[1...];
-                // Invoke Controlled R1, which will recursively call back into ApplyGlobalPhase.
-                // Each time the ctls array is one shorter, until it is empty and the recursion stops.
-                Controlled R1(rest, (theta, qubit));
+            if Length(ctls) == 0 {
+                // Noop
+            }
+            elif Length(ctls) == 1 {
+                Rz(theta, ctls[0]);
+            }
+            elif Length(ctls) == 2 {
+                Controlled R1([ctls[1]], (theta, ctls[0]));
+            }
+            elif Length(ctls) == 3 {
+                Controlled R1([ctls[1], ctls[2]], (theta, ctls[0]));
+            }
+            elif Length(ctls) == 4 {
+                Controlled R1([ctls[1], ctls[2], ctls[3]], (theta, ctls[0]));
+            }
+            elif Length(ctls) == 5 {
+                Controlled R1([ctls[1], ctls[2], ctls[3], ctls[4]], (theta, ctls[0]));
+            }
+            elif Length(ctls) == 6 {
+                Controlled R1([ctls[1], ctls[2], ctls[3], ctls[4], ctls[5]], (theta, ctls[0]));
+            }
+            elif Length(ctls) == 7 {
+                Controlled R1([ctls[1], ctls[2], ctls[3], ctls[4], ctls[5], ctls[6]], (theta, ctls[0]));
+            }
+            elif Length(ctls) == 8 {
+                Controlled R1([ctls[1], ctls[2], ctls[3], ctls[4], ctls[5], ctls[6], ctls[7]], (theta, ctls[0]));
+            }
+            else {
+                fail "Too many controls specified to R gate.";
             }
         }
     }

--- a/src/Simulation/TargetDefinitions/Decompositions/RxFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RxFromSinglyControlled.qs
@@ -32,19 +32,16 @@ namespace Microsoft.Quantum.Intrinsic {
             ApplyUncontrolledRx(theta, qubit);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledRx(theta, qubit);
             }
-            elif (Length(ctls) == 1) {
+            else {
                 within {
                     MapPauli(qubit, PauliZ, PauliX);
                 }
                 apply {
                     Controlled Rz(ctls, (theta, qubit));
                 }
-            }
-            else {
-                ApplyWithLessControlsA(Controlled Rx, (ctls, (theta, qubit)));
             }
         }
         adjoint (...) {

--- a/src/Simulation/TargetDefinitions/Decompositions/RyFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RyFromSinglyControlled.qs
@@ -32,19 +32,16 @@ namespace Microsoft.Quantum.Intrinsic {
             ApplyUncontrolledRy(theta, qubit);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledRy(theta, qubit);
             }
-            elif (Length(ctls) == 1) {
+            else {
                 within {
                     MapPauli(qubit, PauliZ, PauliY);
                 }
                 apply {
                     Controlled Rz(ctls, (theta, qubit));
                 }
-            }
-            else {
-                ApplyWithLessControlsA(Controlled Ry, (ctls, (theta, qubit)));
             }
         }
         adjoint (...) {

--- a/src/Simulation/TargetDefinitions/Decompositions/RzFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RzFromSinglyControlled.qs
@@ -33,20 +33,111 @@ namespace Microsoft.Quantum.Intrinsic {
         }
         controlled (ctls, ...) {
             if (Length(ctls) == 0) {
-                Rz(theta, qubit);
+                ApplyUncontrolledRz(theta, qubit);
             }
-            elif (Length(ctls) == 1) {
-                Rz(theta/2.0, qubit);
-                CNOT(ctls[0], qubit);
-                Rz(-theta/2.0, qubit);
-                CNOT(ctls[0], qubit);
+            elif Length(ctls) == 1 {
+                CRz(ctls[0], theta, qubit);
+            }
+            elif Length(ctls) == 2 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    CRz(temp, theta, qubit);
+                }
+            }
+            elif Length(ctls) == 3 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], temps[0], temps[1]);
+                }
+                apply {
+                    CRz(temps[1], theta, qubit);
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    CRz(temps[2], theta, qubit);
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], temps[0], temps[2]);
+                    PhaseCCX(temps[1], temps[2], temps[3]);
+                }
+                apply {
+                    CRz(temps[3], theta, qubit);
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    CRz(temps[4], theta, qubit);
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], temps[0], temps[3]);
+                    PhaseCCX(temps[1], temps[2], temps[4]);
+                    PhaseCCX(temps[3], temps[4], temps[5]);
+                }
+                apply {
+                    CRz(temps[5], theta, qubit);
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[7];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                    PhaseCCX(temps[4], temps[5], temps[6]);
+                }
+                apply {
+                    CRz(temps[6], theta, qubit);
+                }
             }
             else {
-                ApplyWithLessControlsA(Controlled Rz, (ctls, (theta, qubit)));
+                fail "Too many control qubits specified to Rz gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled Rz, (ctls, qubit));
             }
         }
         adjoint (...) {
             Rz(-theta, qubit);
         }
+    }
+
+    internal operation CRz(control : Qubit, theta : Double, target : Qubit) : Unit is Adj {
+        Rz(theta / 2.0, target);
+        CNOT(control, target);
+        Rz(-theta / 2.0, target);
+        CNOT(control, target);
     }
 }

--- a/src/Simulation/TargetDefinitions/Decompositions/RzFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RzFromSinglyControlled.qs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Intrinsic {
             ApplyUncontrolledRz(theta, qubit);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledRz(theta, qubit);
             }
             elif Length(ctls) == 1 {

--- a/src/Simulation/TargetDefinitions/Decompositions/SFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/SFromSinglyControlled.qs
@@ -26,34 +26,184 @@ namespace Microsoft.Quantum.Intrinsic {
             ApplyUncontrolledSAdj(qubit);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledS(qubit);
             }
-            elif (Length(ctls) == 1) {
-                T(ctls[0]);
-                T(qubit);
-                CNOT(ctls[0], qubit);
-                Adjoint T(qubit);
-                CNOT(ctls[0], qubit);
+            elif Length(ctls) == 1 {
+                CS(ctls[0], qubit);
+            }
+            elif Length(ctls) == 2 {
+                Controlled CS([ctls[0]], (ctls[1], qubit));
+            }
+            elif Length(ctls) == 3 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    Controlled CS([temp], (ctls[2], qubit));
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                }
+                apply {
+                    Controlled CS([temps[0]], (temps[1], qubit));
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    Controlled CS([temps[2]], (ctls[4], qubit));
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                }
+                apply {
+                    Controlled CS([temps[2]], (temps[3], qubit));
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    Controlled CS([temps[4]], (ctls[6], qubit));
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                }
+                apply {
+                    Controlled CS([temps[4]], (temps[5], qubit));
+                }
             }
             else {
-                ApplyWithLessControlsA(Controlled S, (ctls, qubit));
+                fail "Too many control qubits specified to S gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled S, (ctls, qubit));
             }
         }
         controlled adjoint (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledSAdj(qubit);
             }
-            elif (Length(ctls) == 1) {
-                Adjoint T(ctls[0]);
-                Adjoint T(qubit);
-                CNOT(ctls[0], qubit);
-                T(qubit);
-                CNOT(ctls[0], qubit);
+            elif Length(ctls) == 1 {
+                Adjoint CS(ctls[0], qubit);
+            }
+            elif Length(ctls) == 2 {
+                Controlled Adjoint CS([ctls[0]], (ctls[1], qubit));
+            }
+            elif Length(ctls) == 3 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    Controlled Adjoint CS([temp], (ctls[2], qubit));
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                }
+                apply {
+                    Controlled Adjoint CS([temps[0]], (temps[1], qubit));
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    Controlled Adjoint CS([temps[2]], (ctls[4], qubit));
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                }
+                apply {
+                    Controlled Adjoint CS([temps[2]], (temps[3], qubit));
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    Controlled Adjoint CS([temps[4]], (ctls[6], qubit));
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                }
+                apply {
+                    Controlled Adjoint CS([temps[4]], (temps[5], qubit));
+                }
             }
             else {
-                ApplyWithLessControlsA(Controlled Adjoint S, (ctls, qubit));
+                fail "Too many control qubits specified to Adjoint S gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled Adjoint S, (ctls, qubit));
             }
         }
+    }
+
+    internal operation CS(control : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        T(control);
+        T(target);
+        CNOT(control, target);
+        Adjoint T(target);
+        CNOT(control, target);
     }
 }

--- a/src/Simulation/TargetDefinitions/Decompositions/TFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/TFromSinglyControlled.qs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Intrinsic {
+    open Microsoft.Quantum.Math;
 
     /// # Summary
     /// Applies the π/8 gate to a single qubit.
@@ -26,34 +27,223 @@ namespace Microsoft.Quantum.Intrinsic {
             ApplyUncontrolledTAdj(qubit);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledT(qubit);
             }
-            elif (Length(ctls) == 1) {
-                R1Frac(1, 3, ctls[0]);
-                R1Frac(1, 3, qubit);
-                CNOT(ctls[0], qubit);
-                Adjoint R1Frac(1, 3, qubit);
-                CNOT(ctls[0], qubit);
+            elif Length(ctls) == 1 {
+                CT(ctls[0], qubit);
+            }
+            elif Length(ctls) == 2 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    CT(temp, qubit);
+                }
+            }
+            elif Length(ctls) == 3 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], temps[0], temps[1]);
+                }
+                apply {
+                    CT(temps[1], qubit);
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    CT(temps[2], qubit);
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], temps[0], temps[2]);
+                    PhaseCCX(temps[1], temps[2], temps[3]);
+                }
+                apply {
+                    CT(temps[3], qubit);
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    CT(temps[4], qubit);
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], temps[0], temps[3]);
+                    PhaseCCX(temps[1], temps[2], temps[4]);
+                    PhaseCCX(temps[3], temps[4], temps[5]);
+                }
+                apply {
+                    CT(temps[5], qubit);
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], temps[0], temps[3]);
+                    PhaseCCX(temps[1], temps[2], temps[4]);
+                    PhaseCCX(temps[3], temps[4], temps[5]);
+                }
+                apply {
+                    CT(temps[5], qubit);
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[7];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                    PhaseCCX(temps[4], temps[5], temps[6]);
+                }
+                apply {
+                    CT(temps[6], qubit);
+                }
             }
             else {
-                ApplyWithLessControlsA(Controlled T, (ctls, qubit));
+                fail "Too many control qubits specified to T gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled T, (ctls, qubit));
             }
         }
         controlled adjoint (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledTAdj(qubit);
             }
-            elif (Length(ctls) == 1) {
-                Adjoint R1Frac(1, 3, ctls[0]);
-                Adjoint R1Frac(1, 3, qubit);
-                CNOT(ctls[0], qubit);
-                R1Frac(1, 3, qubit);
-                CNOT(ctls[0], qubit);
+            elif Length(ctls) == 1 {
+                Adjoint CT(ctls[0], qubit);
+            }
+            elif Length(ctls) == 2 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    Adjoint CT(temp, qubit);
+                }
+            }
+            elif Length(ctls) == 3 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], temps[0], temps[1]);
+                }
+                apply {
+                    Adjoint CT(temps[1], qubit);
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    Adjoint CT(temps[2], qubit);
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], temps[0], temps[2]);
+                    PhaseCCX(temps[1], temps[2], temps[3]);
+                }
+                apply {
+                    Adjoint CT(temps[3], qubit);
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    Adjoint CT(temps[4], qubit);
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], temps[0], temps[3]);
+                    PhaseCCX(temps[1], temps[2], temps[4]);
+                    PhaseCCX(temps[3], temps[4], temps[5]);
+                }
+                apply {
+                    Adjoint CT(temps[5], qubit);
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[7];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                    PhaseCCX(temps[4], temps[5], temps[6]);
+                }
+                apply {
+                    Adjoint CT(temps[6], qubit);
+                }
             }
             else {
-                ApplyWithLessControlsA(Controlled Adjoint T, (ctls, qubit));
+                fail "Too many control qubits specified to Adjoint T gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled Adjoint T, (ctls, qubit));
             }
         }
+    }
+
+    internal operation CT(control : Qubit, target : Qubit) : Unit is Adj {
+        let angle = PI() / 8.0;
+        Rz(angle, control);
+        Rz(angle, target);
+        CNOT(control, target);
+        Adjoint Rz(angle, target);
+        CNOT(control, target);
     }
 }

--- a/src/Simulation/TargetDefinitions/Decompositions/Utils.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/Utils.qs
@@ -14,31 +14,6 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation ApplyGlobalPhase (theta : Double) : Unit is Ctl + Adj {
-        body (...) {}
-        controlled (controls, (...)) {
-            if (Length(controls) > 0) {
-                let qubit = controls[0];
-                let rest = controls[1...];
-                // Invoke Controlled R1, which will recursively call back into ApplyGlobalPhase.
-                // Each time the controls is one shorter, until it is empty and the recursion stops.
-                Controlled R1(rest, (theta, qubit));
-            }
-        }
-    }
-
-    internal operation ApplyGlobalPhaseFracWithR1Frac (numerator : Int, power : Int) : Unit is Adj + Ctl {
-        body (...) {}
-        controlled (ctrls, ...) {
-            let numControls =  Length(ctrls);
-            if (numControls > 0 ) {
-                // Invoke Controlled R1Frac, which will recursively call back into ApplyGlobalPhase.
-                // Each time the controls is one shorter, until it is empty and the recursion stops.
-                Controlled R1Frac(ctrls[1 .. numControls - 1], (numerator, power, ctrls[0]));
-            }
-        }
-    }
-
     internal operation MapPauli (qubit : Qubit, from : Pauli, to : Pauli) : Unit is Adj {
         if (from == to) {
         }

--- a/src/Simulation/TargetDefinitions/Decompositions/YFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/YFromSinglyControlled.qs
@@ -31,17 +31,93 @@ namespace Microsoft.Quantum.Intrinsic {
                 CY(ctls[0], qubit);
             }
             elif (Length(ctls) == 2) {
+                CCY(ctls[0], ctls[1], qubit);
+            }
+            elif Length(ctls) == 3 {
+                use temp = Qubit();
                 within {
-                    MapPauli(qubit, PauliZ, PauliY);
+                    PhaseCCX(ctls[0], ctls[1], temp);
                 }
                 apply {
-                    CCZ(ctls[0], ctls[1], qubit);
+                    CCY(temp, ctls[2], qubit);
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                }
+                apply {
+                    CCY(temps[0], temps[1], qubit);
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    CCY(temps[2], ctls[4], qubit);
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                }
+                apply {
+                    CCY(temps[2], temps[3], qubit);
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    CCY(temps[4], ctls[6], qubit);
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                }
+                apply {
+                    CCY(temps[4], temps[5], qubit);
                 }
             }
             else {
-                ApplyWithLessControlsA(Controlled Y, (ctls, qubit));
+                fail "Too many control qubits specified to Y gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled Y, (ctls, qubit));
             }
         }
         adjoint self;
+    }
+
+    internal operation CCY(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+        within {
+            MapPauli(target, PauliZ, PauliY);
+        }
+        apply {
+            CCZ(control1, control2, target);
+        }
     }
 }

--- a/src/Simulation/TargetDefinitions/Decompositions/ZFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ZFromSinglyControlled.qs
@@ -33,8 +33,80 @@ namespace Microsoft.Quantum.Intrinsic {
             elif (Length(ctls) == 2) {
                 CCZ(ctls[0], ctls[1], qubit);
             }
+            elif Length(ctls) == 3 {
+                use temp = Qubit();
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temp);
+                }
+                apply {
+                    CCZ(temp, ctls[2], qubit);
+                }
+            }
+            elif Length(ctls) == 4 {
+                use temps = Qubit[2];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                }
+                apply {
+                    CCZ(temps[0], temps[1], qubit);
+                }
+            }
+            elif Length(ctls) == 5 {
+                use temps = Qubit[3];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(temps[0], temps[1], temps[2]);
+                }
+                apply {
+                    CCZ(temps[2], ctls[4], qubit);
+                }
+            }
+            elif Length(ctls) == 6 {
+                use temps = Qubit[4];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                }
+                apply {
+                    CCZ(temps[2], temps[3], qubit);
+                }
+            }
+            elif Length(ctls) == 7 {
+                use temps = Qubit[5];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(temps[0], temps[1], temps[3]);
+                    PhaseCCX(temps[2], temps[3], temps[4]);
+                }
+                apply {
+                    CCZ(temps[4], ctls[6], qubit);
+                }
+            }
+            elif Length(ctls) == 8 {
+                use temps = Qubit[6];
+                within {
+                    PhaseCCX(ctls[0], ctls[1], temps[0]);
+                    PhaseCCX(ctls[2], ctls[3], temps[1]);
+                    PhaseCCX(ctls[4], ctls[5], temps[2]);
+                    PhaseCCX(ctls[6], ctls[7], temps[3]);
+                    PhaseCCX(temps[0], temps[1], temps[4]);
+                    PhaseCCX(temps[2], temps[3], temps[5]);
+                }
+                apply {
+                    CCZ(temps[4], temps[5], qubit);
+                }
+            }
             else {
-                ApplyWithLessControlsA(Controlled Z, (ctls, qubit));
+                fail "Too many control qubits specified to Z gate.";
+
+                // Eventually, we can use recursion via callables with the below utility:
+                // ApplyWithLessControlsA(Controlled Z, (ctls, qubit));
             }
         }
         adjoint self;

--- a/src/Simulation/TargetDefinitions/Decompositions/ZFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ZFromSinglyControlled.qs
@@ -24,13 +24,13 @@ namespace Microsoft.Quantum.Intrinsic {
             ApplyUncontrolledZ(qubit);
         }
         controlled (ctls, ...) {
-            if (Length(ctls) == 0) {
+            if Length(ctls) == 0 {
                 ApplyUncontrolledZ(qubit);
             }
-            elif (Length(ctls) == 1) {
+            elif Length(ctls) == 1 {
                 ApplyControlledZ(ctls[0], qubit);
             }
-            elif (Length(ctls) == 2) {
+            elif Length(ctls) == 2 {
                 CCZ(ctls[0], ctls[1], qubit);
             }
             elif Length(ctls) == 3 {

--- a/src/Simulation/TargetDefinitions/TargetPackages/Type1.Package.props
+++ b/src/Simulation/TargetDefinitions/TargetPackages/Type1.Package.props
@@ -40,8 +40,8 @@
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\MResetZExplicit.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\MWithPostPrep.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\PreparePostM.qs" />
-    <QSharpCompile Include="..\TargetDefinitions\Decompositions\R.qs" />
-    <QSharpCompile Include="..\TargetDefinitions\Decompositions\R1.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\RFromSinglyControlledR1.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\R1FromSinglyControlled.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\R1Frac.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\ResetAll.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\RFrac.qs" />

--- a/src/Simulation/TargetDefinitions/TargetPackages/Type3.Package.props
+++ b/src/Simulation/TargetDefinitions/TargetPackages/Type3.Package.props
@@ -41,8 +41,8 @@
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\MResetZExplicit.qs" />
     <QSharpCompile Include="..\TargetDefinitions\Decompositions\MWithPostPrep.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\PreparePostMNoop.qs" />
-    <QsharpCompile Include="..\TargetDefinitions\Decompositions\R.qs" />
-    <QsharpCompile Include="..\TargetDefinitions\Decompositions\R1.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\RFromSinglyControlledR1.qs" />
+    <QSharpCompile Include="..\TargetDefinitions\Decompositions\R1FromSinglyControlled.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\R1Frac.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\ResetAll.qs" />
     <QsharpCompile Include="..\TargetDefinitions\Decompositions\RFrac.qs" />

--- a/src/Simulation/TargetDefinitions/Tests/DecompositionTests.qs
+++ b/src/Simulation/TargetDefinitions/Tests/DecompositionTests.qs
@@ -95,6 +95,13 @@ namespace DecompositionTests {
     }
 
     @Test("SparseSimulator")
+    operation VerifyR1() : Unit {
+        // Use an angle that doesn't have any symmetries as a stand-in for broader validation.
+        let angle = PI() / 7.0;
+        VerifyUnitaryAndFunctors(q => R1(angle, q), q => Reference.R1(angle, q));
+    }
+
+    @Test("SparseSimulator")
     operation VerifySWAP() : Unit {
         VerifyUnitaryAndFunctors2(SWAP, Reference.SWAP);
     }
@@ -124,6 +131,8 @@ namespace DecompositionTests {
         // Verify equality up to 8 controls.
         Reference.AssertOperationsEqualReferenced(1, qs => unitary(qs[0]),
             qs => reference(qs[0]));
+        Reference.AssertOperationsEqualReferenced(1, qs => Controlled unitary([], qs[0]),
+            qs => Controlled reference([], qs[0]));
         Reference.AssertOperationsEqualReferenced(2, qs => Controlled unitary([qs[0]], qs[1]),
             qs => Controlled reference([qs[0]], qs[1]));
         Reference.AssertOperationsEqualReferenced(3, (qs => Controlled unitary([qs[0], qs[1]], qs[2])),
@@ -144,6 +153,8 @@ namespace DecompositionTests {
         // Verify equality up to 8 controls.
         Reference.AssertOperationsEqualReferenced(2, qs => unitary(qs[0], qs[1]),
             qs => reference(qs[0], qs[1]));
+        Reference.AssertOperationsEqualReferenced(2, qs => Controlled unitary([], (qs[0], qs[1])),
+            qs => Controlled reference([], (qs[0], qs[1])));
         Reference.AssertOperationsEqualReferenced(3, qs => Controlled unitary([qs[0]], (qs[1], qs[2])),
             qs => Controlled reference([qs[0]], (qs[1], qs[2])));
         Reference.AssertOperationsEqualReferenced(4, qs => Controlled unitary([qs[0], qs[1]], (qs[2], qs[3])),
@@ -164,6 +175,8 @@ namespace DecompositionTests {
         // Verify equality up to 8 controls.
         Reference.AssertOperationsEqualReferenced(3, qs => unitary(qs[0], qs[1], qs[2]),
             qs => reference(qs[0], qs[1], qs[2]));
+        Reference.AssertOperationsEqualReferenced(3, qs => Controlled unitary([], (qs[0], qs[1], qs[2])),
+            qs => Controlled reference([], (qs[0], qs[1], qs[2])));
         Reference.AssertOperationsEqualReferenced(4, qs => Controlled unitary([qs[0]], (qs[1], qs[2], qs[3])),
             qs => Controlled reference([qs[0]], (qs[1], qs[2], qs[3])));
         Reference.AssertOperationsEqualReferenced(5, qs => Controlled unitary([qs[0], qs[1]], (qs[2], qs[3], qs[4])),
@@ -184,6 +197,8 @@ namespace DecompositionTests {
         // Verify equality up to 8 controls.
         Reference.AssertOperationsEqualReferenced(4, qs => unitary(qs[0], qs[1], qs[2], qs[3]),
             qs => reference(qs[0], qs[1], qs[2], qs[3]));
+        Reference.AssertOperationsEqualReferenced(4, qs => Controlled unitary([], (qs[0], qs[1], qs[2], qs[3])),
+            qs => Controlled reference([], (qs[0], qs[1], qs[2], qs[3])));
         Reference.AssertOperationsEqualReferenced(5, qs => Controlled unitary([qs[0]], (qs[1], qs[2], qs[3], qs[4])),
             qs => Controlled reference([qs[0]], (qs[1], qs[2], qs[3], qs[4])));
         Reference.AssertOperationsEqualReferenced(6, qs => Controlled unitary([qs[0], qs[1]], (qs[2], qs[3], qs[4], qs[5])),

--- a/src/Simulation/TargetDefinitions/Tests/DecompositionTests.qs
+++ b/src/Simulation/TargetDefinitions/Tests/DecompositionTests.qs
@@ -107,111 +107,67 @@ namespace DecompositionTests {
     }
 
     internal operation VerifyUnitaryAndFunctors(unitary : Qubit => Unit is Adj + Ctl, reference : Qubit => Unit is Adj + Ctl) : Unit {
-        VerifyUnitary(unitary, reference);
-        VerifyUnitary(Adjoint unitary, Adjoint reference);
-        VerifyUnitary2((q0, q1) => Controlled unitary([q0], q1), (q0, q1) => Controlled reference([q0], q1));
-        VerifyUnitary2((q0, q1) => Controlled Adjoint unitary([q0], q1), (q0, q1) => Controlled Adjoint reference([q0], q1));
+        VerifyUnitary(unitary, reference, 8);
+        VerifyUnitary(Adjoint unitary, Adjoint reference, 8);
+        VerifyUnitary2((q0, q1) => Controlled unitary([q0], q1), (q0, q1) => Controlled reference([q0], q1), 7);
+        VerifyUnitary2((q0, q1) => Controlled Adjoint unitary([q0], q1), (q0, q1) => Controlled Adjoint reference([q0], q1), 7);
     }
 
     internal operation VerifyUnitaryAndFunctors2(unitary : (Qubit, Qubit) => Unit is Adj + Ctl, reference : (Qubit, Qubit) => Unit is Adj + Ctl) : Unit {
-        VerifyUnitary2(unitary, reference);
-        VerifyUnitary2(Adjoint unitary, Adjoint reference);
-        VerifyUnitary3((q0, q1, q2) => Controlled unitary([q0], (q1, q2)), (q0, q1, q2) => Controlled reference([q0], (q1, q2)));
-        VerifyUnitary3((q0, q1, q2) => Controlled Adjoint unitary([q0], (q1, q2)), (q0, q1, q2) => Controlled Adjoint reference([q0], (q1, q2)));
+        VerifyUnitary2(unitary, reference, 8);
+        VerifyUnitary2(Adjoint unitary, Adjoint reference, 8);
+        VerifyUnitary3((q0, q1, q2) => Controlled unitary([q0], (q1, q2)), (q0, q1, q2) => Controlled reference([q0], (q1, q2)), 7);
+        VerifyUnitary3((q0, q1, q2) => Controlled Adjoint unitary([q0], (q1, q2)), (q0, q1, q2) => Controlled Adjoint reference([q0], (q1, q2)), 7);
     }
 
     internal operation VerifyUnitaryAndFunctors3(unitary : (Qubit, Qubit, Qubit) => Unit is Adj + Ctl, reference : (Qubit, Qubit, Qubit) => Unit is Adj + Ctl) : Unit {
-        VerifyUnitary3(unitary, reference);
-        VerifyUnitary3(Adjoint unitary, Adjoint reference);
-        VerifyUnitary4((q0, q1, q2, q3) => Controlled unitary([q0], (q1, q2, q3)), (q0, q1, q2, q3) => Controlled reference([q0], (q1, q2, q3)));
-        VerifyUnitary4((q0, q1, q2, q3) => Controlled Adjoint unitary([q0], (q1, q2, q3)), (q0, q1, q2, q3) => Controlled Adjoint reference([q0], (q1, q2, q3)));
+        VerifyUnitary3(unitary, reference, 8);
+        VerifyUnitary3(Adjoint unitary, Adjoint reference, 8);
+        VerifyUnitary4((q0, q1, q2, q3) => Controlled unitary([q0], (q1, q2, q3)), (q0, q1, q2, q3) => Controlled reference([q0], (q1, q2, q3)), 7);
+        VerifyUnitary4((q0, q1, q2, q3) => Controlled Adjoint unitary([q0], (q1, q2, q3)), (q0, q1, q2, q3) => Controlled Adjoint reference([q0], (q1, q2, q3)), 7);
     }
 
-    internal operation VerifyUnitary(unitary : Qubit => Unit is Adj + Ctl, reference : Qubit => Unit is Adj + Ctl) : Unit {
+    internal operation VerifyUnitary(unitary : Qubit => Unit is Adj + Ctl, reference : Qubit => Unit is Adj + Ctl, limit : Int) : Unit {
         // Verify equality up to 8 controls.
         Reference.AssertOperationsEqualReferenced(1, qs => unitary(qs[0]),
             qs => reference(qs[0]));
-        Reference.AssertOperationsEqualReferenced(1, qs => Controlled unitary([], qs[0]),
-            qs => Controlled reference([], qs[0]));
-        Reference.AssertOperationsEqualReferenced(2, qs => Controlled unitary([qs[0]], qs[1]),
-            qs => Controlled reference([qs[0]], qs[1]));
-        Reference.AssertOperationsEqualReferenced(3, (qs => Controlled unitary([qs[0], qs[1]], qs[2])),
-            qs => Controlled reference([qs[0], qs[1]], qs[2]));
-        Reference.AssertOperationsEqualReferenced(4, qs => Controlled unitary([qs[0], qs[1], qs[2]], qs[3]),
-            qs => Controlled reference([qs[0], qs[1], qs[2]], qs[3]));
-        Reference.AssertOperationsEqualReferenced(5, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3]], qs[4]),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3]], qs[4]));
-        Reference.AssertOperationsEqualReferenced(6, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4]], qs[5]),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4]], qs[5]));
-        Reference.AssertOperationsEqualReferenced(7, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5]], qs[6]),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5]], qs[6]));
-        Reference.AssertOperationsEqualReferenced(8, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6]], qs[7]),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6]], qs[7]));
+
+        for numControls in 0..limit {
+            Reference.AssertOperationsEqualReferenced(1 + numControls, qs => Controlled unitary(qs[1..numControls], qs[0]),
+                qs => Controlled reference(qs[1..numControls], qs[0]));
+        }
     }
 
-    internal operation VerifyUnitary2(unitary : (Qubit, Qubit) => Unit is Adj + Ctl, reference : (Qubit, Qubit) => Unit is Adj + Ctl) : Unit {
+    internal operation VerifyUnitary2(unitary : (Qubit, Qubit) => Unit is Adj + Ctl, reference : (Qubit, Qubit) => Unit is Adj + Ctl, limit : Int) : Unit {
         // Verify equality up to 8 controls.
         Reference.AssertOperationsEqualReferenced(2, qs => unitary(qs[0], qs[1]),
             qs => reference(qs[0], qs[1]));
-        Reference.AssertOperationsEqualReferenced(2, qs => Controlled unitary([], (qs[0], qs[1])),
-            qs => Controlled reference([], (qs[0], qs[1])));
-        Reference.AssertOperationsEqualReferenced(3, qs => Controlled unitary([qs[0]], (qs[1], qs[2])),
-            qs => Controlled reference([qs[0]], (qs[1], qs[2])));
-        Reference.AssertOperationsEqualReferenced(4, qs => Controlled unitary([qs[0], qs[1]], (qs[2], qs[3])),
-            qs => Controlled reference([qs[0], qs[1]], (qs[2], qs[3])));
-        Reference.AssertOperationsEqualReferenced(5, qs => Controlled unitary([qs[0], qs[1], qs[2]], (qs[3], qs[4])),
-            qs => Controlled reference([qs[0], qs[1], qs[2]], (qs[3], qs[4])));
-        Reference.AssertOperationsEqualReferenced(6, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3]], (qs[4], qs[5])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3]], (qs[4], qs[5])));
-        Reference.AssertOperationsEqualReferenced(7, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4]], (qs[5], qs[6])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4]], (qs[5], qs[6])));
-        Reference.AssertOperationsEqualReferenced(8, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5]], (qs[6], qs[7])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5]], (qs[6], qs[7])));
-        Reference.AssertOperationsEqualReferenced(9, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6]], (qs[7], qs[8])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6]], (qs[7], qs[8])));
+
+        for numControls in 0..limit {
+            Reference.AssertOperationsEqualReferenced(2 + numControls, qs => Controlled unitary(qs[2..(numControls + 1)], (qs[0], qs[1])),
+                qs => Controlled reference(qs[2..(numControls + 1)], (qs[0], qs[1])));
+        }
     }
 
-    internal operation VerifyUnitary3(unitary : (Qubit, Qubit, Qubit) => Unit is Adj + Ctl, reference : (Qubit, Qubit, Qubit) => Unit is Adj + Ctl) : Unit {
+    internal operation VerifyUnitary3(unitary : (Qubit, Qubit, Qubit) => Unit is Adj + Ctl, reference : (Qubit, Qubit, Qubit) => Unit is Adj + Ctl, limit : Int) : Unit {
         // Verify equality up to 8 controls.
         Reference.AssertOperationsEqualReferenced(3, qs => unitary(qs[0], qs[1], qs[2]),
             qs => reference(qs[0], qs[1], qs[2]));
-        Reference.AssertOperationsEqualReferenced(3, qs => Controlled unitary([], (qs[0], qs[1], qs[2])),
-            qs => Controlled reference([], (qs[0], qs[1], qs[2])));
-        Reference.AssertOperationsEqualReferenced(4, qs => Controlled unitary([qs[0]], (qs[1], qs[2], qs[3])),
-            qs => Controlled reference([qs[0]], (qs[1], qs[2], qs[3])));
-        Reference.AssertOperationsEqualReferenced(5, qs => Controlled unitary([qs[0], qs[1]], (qs[2], qs[3], qs[4])),
-            qs => Controlled reference([qs[0], qs[1]], (qs[2], qs[3], qs[4])));
-        Reference.AssertOperationsEqualReferenced(6, qs => Controlled unitary([qs[0], qs[1], qs[2]], (qs[3], qs[4], qs[5])),
-            qs => Controlled reference([qs[0], qs[1], qs[2]], (qs[3], qs[4], qs[5])));
-        Reference.AssertOperationsEqualReferenced(7, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3]], (qs[4], qs[5], qs[6])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3]], (qs[4], qs[5], qs[6])));
-        Reference.AssertOperationsEqualReferenced(8, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4]], (qs[5], qs[6], qs[7])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4]], (qs[5], qs[6], qs[7])));
-        Reference.AssertOperationsEqualReferenced(9, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5]], (qs[6], qs[7], qs[8])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5]], (qs[6], qs[7], qs[8])));
-        Reference.AssertOperationsEqualReferenced(10, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6]], (qs[7], qs[8], qs[9])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6]], (qs[7], qs[8], qs[9])));
+
+        for numControls in 0..limit {
+            Reference.AssertOperationsEqualReferenced(3 + numControls, qs => Controlled unitary(qs[3..(numControls + 2)], (qs[0], qs[1], qs[2])),
+                qs => Controlled reference(qs[3..(numControls + 2)], (qs[0], qs[1], qs[2])));
+        }
     }
 
-    internal operation VerifyUnitary4(unitary : (Qubit, Qubit, Qubit, Qubit) => Unit is Adj + Ctl, reference : (Qubit, Qubit, Qubit, Qubit) => Unit is Adj + Ctl) : Unit {
+    internal operation VerifyUnitary4(unitary : (Qubit, Qubit, Qubit, Qubit) => Unit is Adj + Ctl, reference : (Qubit, Qubit, Qubit, Qubit) => Unit is Adj + Ctl, limit : Int) : Unit {
         // Verify equality up to 8 controls.
         Reference.AssertOperationsEqualReferenced(4, qs => unitary(qs[0], qs[1], qs[2], qs[3]),
             qs => reference(qs[0], qs[1], qs[2], qs[3]));
-        Reference.AssertOperationsEqualReferenced(4, qs => Controlled unitary([], (qs[0], qs[1], qs[2], qs[3])),
-            qs => Controlled reference([], (qs[0], qs[1], qs[2], qs[3])));
-        Reference.AssertOperationsEqualReferenced(5, qs => Controlled unitary([qs[0]], (qs[1], qs[2], qs[3], qs[4])),
-            qs => Controlled reference([qs[0]], (qs[1], qs[2], qs[3], qs[4])));
-        Reference.AssertOperationsEqualReferenced(6, qs => Controlled unitary([qs[0], qs[1]], (qs[2], qs[3], qs[4], qs[5])),
-            qs => Controlled reference([qs[0], qs[1]], (qs[2], qs[3], qs[4], qs[5])));
-        Reference.AssertOperationsEqualReferenced(7, qs => Controlled unitary([qs[0], qs[1], qs[2]], (qs[3], qs[4], qs[5], qs[6])),
-            qs => Controlled reference([qs[0], qs[1], qs[2]], (qs[3], qs[4], qs[5], qs[6])));
-        Reference.AssertOperationsEqualReferenced(8, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3]], (qs[4], qs[5], qs[6], qs[7])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3]], (qs[4], qs[5], qs[6], qs[7])));
-        Reference.AssertOperationsEqualReferenced(9, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4]], (qs[5], qs[6], qs[7], qs[8])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4]], (qs[5], qs[6], qs[7], qs[8])));
-        Reference.AssertOperationsEqualReferenced(10, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5]], (qs[6], qs[7], qs[8], qs[9])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5]], (qs[6], qs[7], qs[8], qs[9])));
-        Reference.AssertOperationsEqualReferenced(11, qs => Controlled unitary([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6]], (qs[7], qs[8], qs[9], qs[10])),
-            qs => Controlled reference([qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6]], (qs[7], qs[8], qs[9], qs[10])));
+
+        for numControls in 0..limit {
+            Reference.AssertOperationsEqualReferenced(4 + numControls, qs => Controlled unitary(qs[4..(numControls + 3)], (qs[0], qs[1], qs[2], qs[3])),
+                qs => Controlled reference(qs[4..(numControls + 3)], (qs[0], qs[1], qs[2], qs[3])));
+        }
     }
 }

--- a/src/Simulation/TargetDefinitions/Tests/Reference.qs
+++ b/src/Simulation/TargetDefinitions/Tests/Reference.qs
@@ -49,6 +49,12 @@ namespace Reference {
         Controlled X([qubit1], qubit2);
     }
 
+    // Use the trivial decomposition of R1 to emulate intrinsic R1 on the simulator.
+    operation R1 (theta : Double, qubit : Qubit) : Unit is Adj + Ctl {
+        R(PauliZ, theta, qubit);
+        R(PauliI, -theta, qubit);
+    }
+
     // The following operations are reproduced here to ensure that `AssertOperationsEqualReferenced`
     // uses these reference implementations for preparation and evaluation instead of the decompositions
     // under test.

--- a/src/Simulation/TargetDefinitions/Tests/Tests.TargetDefinitions.csproj
+++ b/src/Simulation/TargetDefinitions/Tests/Tests.TargetDefinitions.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <QscVerbosity>detailed</QscVerbosity>
     <!-- we will provide our own -->
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>
@@ -33,10 +34,8 @@
     <QSharpCompile Include="..\Decompositions\CYFromCNOT.qs" />
     <QSharpCompile Include="..\Decompositions\CZFromSinglyControlled.qs" />
     <QsharpCompile Include="..\Decompositions\HFromSinglyControlled.qs" />
-    <QsharpCompile Include="..\Decompositions\R.qs" />
-    <QsharpCompile Include="..\Decompositions\R1.qs" />
-    <QsharpCompile Include="..\Decompositions\R1Frac.qs" />
-    <QsharpCompile Include="..\Decompositions\RFrac.qs" />
+    <QsharpCompile Include="..\Decompositions\RFromSinglyControlledR1.qs" />
+    <QsharpCompile Include="..\Decompositions\R1FromSinglyControlled.qs" />
     <QsharpCompile Include="..\Decompositions\RxFromSinglyControlled.qs" />
     <QsharpCompile Include="..\Decompositions\RyFromSinglyControlled.qs" />
     <QsharpCompile Include="..\Decompositions\RzFromSinglyControlled.qs" />

--- a/src/Xunit/Microsoft.Quantum.Xunit.nuspec
+++ b/src/Xunit/Microsoft.Quantum.Xunit.nuspec
@@ -22,7 +22,7 @@
     <dependencies>
       <dependency id="xunit" version="2.3.1" />
       <dependency id="Microsoft.NET.Test.Sdk" version="15.3.0" />
-      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.201332" />
+      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.205218-beta" />
     </dependencies>
   </metadata>
 


### PR DESCRIPTION
This change refactors the decompositions to avoid specific patterns. Namely recursion, array concatenation and slicing, and complex mathematical operations. It uses the new decomposition tests to validate the refactor across controlled and adjoint specializations with up to 8 controls. This should make the decompositions more compatible with future hardware targeting transformations.

Note that this updatest to a beta version of the QDK to pick up a compiler fix that is required to compile the decompositions.