### PR TITLE
Edits to target packages to make intrinsics accessible in regenerated library code

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Microsoft.Quantum.Sdk": "0.24.41904-alpha"
+    "Microsoft.Quantum.Sdk": "0.24.41925-alpha"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Microsoft.Quantum.Sdk": "0.24.41925-alpha"
+    "Microsoft.Quantum.Sdk": "0.24.41940-alpha"
   }
 }

--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.41925-alpha" />
+    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.41940-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.41904-alpha" />
+    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.41925-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
+++ b/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.41904-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.41925-alpha" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
   </ItemGroup>
 

--- a/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
+++ b/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.41925-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.41940-alpha" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
   </ItemGroup>
 

--- a/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.41904-alpha" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.41925-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.41925-alpha" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.41940-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\QSharpCore\Microsoft.Quantum.QSharp.Core.csproj" />
-	<ProjectReference Include="..\..\..\Type3Core\Microsoft.Quantum.Type3.Core.csproj" Aliases="TargetPackage" IsTargetPackage='true' />
+    <ProjectReference Include="..\..\..\Type3Core\Microsoft.Quantum.Type3.Core.csproj" Aliases="TargetPackage" IsTargetPackage='true' />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCIExe.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\QSharpCore\Microsoft.Quantum.QSharp.Core.csproj" />
-	<ProjectReference Include="..\..\..\Type3Core\Microsoft.Quantum.Type3.Core.csproj" IsTargetPackage='true' />
+	<ProjectReference Include="..\..\..\Type3Core\Microsoft.Quantum.Type3.Core.csproj" Aliases="TargetPackage" IsTargetPackage='true' />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCISimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/QCIExe/QCISimulation.qs
@@ -7,323 +7,283 @@ namespace Microsoft.Quantum.Simulation.Testing.QCI {
     open Microsoft.Quantum.Simulation.Testing.QCI.ClassicallyControlledSupportTests;
     open Microsoft.Quantum.Simulation.Testing.QCI.MeasurementSupportTests;
 
+    // The resource estimator is not compatible with executables 
+    // that have been targeted for hardware backends, since it 
+    // does not implement the necessary interfaces.
+    // There are hence no test cases running on the resources estimator.
+
+
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation MeasureInMiddleTest() : Unit {
         MeasureInMiddle();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation QubitAfterMeasurementTest() : Unit {
         QubitAfterMeasurement();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation BranchOnMeasurementTest() : Unit {
         BranchOnMeasurement();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation BasicLiftTest() : Unit {
         BasicLift();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation LiftLoopsTest() : Unit {
         LiftLoops();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation LiftSingleNonCallTest() : Unit {
         LiftSingleNonCall();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation LiftSelfContainedMutableTest() : Unit {
         LiftSelfContainedMutable();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ArgumentsPartiallyResolveTypeParametersTest() : Unit {
         ArgumentsPartiallyResolveTypeParameters();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation LiftFunctorApplicationTest() : Unit {
         LiftFunctorApplication();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation LiftOneNotBothTest() : Unit {
         LiftOneNotBoth();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ApplyIfZeroTest() : Unit {
         ApplyIfZero_Test();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ApplyIfOneTest() : Unit {
         ApplyIfOne_Test();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ApplyIfZeroElseOneTest() : Unit {
         ApplyIfZeroElseOne();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ApplyIfOneElseZeroTest() : Unit {
         ApplyIfOneElseZero();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation IfElifTest() : Unit {
         IfElif();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation AndConditionTest() : Unit {
         AndCondition();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation OrConditionTest() : Unit {
         OrCondition();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ApplyConditionallyTest() : Unit {
         ApplyConditionally();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ApplyConditionallyWithNoOpTest() : Unit {
         ApplyConditionallyWithNoOp();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation InequalityWithApplyConditionallyTest() : Unit {
         InequalityWithApplyConditionally();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation InequalityWithApplyIfOneElseZeroTest() : Unit {
         InequalityWithApplyIfOneElseZero();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation InequalityWithApplyIfZeroElseOneTest() : Unit {
         InequalityWithApplyIfZeroElseOne();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation InequalityWithApplyIfOneTest() : Unit {
         InequalityWithApplyIfOne();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation InequalityWithApplyIfZeroTest() : Unit {
         InequalityWithApplyIfZero();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation LiteralOnTheLeftTest() : Unit {
         LiteralOnTheLeft();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation GenericsSupportTest() : Unit {
         GenericsSupport<Int, Int, Int>();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation WithinBlockSupportTest() : Unit {
         WithinBlockSupport();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation AdjointSupportProvidedTest() : Unit {
         AdjointSupportProvided();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation AdjointSupportSelfTest() : Unit {
         AdjointSupportSelf();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation AdjointSupportInvertTest() : Unit {
         AdjointSupportInvert();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledSupportProvidedTest() : Unit {
         ControlledSupportProvided();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledSupportDistributeTest() : Unit {
         ControlledSupportDistribute();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportProvided_ProvidedBodyTest() : Unit {
         ControlledAdjointSupportProvided_ProvidedBody();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportProvided_ProvidedAdjointTest() : Unit {
         ControlledAdjointSupportProvided_ProvidedAdjoint();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportProvided_ProvidedControlledTest() : Unit {
         ControlledAdjointSupportProvided_ProvidedControlled();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportProvided_ProvidedAllTest() : Unit {
         ControlledAdjointSupportProvided_ProvidedAll();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportDistribute_DistributeBodyTest() : Unit {
         ControlledAdjointSupportDistribute_DistributeBody();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportDistribute_DistributeAdjointTest() : Unit {
         ControlledAdjointSupportDistribute_DistributeAdjoint();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportDistribute_DistributeControlledTest() : Unit {
         ControlledAdjointSupportDistribute_DistributeControlled();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportDistribute_DistributeAllTest() : Unit {
         ControlledAdjointSupportDistribute_DistributeAll();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportInvert_InvertBodyTest() : Unit {
         ControlledAdjointSupportInvert_InvertBody();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportInvert_InvertAdjointTest() : Unit {
         ControlledAdjointSupportInvert_InvertAdjoint();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportInvert_InvertControlledTest() : Unit {
         ControlledAdjointSupportInvert_InvertControlled();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportInvert_InvertAllTest() : Unit {
         ControlledAdjointSupportInvert_InvertAll();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportSelf_SelfBodyTest() : Unit {
         ControlledAdjointSupportSelf_SelfBody();
     }
 
     @Test("QuantumSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ControlledAdjointSupportSelf_SelfControlledTest() : Unit {
         ControlledAdjointSupportSelf_SelfControlled();

--- a/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-	<QscVerbosity>detailed</QscVerbosity>
+    <QscVerbosity>detailed</QscVerbosity>
     <!-- we will provide our own -->
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>

--- a/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/TargetedExe/TargetedExe.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\EntryPointDriver\Microsoft.Quantum.EntryPointDriver.csproj" />
     <ProjectReference Include="..\..\..\QSharpCore\Microsoft.Quantum.QSharp.Core.csproj" />
-    <ProjectReference Include="..\..\..\Type1Core\Microsoft.Quantum.Type1.Core.csproj" IsTargetPackage='true' />
+    <ProjectReference Include="..\..\..\Type1Core\Microsoft.Quantum.Type1.Core.csproj" Aliases="TargetPackage" IsTargetPackage='true' />
 </ItemGroup>
 
 </Project>

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -8,6 +8,7 @@
     <LanguageVersion>8.0</LanguageVersion>
     <Nullable>enable</Nullable>
     <TargetFramework>netstandard2.1</TargetFramework>
+	<IncludeCSharpRuntime>false</IncludeCSharpRuntime>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -8,7 +8,7 @@
     <LanguageVersion>8.0</LanguageVersion>
     <Nullable>enable</Nullable>
     <TargetFramework>netstandard2.1</TargetFramework>
-	<IncludeCSharpRuntime>false</IncludeCSharpRuntime>
+    <IncludeCSharpRuntime>false</IncludeCSharpRuntime>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>

--- a/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualInPlace.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualInPlace.qs
@@ -9,7 +9,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// Iterates a variable through a Cartesian product
     /// [ 0, bounds[0]-1 ] × [ 0, bounds[1]-1 ] × [ 0, bounds[Length(bounds)-1]-1 ]
     /// and calls op(arr) for every element of the Cartesian product
-    internal operation IterateThroughCartesianPower (length : Int, value : Int, op : (Int[] => Unit)) : Unit {
+    operation IterateThroughCartesianPower (length : Int, value : Int, op : (Int[] => Unit)) : Unit {
         mutable bounds = new Int[length];
 
         for i in 0 .. length - 1
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// ## basis
     /// Array of single-qubit basis state IDs (0 <= id <= 3), one for each element of
     /// qubits.
-    internal operation FlipToBasis (basis : Int[], qubits : Qubit[]) : Unit is Adj + Ctl {
+    operation FlipToBasis (basis : Int[], qubits : Qubit[]) : Unit is Adj + Ctl {
         if (Length(qubits) != Length(basis))
         {
             fail "qubits and stateIds must have the same length";
@@ -117,7 +117,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// Operation on $n$ qubits to be checked.
     /// ## expectedU
     /// Reference operation on $n$ qubits that givenU is to be compared against.
-    internal operation AssertEqualOnBasisVector (basis : Int[], givenU : (Qubit[] => Unit), expectedU : (Qubit[] => Unit is Adj)) : Unit {
+    operation AssertEqualOnBasisVector (basis : Int[], givenU : (Qubit[] => Unit), expectedU : (Qubit[] => Unit is Adj)) : Unit {
         let tolerance = 1e-5;
 
         use qubits = Qubit[Length(basis)] {

--- a/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualInPlace.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualInPlace.qs
@@ -9,7 +9,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// Iterates a variable through a Cartesian product
     /// [ 0, bounds[0]-1 ] × [ 0, bounds[1]-1 ] × [ 0, bounds[Length(bounds)-1]-1 ]
     /// and calls op(arr) for every element of the Cartesian product
-    operation IterateThroughCartesianPower (length : Int, value : Int, op : (Int[] => Unit)) : Unit {
+    internal operation IterateThroughCartesianPower (length : Int, value : Int, op : (Int[] => Unit)) : Unit {
         mutable bounds = new Int[length];
 
         for i in 0 .. length - 1
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// ## basis
     /// Array of single-qubit basis state IDs (0 <= id <= 3), one for each element of
     /// qubits.
-    operation FlipToBasis (basis : Int[], qubits : Qubit[]) : Unit is Adj + Ctl {
+    internal operation FlipToBasis (basis : Int[], qubits : Qubit[]) : Unit is Adj + Ctl {
         if (Length(qubits) != Length(basis))
         {
             fail "qubits and stateIds must have the same length";
@@ -117,7 +117,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// Operation on $n$ qubits to be checked.
     /// ## expectedU
     /// Reference operation on $n$ qubits that givenU is to be compared against.
-    operation AssertEqualOnBasisVector (basis : Int[], givenU : (Qubit[] => Unit), expectedU : (Qubit[] => Unit is Adj)) : Unit {
+    internal operation AssertEqualOnBasisVector (basis : Int[], givenU : (Qubit[] => Unit), expectedU : (Qubit[] => Unit is Adj)) : Unit {
         let tolerance = 1e-5;
 
         use qubits = Qubit[Length(basis)] {

--- a/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualReferenced.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualReferenced.qs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// A qubit array in the $\ket{0\cdots 0}$ state
     /// ## right
     /// A qubit array in the $\ket{0\cdots 0}$ state
-    operation PrepareEntangledState (left : Qubit[], right : Qubit[]) : Unit
+    internal operation PrepareEntangledState (left : Qubit[], right : Qubit[]) : Unit
     is Adj + Ctl {
 
         for idxQubit in 0 .. Length(left) - 1

--- a/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualReferenced.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualReferenced.qs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// A qubit array in the $\ket{0\cdots 0}$ state
     /// ## right
     /// A qubit array in the $\ket{0\cdots 0}$ state
-    internal operation PrepareEntangledState (left : Qubit[], right : Qubit[]) : Unit
+    operation PrepareEntangledState (left : Qubit[], right : Qubit[]) : Unit
     is Adj + Ctl {
 
         for idxQubit in 0 .. Length(left) - 1

--- a/src/Simulation/TargetDefinitions/Decompositions/ExpFracFromExpUtil.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ExpFracFromExpUtil.qs
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation ApplyGlobalPhaseFracWithR1Frac (numerator : Int, power : Int) : Unit is Adj + Ctl {
+    operation ApplyGlobalPhaseFracWithR1Frac (numerator : Int, power : Int) : Unit is Adj + Ctl {
         body (...) {}
         controlled (ctrls, ...) {
             let numControls =  Length(ctrls);

--- a/src/Simulation/TargetDefinitions/Decompositions/ExpUtil.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ExpUtil.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Intrinsic {
 
-    internal operation ExpUtil (paulis : Pauli[], theta : Double, qubits : Qubit[], rotation : ((Pauli, Qubit) => Unit is Adj + Ctl)) : Unit is Ctl {
+    operation ExpUtil (paulis : Pauli[], theta : Double, qubits : Qubit[], rotation : ((Pauli, Qubit) => Unit is Adj + Ctl)) : Unit is Ctl {
         if (Length(paulis) != Length(qubits)) { fail "Arrays 'paulis' and 'qubits' must have the same length"; }
         if (Length(paulis) == 1) {
             rotation(paulis[0], qubits[0]);

--- a/src/Simulation/TargetDefinitions/Decompositions/ExpUtilFromIsing.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/ExpUtilFromIsing.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Intrinsic {
 
-    internal operation ExpUtil (paulis : Pauli[], theta : Double, qubits : Qubit[], rotation : ((Pauli, Qubit) => Unit is Adj + Ctl)) : Unit is Ctl {
+    operation ExpUtil (paulis : Pauli[], theta : Double, qubits : Qubit[], rotation : ((Pauli, Qubit) => Unit is Adj + Ctl)) : Unit is Ctl {
         if (Length(paulis) != Length(qubits)) { fail "Arrays 'paulis' and 'qubits' must have the same length"; }
         if (Length(paulis) == 1) {
             rotation(paulis[0], qubits[0]);

--- a/src/Simulation/TargetDefinitions/Decompositions/HFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/HFromSinglyControlled.qs
@@ -51,7 +51,7 @@ namespace Microsoft.Quantum.Intrinsic {
         adjoint self;
     }
 
-    internal operation CH(control : Qubit, target : Qubit) : Unit is Adj {
+    operation CH(control : Qubit, target : Qubit) : Unit is Adj {
         within {
             S(target);
             H(target);
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation CCH(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+    operation CCH(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         within {
             S(target);
             H(target);

--- a/src/Simulation/TargetDefinitions/Decompositions/PreparePostM.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/PreparePostM.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Intrinsic {
 
-    internal operation PreparePostM(result : Result, qubit : Qubit) : Unit {
+    operation PreparePostM(result : Result, qubit : Qubit) : Unit {
         // This platform requires reset after measurement, and then must
         // re-prepare the measured state in the qubit.
         Reset(qubit);

--- a/src/Simulation/TargetDefinitions/Decompositions/PreparePostMNoop.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/PreparePostMNoop.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Intrinsic {
 
-    internal operation PreparePostM(result : Result, qubit : Qubit) : Unit {
+    operation PreparePostM(result : Result, qubit : Qubit) : Unit {
         // This platform does not require any post-measurement reset, so
         // no additional work is needed.
     }

--- a/src/Simulation/TargetDefinitions/Decompositions/R.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/R.qs
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation ApplyGlobalPhase (theta : Double) : Unit is Ctl + Adj {
+    operation ApplyGlobalPhase (theta : Double) : Unit is Ctl + Adj {
         body (...) {}
         controlled (ctls, (...)) {
             if (Length(ctls) > 0) {

--- a/src/Simulation/TargetDefinitions/Decompositions/R1FromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/R1FromSinglyControlled.qs
@@ -48,7 +48,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation CR1(theta : Double, control : Qubit, target : Qubit) : Unit is Adj {
+    operation CR1(theta : Double, control : Qubit, target : Qubit) : Unit is Adj {
         Rz(theta/2.0, target);
         Rz(theta/2.0, control);
         CNOT(control,target);

--- a/src/Simulation/TargetDefinitions/Decompositions/RFromSinglyControlledR1.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RFromSinglyControlledR1.qs
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation ApplyGlobalPhase (theta : Double) : Unit is Ctl + Adj {
+    operation ApplyGlobalPhase (theta : Double) : Unit is Ctl + Adj {
         body (...) {}
         controlled (ctls, (...)) {
             if Length(ctls) == 0 {

--- a/src/Simulation/TargetDefinitions/Decompositions/RzFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RzFromSinglyControlled.qs
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation CRz(control : Qubit, theta : Double, target : Qubit) : Unit is Adj {
+    operation CRz(control : Qubit, theta : Double, target : Qubit) : Unit is Adj {
         Rz(theta / 2.0, target);
         CNOT(control, target);
         Rz(-theta / 2.0, target);

--- a/src/Simulation/TargetDefinitions/Decompositions/SFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/SFromSinglyControlled.qs
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation CS(control : Qubit, target : Qubit) : Unit is Adj + Ctl {
+    operation CS(control : Qubit, target : Qubit) : Unit is Adj + Ctl {
         T(control);
         T(target);
         CNOT(control, target);

--- a/src/Simulation/TargetDefinitions/Decompositions/TFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/TFromSinglyControlled.qs
@@ -64,7 +64,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation CT(control : Qubit, target : Qubit) : Unit is Adj {
+    operation CT(control : Qubit, target : Qubit) : Unit is Adj {
         let angle = PI() / 8.0;
         Rz(angle, control);
         Rz(angle, target);

--- a/src/Simulation/TargetDefinitions/Decompositions/Utils.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/Utils.qs
@@ -4,7 +4,7 @@
 namespace Microsoft.Quantum.Intrinsic {
     open Microsoft.Quantum.Measurement;
 
-    internal operation SpreadZ (from : Qubit, to : Qubit[]) : Unit is Adj {
+    operation SpreadZ (from : Qubit, to : Qubit[]) : Unit is Adj {
         if (Length(to) > 0) {
             CNOT(to[0], from);
             if (Length(to) > 1) {
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation MapPauli (qubit : Qubit, from : Pauli, to : Pauli) : Unit is Adj {
+    operation MapPauli (qubit : Qubit, from : Pauli, to : Pauli) : Unit is Adj {
         if (from == to) {
         }
         elif ((from == PauliZ and to == PauliX) or (from == PauliX and to == PauliZ)) {
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    internal operation EntangleForJointMeasure(basis : Pauli, aux : Qubit, qubit : Qubit) : Unit {
+    operation EntangleForJointMeasure(basis : Pauli, aux : Qubit, qubit : Qubit) : Unit {
         if basis == PauliX {
             Controlled X([aux], qubit);
         }
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// For example, if the controls list is 6 qubits, the auxiliary list must be 5 qubits, and the
     /// state from the 6 control qubits will be collected into the last qubit of the auxiliary array.
-    internal operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
+    operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
         // First collect the controls into the first part of the auxiliary list.
         for i in 0..2..(Length(ctls) - 2) {
             PhaseCCX(ctls[i], ctls[i + 1], aux[i / 2]);
@@ -77,13 +77,13 @@ namespace Microsoft.Quantum.Intrinsic {
 
     /// When collecting controls, if there is an uneven number of original control qubits then the
     /// last control and the second to last auxiliary will be collected into the last auxiliary.
-    internal operation AdjustForSingleControl(ctls : Qubit[], aux : Qubit[]) : Unit is Adj {
+    operation AdjustForSingleControl(ctls : Qubit[], aux : Qubit[]) : Unit is Adj {
         if Length(ctls) % 2 != 0 {
             PhaseCCX(ctls[Length(ctls) - 1], aux[Length(ctls) - 3], aux[Length(ctls) - 2]);
         }
     }
 
-    internal operation PhaseCCX (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+    operation PhaseCCX (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         // https://arxiv.org/pdf/1210.0974.pdf#page=2
         H(target);
         CNOT(target,control1);
@@ -98,7 +98,7 @@ namespace Microsoft.Quantum.Intrinsic {
         H(target);
     }
 
-    internal operation CCZ (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+    operation CCZ (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         // [Page 15 of arXiv:1206.0758v3](https://arxiv.org/pdf/1206.0758v3.pdf#page=15)
         Adjoint T(control1);
         Adjoint T(control2);
@@ -115,7 +115,7 @@ namespace Microsoft.Quantum.Intrinsic {
         CNOT(control2, control1);
     }
 
-    internal function ReducedDyadicFraction (numerator : Int, denominatorPowerOfTwo : Int) : (Int, Int) {
+    function ReducedDyadicFraction (numerator : Int, denominatorPowerOfTwo : Int) : (Int, Int) {
         if (numerator == 0) { return (0,0); }
         mutable num = numerator;
         mutable denPow = denominatorPowerOfTwo;
@@ -126,7 +126,7 @@ namespace Microsoft.Quantum.Intrinsic {
         return (num,denPow);
     }
 
-    internal function ReducedDyadicFractionPeriodic (numerator : Int, denominatorPowerOfTwo : Int) : (Int, Int) {
+    function ReducedDyadicFractionPeriodic (numerator : Int, denominatorPowerOfTwo : Int) : (Int, Int) {
         let (k,n) = ReducedDyadicFraction(numerator,denominatorPowerOfTwo); // k is odd, or (k,n) are both 0
         let period = 2*2^n; // \pi k / 2^n is 2\pi periodic, therefore k is 2 * 2^n periodic
         let kMod = k % period; // if k was negative, we get kMod in a range [-period + 1, 0]
@@ -136,7 +136,7 @@ namespace Microsoft.Quantum.Intrinsic {
 
     // TODO(swernli): Consider removing this in favor of pulling Microsoft.Quantum.Arrays.Subarray
     // into the runtime.
-    internal function Subarray<'T> (indices : Int[], array : 'T[]) : 'T[] {
+    function Subarray<'T> (indices : Int[], array : 'T[]) : 'T[] {
         let nSliced = Length(indices);
         mutable sliced = new 'T[nSliced];
 
@@ -147,7 +147,7 @@ namespace Microsoft.Quantum.Intrinsic {
         return sliced;
     }
 
-    internal function IndicesOfNonIdentity (paulies : Pauli[]) : Int[] {
+    function IndicesOfNonIdentity (paulies : Pauli[]) : Int[] {
         mutable nonIdPauliCount = 0;
 
         for i in 0 .. Length(paulies) - 1 {
@@ -167,7 +167,7 @@ namespace Microsoft.Quantum.Intrinsic {
         return indices;
     }
 
-    internal function RemovePauliI (paulis : Pauli[], qubits : Qubit[]) : (Pauli[], Qubit[]) {
+    function RemovePauliI (paulis : Pauli[], qubits : Qubit[]) : (Pauli[], Qubit[]) {
         let indices = IndicesOfNonIdentity(paulis);
         let newPaulis = Subarray(indices, paulis);
         let newQubits = Subarray(indices, qubits);

--- a/src/Simulation/TargetDefinitions/Decompositions/YFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/YFromSinglyControlled.qs
@@ -51,7 +51,7 @@ namespace Microsoft.Quantum.Intrinsic {
         adjoint self;
     }
 
-    internal operation CCY(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+    operation CCY(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         within {
             MapPauli(target, PauliZ, PauliY);
         }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyControlledX.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyControlledX.qs
@@ -33,7 +33,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// CNOT(control, target);
     /// ```
     @TargetInstruction("cnot__body")
-    internal operation ApplyControlledX (control : Qubit, target : Qubit) : Unit is Adj {
+    operation ApplyControlledX (control : Qubit, target : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyControlledZ.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyControlledZ.qs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Controlled Z([control], target);
     /// ```
     @TargetInstruction("cz__body")
-    internal operation ApplyControlledZ (control : Qubit, target : Qubit) : Unit is Adj {
+    operation ApplyControlledZ (control : Qubit, target : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledH.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledH.qs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ## qubit
     /// Qubit to which the gate should be applied.
     @TargetInstruction("h__body")
-    internal operation ApplyUncontrolledH (qubit : Qubit) : Unit is Adj {
+    operation ApplyUncontrolledH (qubit : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRx.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRx.qs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// R(PauliX, theta, qubit);
     /// ```
     @TargetInstruction("rx__body")
-    internal operation ApplyUncontrolledRx (theta : Double, qubit : Qubit) : Unit {
+    operation ApplyUncontrolledRx (theta : Double, qubit : Qubit) : Unit {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRy.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRy.qs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// R(PauliY, theta, qubit);
     /// ```
     @TargetInstruction("ry__body")
-    internal operation ApplyUncontrolledRy (theta : Double, qubit : Qubit) : Unit {
+    operation ApplyUncontrolledRy (theta : Double, qubit : Qubit) : Unit {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRz.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledRz.qs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// R(PauliZ, theta, qubit);
     /// ```
     @TargetInstruction("rz__body")
-    internal operation ApplyUncontrolledRz (theta : Double, qubit : Qubit) : Unit {
+    operation ApplyUncontrolledRz (theta : Double, qubit : Qubit) : Unit {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledS.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledS.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ## qubit
     /// Qubit to which the gate should be applied.
     @TargetInstruction("s__body")
-    internal operation ApplyUncontrolledS (qubit : Qubit) : Unit {
+    operation ApplyUncontrolledS (qubit : Qubit) : Unit {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledSAdj.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledSAdj.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ## qubit
     /// Qubit to which the gate should be applied.
     @TargetInstruction("s__adj")
-    internal operation ApplyUncontrolledSAdj (qubit : Qubit) : Unit {
+    operation ApplyUncontrolledSAdj (qubit : Qubit) : Unit {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledT.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledT.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ## qubit
     /// Qubit to which the gate should be applied.
     @TargetInstruction("t__body")
-    internal operation ApplyUncontrolledT (qubit : Qubit) : Unit {
+    operation ApplyUncontrolledT (qubit : Qubit) : Unit {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledTAdj.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledTAdj.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ## qubit
     /// Qubit to which the gate should be applied.
     @TargetInstruction("t__adj")
-    internal operation ApplyUncontrolledTAdj (qubit : Qubit) : Unit {
+    operation ApplyUncontrolledTAdj (qubit : Qubit) : Unit {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledX.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledX.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ## qubit
     /// Qubit to which the gate should be applied.
     @TargetInstruction("x__body")
-    internal operation ApplyUncontrolledX (qubit : Qubit) : Unit is Adj {
+    operation ApplyUncontrolledX (qubit : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledY.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledY.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ## qubit
     /// Qubit to which the gate should be applied.
     @TargetInstruction("y__body")
-    internal operation ApplyUncontrolledY (qubit : Qubit) : Unit is Adj {
+    operation ApplyUncontrolledY (qubit : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledZ.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledZ.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ## qubit
     /// Qubit to which the gate should be applied.
     @TargetInstruction("z__body")
-    internal operation ApplyUncontrolledZ (qubit : Qubit) : Unit is Adj {
+    operation ApplyUncontrolledZ (qubit : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;
     }

--- a/src/Simulation/TargetDefinitions/Intrinsic/IsingXX.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/IsingXX.qs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The first qubit input to the gate.
     /// ## qubit1
     /// The second qubit input to the gate.
-    internal operation IsingXX (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+    operation IsingXX (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/IsingYY.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/IsingYY.qs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The first qubit input to the gate.
     /// ## qubit1
     /// The second qubit input to the gate.
-    internal operation IsingYY (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+    operation IsingYY (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/IsingZZ.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/IsingZZ.qs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The first qubit input to the gate.
     /// ## qubit1
     /// The second qubit input to the gate.
-    internal operation IsingZZ (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+    operation IsingZZ (theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body intrinsic;
     }
 }

--- a/src/Simulation/TargetDefinitions/Intrinsic/MZ.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/MZ.qs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Measure([PauliZ], [qubit]);
     /// ```
     @TargetInstruction("m__body")
-    internal operation MZ (qubit : Qubit) : Result {
+    operation MZ (qubit : Qubit) : Result {
         body intrinsic;
     }
 }

--- a/src/Xunit/Microsoft.Quantum.Xunit.nuspec
+++ b/src/Xunit/Microsoft.Quantum.Xunit.nuspec
@@ -22,7 +22,7 @@
     <dependencies>
       <dependency id="xunit" version="2.3.1" />
       <dependency id="Microsoft.NET.Test.Sdk" version="15.3.0" />
-      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.41904-alpha" />
+      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.41925-alpha" />
     </dependencies>
   </metadata>
 

--- a/src/Xunit/Microsoft.Quantum.Xunit.nuspec
+++ b/src/Xunit/Microsoft.Quantum.Xunit.nuspec
@@ -22,7 +22,7 @@
     <dependencies>
       <dependency id="xunit" version="2.3.1" />
       <dependency id="Microsoft.NET.Test.Sdk" version="15.3.0" />
-      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.41925-alpha" />
+      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.41940-alpha" />
     </dependencies>
   </metadata>
 


### PR DESCRIPTION
Note that I did not make anything public that is part of the Q# Core, only the callables that are used in the target packages that replace it. This should hence be a non-breaking change. Unfortunately, having callables in target packages be internal makes it inpossible to regenerate the code that calls into it, and hence poses a problem.