### PR TITLE
Add --submit-config-file option to standalone executable driver

### DIFF
--- a/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Quantum
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.IO;
     using System.Linq;
     using System.Reflection;
     using System.Text.RegularExpressions;
@@ -23,8 +24,16 @@ namespace Microsoft.Azure.Quantum
         /// </summary>
         private static readonly ImmutableList<SubmitterInfo> QirSubmitters = ImmutableList.Create(
             new SubmitterInfo(
-                new Regex(@"\Amicrosoft\.simulator\.([\w]+\.)*[\w]+\z"),
+                new Regex(@"\Amicrosoft\.simulator\.([\w-_]+\.)*[\w-_]+\z"),
                 "Microsoft.Quantum.Providers.Targets.MicrosoftSimulatorSubmitter, Microsoft.Quantum.Providers.Core",
+                "QirSubmitter"),
+            new SubmitterInfo(
+                new Regex(@"\Aquantinuum\.([\w-_]+\.)*[\w-_]+\z"),
+                "Microsoft.Quantum.Providers.Quantinuum.Targets.QuantinuumQirSubmitter, Microsoft.Quantum.Providers.Honeywell",
+                "QirSubmitter"),
+            new SubmitterInfo(
+                new Regex(@"\Aqci\.([\w-_]+\.)*[\w-_]+\z"),
+                "Microsoft.Quantum.Providers.QCI.Targets.QCIQirSubmitter, Microsoft.Quantum.Providers.QCI",
                 "QirSubmitter"));
 
         private static readonly ImmutableList<SubmitterInfo> QirPayloadGenerators = ImmutableList.Create(
@@ -55,6 +64,13 @@ namespace Microsoft.Azure.Quantum
         /// <returns>A QIR submitter.</returns>
         public static IQirSubmitter? QirSubmitter(string target, IWorkspace workspace, string? storageConnection) =>
             Submitter<IQirSubmitter>(QirSubmitters, target, workspace, storageConnection);
+
+        public static IQirSubmitter? QirSubmitterFromConfigFile(
+            FileInfo configFile, IWorkspace workspace, string? storageConnection)
+        {
+            // TODO: Implement.
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// Returns a Q# submitter.
@@ -171,6 +187,8 @@ namespace Microsoft.Azure.Quantum
             /// The name of the static factory method.
             /// </summary>
             public string MethodName { get; }
+
+            // TODO: Extend this for Quantinuum.
         }
     }
 }

--- a/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
@@ -66,10 +66,13 @@ namespace Microsoft.Azure.Quantum
             Submitter<IQirSubmitter>(QirSubmitters, target, workspace, storageConnection);
 
         public static IQirSubmitter? QirSubmitterFromConfigFile(
-            FileInfo configFile, IWorkspace workspace, string? storageConnection)
+            string target, FileInfo configFile, IWorkspace workspace, string? storageConnection)
         {
-            // TODO: Implement.
-            throw new NotImplementedException();
+            var constructorType = QdkType("Microsoft.Quantum.Providers.Targets.GenericQirSubmitter");
+            var constructorName = "QirSubmitter";
+            var args = new object?[] { target, configFile, workspace, storageConnection };
+            return (IQirSubmitter)constructorType.InvokeMember(
+                constructorName, BindingFlags.InvokeMethod, Type.DefaultBinder, null, args);
         }
 
         /// <summary>
@@ -187,8 +190,6 @@ namespace Microsoft.Azure.Quantum
             /// The name of the static factory method.
             /// </summary>
             public string MethodName { get; }
-
-            // TODO: Extend this for Quantinuum.
         }
     }
 }

--- a/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
@@ -68,7 +68,8 @@ namespace Microsoft.Azure.Quantum
         public static IQirSubmitter? QirSubmitterFromConfigFile(
             string target, FileInfo configFile, IWorkspace workspace, string? storageConnection)
         {
-            var constructorType = QdkType("Microsoft.Quantum.Providers.Targets.GenericQirSubmitter");
+            var constructorType = QdkType(
+                "Microsoft.Quantum.Providers.Targets.GenericQirSubmitter, Microsoft.Quantum.Providers.Core");
             var constructorName = "QirSubmitter";
             var args = new object?[] { target, configFile, workspace, storageConnection };
             return (IQirSubmitter)constructorType.InvokeMember(

--- a/src/Simulation/EntryPointDriver.Tests/Tests.fs
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.fs
@@ -1123,6 +1123,7 @@ let ``Shows help text for submit command`` () =
                       --output <FriendlyUri|Id>                           The information to show in the output after the job is submitted.
                       --dry-run                                           Validate the program and options, but do not submit to Azure Quantum.
                       --verbose                                           Show additional information about the submission.
+                      --submit-config-file <submit-config-file>           Configuration file to use custom submit properties.
                       -?, -h, --help                                      Show help and usage information"
     let given = test "Help"
     given ["submit"; "--help"] |> yields message
@@ -1155,6 +1156,7 @@ let ``Shows help text for submit command with default target`` () =
                       --output <FriendlyUri|Id>                           The information to show in the output after the job is submitted.
                       --dry-run                                           Validate the program and options, but do not submit to Azure Quantum.
                       --verbose                                           Show additional information about the submission.
+                      --submit-config-file <submit-config-file>           Configuration file to use custom submit properties.
                       -?, -h, --help                                      Show help and usage information"
     let given = testWithTarget "foo.target" "Help"
     given ["submit"; "--help"] |> yields message

--- a/src/Simulation/EntryPointDriver/Azure/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure/Azure.cs
@@ -413,13 +413,17 @@ namespace Microsoft.Quantum.EntryPointDriver
         /// </summary>
         /// <param name="settings">The Azure settings.</param>
         /// <returns>A QIR submitter.</returns>
-        private static IQirSubmitter? QirSubmitter(AzureSettings settings) => settings.Target switch
+        private static IQirSubmitter? QirSubmitter(AzureSettings settings)
         {
-            null => null,
-            NoOpQirSubmitter.Target => new NoOpQirSubmitter(),
-            NoOpSubmitter.Target => new NoOpSubmitter(),
-            _ => SubmitterFactory.QirSubmitter(settings.Target, settings.CreateWorkspace(), settings.Storage)
-        };
+            // TODO: Implement here.
+            return settings.Target switch
+            {
+                null => null,
+                NoOpQirSubmitter.Target => new NoOpQirSubmitter(),
+                NoOpSubmitter.Target => new NoOpSubmitter(),
+                _ => SubmitterFactory.QirSubmitter(settings.Target, settings.CreateWorkspace(), settings.Storage)
+            };
+        }
 
         /// <summary>
         /// The quantum machine submission context.

--- a/src/Simulation/EntryPointDriver/Azure/Azure.cs
+++ b/src/Simulation/EntryPointDriver/Azure/Azure.cs
@@ -415,10 +415,21 @@ namespace Microsoft.Quantum.EntryPointDriver
         /// <returns>A QIR submitter.</returns>
         private static IQirSubmitter? QirSubmitter(AzureSettings settings)
         {
-            // TODO: Implement here.
+            if (settings.Target is null)
+            {
+                return null;
+            }
+
+            // If a configuration file is provided, create a submitter using it.
+            if (!(settings.SubmitConfigFile is null))
+            {
+                return SubmitterFactory.QirSubmitterFromConfigFile(
+                    settings.Target, settings.SubmitConfigFile, settings.CreateWorkspace(), settings.Storage);
+            }
+
+            // No configuration file was provided, create a submitter depending on the target.
             return settings.Target switch
             {
-                null => null,
                 NoOpQirSubmitter.Target => new NoOpQirSubmitter(),
                 NoOpSubmitter.Target => new NoOpSubmitter(),
                 _ => SubmitterFactory.QirSubmitter(settings.Target, settings.CreateWorkspace(), settings.Storage)

--- a/src/Simulation/EntryPointDriver/Azure/AzureSettings.cs
+++ b/src/Simulation/EntryPointDriver/Azure/AzureSettings.cs
@@ -1,17 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.IO;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
 using Azure.Core;
 using Azure.Quantum;
 
 using Microsoft.Azure.Quantum;
 using Microsoft.Azure.Quantum.Authentication;
 using Microsoft.Quantum.Runtime.Submitters;
-using System;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Quantum.EntryPointDriver
 {
@@ -57,6 +59,11 @@ namespace Microsoft.Quantum.EntryPointDriver
         /// The target device ID.
         /// </summary>
         public string? Target { get; set; }
+
+        /// <summary>
+        /// A configuration file to customize submission.
+        /// </summary>
+        public FileInfo? SubmitConfigFile { get; set; }
 
         /// <summary>
         /// The storage account connection string.

--- a/src/Simulation/EntryPointDriver/Driver.cs
+++ b/src/Simulation/EntryPointDriver/Driver.cs
@@ -154,6 +154,14 @@ namespace Microsoft.Quantum.EntryPointDriver
             ImmutableList.Create("--verbose"), Maybe.Just(false), "Show additional information about the submission.");
 
         /// <summary>
+        /// The base URI option.
+        /// </summary>
+        private static readonly OptionInfo<FileInfo?> SubmitConfigFileOption = new OptionInfo<FileInfo?>(
+            ImmutableList.Create("--submit-config-file"),
+            Maybe.Just<FileInfo?>(null),
+            "Configuration file to use custom submit properties.");
+
+        /// <summary>
         /// The target option.
         /// </summary>
         private readonly OptionInfo<string?> TargetOption;
@@ -493,6 +501,7 @@ namespace Microsoft.Quantum.EntryPointDriver
                 .Concat(AddOptionIfAvailable(command, OutputOption))
                 .Concat(AddOptionIfAvailable(command, DryRunOption))
                 .Concat(AddOptionIfAvailable(command, VerboseOption))
+                .Concat(AddOptionIfAvailable(command, SubmitConfigFileOption))
                 .Concat(MarkOptionsAsMutuallyExclusive(
                     command,
                     new[] { BaseUriOption.Aliases.First(), LocationOption.Aliases.First() }));
@@ -546,7 +555,8 @@ namespace Microsoft.Quantum.EntryPointDriver
                 Shots = DefaultIfShadowed(entryPoint, ShotsOption, azureSettings.Shots),
                 Output = DefaultIfShadowed(entryPoint, OutputOption, azureSettings.Output),
                 DryRun = DefaultIfShadowed(entryPoint, DryRunOption, azureSettings.DryRun),
-                Verbose = DefaultIfShadowed(entryPoint, VerboseOption, azureSettings.Verbose)
+                Verbose = DefaultIfShadowed(entryPoint, VerboseOption, azureSettings.Verbose),
+                SubmitConfigFile = DefaultIfShadowed(entryPoint, SubmitConfigFileOption, azureSettings.SubmitConfigFile)
             });
 
         /// <summary>


### PR DESCRIPTION
This change implements a way to customize submission of an Azure Quantum job by introducing a new command line option: `--submit-config-file`.