### PR TITLE
Fixed the sanitized pipeline.

### DIFF
--- a/build/steps-codecheck.yml
+++ b/build/steps-codecheck.yml
@@ -33,7 +33,7 @@ steps:
   displayName: "Build Native Simulator"
   workingDirectory: $(System.DefaultWorkingDirectory)/src/Simulation/Native
 
-- # QIR Runtime Tests:
+  # QIR Runtime Tests:
 - pwsh: src/Qir/Runtime/test-qir-runtime.ps1
   displayName: "Test QIR Runtime"
   workingDirectory: $(System.DefaultWorkingDirectory)


### PR DESCRIPTION
Looks like upon [this change](https://github.com/microsoft/qsharp-runtime/pull/991/files#diff-ee71c5d9c5af8922aa961fb4ae8e7f71bd9508fa1c90a8877925bba6bee342f6) that added a green line 36 to `build/steps-codecheck.yml`, starting with dash followed by a comment,
the sanitized pipeline started failing **_silently_**. 
Fixing that pipeline failure.