### PR TITLE
Fixing mistakenly public Target package operation

### DIFF
--- a/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledSWAP.qs
+++ b/src/Simulation/TargetDefinitions/Intrinsic/ApplyUncontrolledSWAP.qs
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// CNOT(qubit1, qubit2);
     /// ```
     @TargetInstruction("swap__body")
-    operation ApplyUncontrolledSWAP (qubit1 : Qubit, qubit2 : Qubit) : Unit is Adj {
+    internal operation ApplyUncontrolledSWAP (qubit1 : Qubit, qubit2 : Qubit) : Unit is Adj {
         body intrinsic;
         adjoint self;
     }


### PR DESCRIPTION
The `ApplyUncontrolledSWAP` operation was mistakenly left public instead of being marked as internal. This should not be part of the public API surface and callers should instead use `SWAP` directly.

Fixes Cannot find ApplyUncontrolledSWAP in original package #1029