### PR TITLE
Use Reset in Type1 Measure

### DIFF
--- a/src/Simulation/TargetDefinitions/Decompositions/Measure.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/Measure.qs
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.Intrinsic {
                 MapPauli(qubits[0], PauliZ, bases[0]);
             }
             apply {
-                set res = MZ(qubits[0]);
+                set res = M(qubits[0]);
             }
         }
         else {


### PR DESCRIPTION
This fixes the decomposition of `Measure` in the Type1 target package to use `M` instead of directly calling the internal `MZ` which ensures that single qubit measurement will properly perform the post `M` reset and repreparation of qubit state.