### PR TITLE
Updating to release QDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "Microsoft.Quantum.Sdk": "0.24.205218-beta"
+        "Microsoft.Quantum.Sdk": "0.24.208024"
     }
 }

--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.205218-beta" />
+    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.208024" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
+++ b/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.205218-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.208024" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
   </ItemGroup>
 

--- a/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.205218-beta" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.208024" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xunit/Microsoft.Quantum.Xunit.nuspec
+++ b/src/Xunit/Microsoft.Quantum.Xunit.nuspec
@@ -22,7 +22,7 @@
     <dependencies>
       <dependency id="xunit" version="2.3.1" />
       <dependency id="Microsoft.NET.Test.Sdk" version="15.3.0" />
-      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.205218-beta" />
+      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.208024" />
     </dependencies>
   </metadata>
 


### PR DESCRIPTION
Now that the fix from https://github.com/microsoft/qsharp-compiler/pull/1411 has made it into the release, the QDK version can be updated to the April release instead of a beta version.