### PR TITLE
Block set-env.ps1 from sending to output stream

### DIFF
--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -15,7 +15,7 @@ param(
 );
 
 
-& "$PSScriptRoot/set-env.ps1"
+$env_output = & "$PSScriptRoot/set-env.ps1"
 
 $artifacts = @{
     Packages = @(

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -15,7 +15,7 @@ param(
 );
 
 
-$env_output = & "$PSScriptRoot/set-env.ps1"
+& "$PSScriptRoot/set-env.ps1" | Out-Null
 
 $artifacts = @{
     Packages = @(

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -62,7 +62,6 @@ $artifacts = @{
 }
 
 if ($OutputFormat -eq 'FileInfo') {
-    Write-Host "OutputFormat is FileInfo"
     $artifacts.Packages = $artifacts.Packages | ForEach-Object { Get-Item $_ };
     $artifacts.Assemblies = $artifacts.Assemblies | ForEach-Object { Get-Item $_ };
     $artifacts.Native = $artifacts.Native | ForEach-Object { Get-Item $_ };

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -62,6 +62,7 @@ $artifacts = @{
 }
 
 if ($OutputFormat -eq 'FileInfo') {
+    Write-Host "OutputFormat is FileInfo"
     $artifacts.Packages = $artifacts.Packages | ForEach-Object { Get-Item $_ };
     $artifacts.Assemblies = $artifacts.Assemblies | ForEach-Object { Get-Item $_ };
     $artifacts.Native = $artifacts.Native | ForEach-Object { Get-Item $_ };

--- a/build/set-env.ps1
+++ b/build/set-env.ps1
@@ -39,32 +39,32 @@ If (-not (Test-Path -Path $Env:WHEEL_OUTDIR)) { [IO.Directory]::CreateDirectory(
 If ($Env:DOCS_OUTDIR -eq $null) { $Env:DOCS_OUTDIR =  (Join-Path $Env:DROPS_DIR "docs") }
 If (-not (Test-Path -Path $Env:DOCS_OUTDIR)) { [IO.Directory]::CreateDirectory($Env:DOCS_OUTDIR) }
 
-# Get-ChildItem -Path Env:/* -Include @(
-#     "BUILD_BUILDNUMBER",
-#     "BUILD_CONFIGURATION",
-#     "BUILD_VERBOSITY",
-#     "ASSEMBLY_VERSION",
-#     "PYTHON_VERSION",
-#     "NUGET_VERSION",
-#     "NATIVE_SIMULATOR",
-#     "QIR_DROPS",
-#     "DROPS_DIR",
-#     "DROP_NATIVE",
-#     "INTERNAL_TOOLS_OUTDIR",
-#     "NUGET_OUTDIR",
-#     "CRATE_OUTDIR",
-#     "WHEEL_OUTDIR",
-#     "DOCS_OUTDIR"
-# ) | Format-Table | Out-String | Write-Host
+Get-ChildItem -Path Env:/* -Include @(
+    "BUILD_BUILDNUMBER",
+    "BUILD_CONFIGURATION",
+    "BUILD_VERBOSITY",
+    "ASSEMBLY_VERSION",
+    "PYTHON_VERSION",
+    "NUGET_VERSION",
+    "NATIVE_SIMULATOR",
+    "QIR_DROPS",
+    "DROPS_DIR",
+    "DROP_NATIVE",
+    "INTERNAL_TOOLS_OUTDIR",
+    "NUGET_OUTDIR",
+    "CRATE_OUTDIR",
+    "WHEEL_OUTDIR",
+    "DOCS_OUTDIR"
+) | Format-Table | Out-String | Write-Host
 
-# Get-ChildItem @(
-#     "Env:\DROPS_DIR",
-#     "Env:\DROP_NATIVE",
-#     "Env:\NUGET_OUTDIR",
-#     "Env:\CRATE_OUTDIR",
-#     "Env:\WHEEL_OUTDIR",
-#     "Env:\DOCS_OUTDIR"
-#  ) | Format-Table
+Get-ChildItem @(
+    "Env:\DROPS_DIR",
+    "Env:\DROP_NATIVE",
+    "Env:\NUGET_OUTDIR",
+    "Env:\CRATE_OUTDIR",
+    "Env:\WHEEL_OUTDIR",
+    "Env:\DOCS_OUTDIR"
+ ) | Format-Table
 
-# Write-Host "PATH:"
-# Write-Host "$Env:PATH"
+Write-Host "PATH:"
+Write-Host "$Env:PATH"

--- a/build/set-env.ps1
+++ b/build/set-env.ps1
@@ -39,32 +39,32 @@ If (-not (Test-Path -Path $Env:WHEEL_OUTDIR)) { [IO.Directory]::CreateDirectory(
 If ($Env:DOCS_OUTDIR -eq $null) { $Env:DOCS_OUTDIR =  (Join-Path $Env:DROPS_DIR "docs") }
 If (-not (Test-Path -Path $Env:DOCS_OUTDIR)) { [IO.Directory]::CreateDirectory($Env:DOCS_OUTDIR) }
 
-Get-ChildItem -Path Env:/* -Include @(
-    "BUILD_BUILDNUMBER",
-    "BUILD_CONFIGURATION",
-    "BUILD_VERBOSITY",
-    "ASSEMBLY_VERSION",
-    "PYTHON_VERSION",
-    "NUGET_VERSION",
-    "NATIVE_SIMULATOR",
-    "QIR_DROPS",
-    "DROPS_DIR",
-    "DROP_NATIVE",
-    "INTERNAL_TOOLS_OUTDIR",
-    "NUGET_OUTDIR",
-    "CRATE_OUTDIR",
-    "WHEEL_OUTDIR",
-    "DOCS_OUTDIR"
-) | Format-Table | Out-String | Write-Host
+# Get-ChildItem -Path Env:/* -Include @(
+#     "BUILD_BUILDNUMBER",
+#     "BUILD_CONFIGURATION",
+#     "BUILD_VERBOSITY",
+#     "ASSEMBLY_VERSION",
+#     "PYTHON_VERSION",
+#     "NUGET_VERSION",
+#     "NATIVE_SIMULATOR",
+#     "QIR_DROPS",
+#     "DROPS_DIR",
+#     "DROP_NATIVE",
+#     "INTERNAL_TOOLS_OUTDIR",
+#     "NUGET_OUTDIR",
+#     "CRATE_OUTDIR",
+#     "WHEEL_OUTDIR",
+#     "DOCS_OUTDIR"
+# ) | Format-Table | Out-String | Write-Host
 
-Get-ChildItem @(
-    "Env:\DROPS_DIR",
-    "Env:\DROP_NATIVE",
-    "Env:\NUGET_OUTDIR",
-    "Env:\CRATE_OUTDIR",
-    "Env:\WHEEL_OUTDIR",
-    "Env:\DOCS_OUTDIR"
- ) | Format-Table
+# Get-ChildItem @(
+#     "Env:\DROPS_DIR",
+#     "Env:\DROP_NATIVE",
+#     "Env:\NUGET_OUTDIR",
+#     "Env:\CRATE_OUTDIR",
+#     "Env:\WHEEL_OUTDIR",
+#     "Env:\DOCS_OUTDIR"
+#  ) | Format-Table
 
-Write-Host "PATH:"
-Write-Host "$Env:PATH"
+# Write-Host "PATH:"
+# Write-Host "$Env:PATH"


### PR DESCRIPTION
The end to end build takes the return from `manifest.ps1` by checking the output stream for `$artifacts`, which is [written to output](https://github.com/microsoft/qsharp-runtime/blob/2b82379d284a194a7b613641caca0e550c2db30d/build/manifest.ps1#L70) at the end of the script. The `set-env.ps1` script is also writing to the output stream however, which prevents the end to end build from picking up the expected results. Piping the output from `set-env.ps1` to null ensures that the end to end build can pick up the expected output.