### PR TITLE
Use record to get `with` keyword.

### DIFF
--- a/src/Simulation/Core/Microsoft.Quantum.Runtime.Core.csproj
+++ b/src/Simulation/Core/Microsoft.Quantum.Runtime.Core.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.Runtime</RootNamespace>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Simulation/Core/Submitters/SubmissionOptions.cs
+++ b/src/Simulation/Core/Submitters/SubmissionOptions.cs
@@ -5,32 +5,37 @@ using System.Collections.Immutable;
 
 #nullable enable
 
+namespace System.Runtime.CompilerServices
+{
+    public class IsExternalInit {}
+}
+
 namespace Microsoft.Quantum.Runtime.Submitters
 {
     /// <summary>
     /// Options for a job submitted to Azure Quantum.
     /// </summary>
-    public class SubmissionOptions
+    public record SubmissionOptions
     {
         /// <summary>
         /// A name describing the job.
         /// </summary>
-        public string FriendlyName { get; }
+        public string FriendlyName { get; init; }
 
         /// <summary>
         /// The number of times the program will be executed.
         /// </summary>
-        public int Shots { get; }
+        public int Shots { get; init; }
 
         /// <summary>
         /// Additional target-specific parameters for the job.
         /// </summary>
-        public ImmutableDictionary<string, string> InputParams { get; }
+        public ImmutableDictionary<string, string> InputParams { get; init; }
 
         /// <summary>
         /// The target capability.
         /// </summary>
-        public string TargetCapability { get; set; }
+        public string TargetCapability { get;  init; }
 
         /// <summary>
         /// The default submission options.
@@ -60,7 +65,12 @@ namespace Microsoft.Quantum.Runtime.Submitters
             int? shots = null,
             ImmutableDictionary<string, string>? inputParams = null,
             string? targetCapability = null) =>
-            new SubmissionOptions(
-                friendlyName ?? FriendlyName, shots ?? Shots, inputParams ?? InputParams, targetCapability ?? TargetCapability);
+            this with
+            {
+                FriendlyName = friendlyName ?? FriendlyName,
+                Shots = shots ?? Shots,
+                InputParams = inputParams ?? InputParams,
+                TargetCapability = targetCapability ?? TargetCapability
+            };
     }
 }


### PR DESCRIPTION
This PR modifies the `SubmissionOptions` class to be a record class, allowing other code to use the `with` keyword to modify instances of the class on a field-by-field basis. The existing `With` method can then be refactored to use the `with` keyword.