### PR TITLE
Add Sparse Sim to manifest, link against Spectre libs

### DIFF
--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -54,6 +54,7 @@ $artifacts = @{
     
     Native = @(
         ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulator.Runtime.dll",
+        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.SparseSimulator.Runtime.dll",
         ".\src\Qir\Runtime\bin\$Env:BUILD_CONFIGURATION\bin\Microsoft.Quantum.Qir.QSharp.Core.dll",
         ".\src\Qir\Runtime\bin\$Env:BUILD_CONFIGURATION\bin\Microsoft.Quantum.Qir.QSharp.Foundation.dll",
         ".\src\Qir\Runtime\bin\$Env:BUILD_CONFIGURATION\bin\Microsoft.Quantum.Qir.Runtime.dll",

--- a/src/Common/cmake/secure_dependencies.cmake
+++ b/src/Common/cmake/secure_dependencies.cmake
@@ -38,7 +38,7 @@ macro(locate_win32_spectre_static_runtime)
             NAMES vswhere
             PATHS "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer")
         if (NOT ${vswhere})
-            message(FATAL_ERROR "Could not locate vswhere.exe - unable to source vc redistributable")
+            message(FATAL_ERROR "Could not locate vswhere - unable to search for installed vcruntime libraries.")
         endif()
         execute_process(
             COMMAND "${_vswhere_tool}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/14.29.*/**/lib/spectre/x64 -sort

--- a/src/Common/cmake/secure_dependencies.cmake
+++ b/src/Common/cmake/secure_dependencies.cmake
@@ -1,0 +1,71 @@
+#===============================================================================
+# Configure the flags used to ensure that required security settings are enabled
+macro(configure_security_flags)
+    # Enable Control Flow Guard
+    add_link_options("LINKER:/guard:cf")
+
+    # Enable Compiler supported Spectre mitigations
+    if (NOT APPLE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mspeculative-load-hardening -mretpoline")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mspeculative-load-hardening -mretpoline")
+    endif()
+endmacro()
+
+#===============================================================================
+# Set MSVC static runtime library policy
+# NOTE: Since this sets a cmake policy for ensuring Windows compilation uses static runtime,
+# this policy MUST be set before any projects are declared for it to take effect.
+macro(set_msvc_static_runtime_policy)
+    # Enforce use of static runtime (avoids target machine needing msvcrt installed).
+    # Must set policy CMP0091 before any projects are declared (see https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html#cmake-msvc-runtime-library)
+    cmake_policy(SET CMP0091 NEW)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endmacro()
+
+#===============================================================================
+# Locate Spectre mitigated static C runtime on Windows. Sets the `SPECTRE_LIBS`
+# variable for use in later calls to `target_link_libraries`.
+# NOTE: This sets a cmake policy for ensuring Windows compilation uses static runtime.
+# this policy MUST be set before any projects are declared for it to take effect.
+macro(locate_win32_spectre_static_runtime)
+    if (WIN32)
+        # Locate the vswhere application, which will provide paths to any installed Visual Studio instances.
+        # By invoking it with "-find **/lib/spectre/x64" we will find any Spectre mitigated libaries that
+        # have been installed.
+        find_program(_vswhere_tool
+            NAMES vswhere
+            PATHS "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer")
+        if (NOT ${vswhere})
+            message(FATAL_ERROR "Could not locate vswhere.exe - unable to source vc redistributable")
+        endif()
+        execute_process(
+            COMMAND "${_vswhere_tool}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/14.29.*/**/lib/spectre/x64 -sort
+            OUTPUT_VARIABLE _vs_install_loc_out
+            RESULT_VARIABLE _vs_where_exitcode
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        file(TO_CMAKE_PATH "${_vs_install_loc_out}" SPECTRE_LIB_PATH_OUT)
+        string(REGEX REPLACE "[\r\n]+" ";" SPECTRE_LIB_PATH ${SPECTRE_LIB_PATH_OUT})
+        message(INFO "*** install loc: ${SPECTRE_LIB_PATH}")
+
+        # Locate the spectre mitigated runtime libraries and fail if they can't be found. Targets in this
+        # cmake project can use the variables to explicitly link these libraries rather than using the 
+        # non-mitigated libraries that are found by default.
+        find_library(LIBCMT_SPECTRE_REL libcmt PATHS ${SPECTRE_LIB_PATH} REQUIRED)
+        find_library(LIBCMT_SPECTRE_DEB libcmtd PATHS ${SPECTRE_LIB_PATH} REQUIRED)
+        set(LIBCMT_SPECTRE debug ${LIBCMT_SPECTRE_DEB} optimized ${LIBCMT_SPECTRE_REL})
+        message(INFO "*** using spectre lib: ${LIBCMT_SPECTRE}")
+        find_library(LIBCPMT_SPECTRE_REL libcpmt PATHS ${SPECTRE_LIB_PATH} REQUIRED)
+        find_library(LIBCPMT_SPECTRE_DEB libcpmtd PATHS ${SPECTRE_LIB_PATH} REQUIRED)
+        set(LIBCPMT_SPECTRE debug ${LIBCPMT_SPECTRE_DEB} optimized ${LIBCPMT_SPECTRE_REL})
+        message(INFO "*** using spectre lib: ${LIBCPMT_SPECTRE}")
+        find_library(LIBVCRUNTIME_SPECTRE_REL libvcruntime PATHS ${SPECTRE_LIB_PATH} REQUIRED)
+        find_library(LIBVCRUNTIME_SPECTRE_DEB libvcruntimed PATHS ${SPECTRE_LIB_PATH} REQUIRED)
+        set(LIBVCRUNTIME_SPECTRE debug ${LIBVCRUNTIME_SPECTRE_DEB} optimized ${LIBVCRUNTIME_SPECTRE_REL})
+        message(INFO "*** using spectre lib: ${LIBVCRUNTIME_SPECTRE}")
+        set(SPECTRE_LIBS
+            ${LIBCMT_SPECTRE}
+            ${LIBCPMT_SPECTRE}
+            ${LIBVCRUNTIME_SPECTRE})
+
+    endif (WIN32)
+endmacro()

--- a/src/Common/cmake/secure_dependencies.cmake
+++ b/src/Common/cmake/secure_dependencies.cmake
@@ -2,7 +2,9 @@
 # Configure the flags used to ensure that required security settings are enabled
 macro(configure_security_flags)
     # Enable Control Flow Guard
-    add_link_options("LINKER:/guard:cf")
+    if (WIN32)
+        add_link_options("LINKER:/guard:cf")
+    endif()
 
     # Enable Compiler supported Spectre mitigations
     if (NOT APPLE)

--- a/src/Qir/Runtime/CMakeLists.txt
+++ b/src/Qir/Runtime/CMakeLists.txt
@@ -2,12 +2,10 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 message(INFO "*** build config: ${CMAKE_BUILD_TYPE}")
 
-if (WIN32)
-    # Enforce use of static runtime (avoids target machine needing msvcrt installed).
-    # Must set policy CMP0091 before any projects are declared (see https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html#cmake-msvc-runtime-library)
-    cmake_policy(SET CMP0091 NEW)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-endif (WIN32)
+# Load common utils and configure cmake policies
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../Common/cmake")
+include(secure_dependencies)
+set_msvc_static_runtime_policy()
 
 # set the project name and version
 project(qirruntime)
@@ -16,47 +14,8 @@ project(qirruntime)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-if (WIN32)
-    # Locate the vswhere application, which will provide paths to any installed Visual Studio instances.
-    # By invoking it with "-find **/lib/spectre/x64" we will find any Spectre mitigated libaries that
-    # have been installed.
-    find_program(_vswhere_tool
-        NAMES vswhere
-        PATHS "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer")
-    if (NOT ${vswhere})
-        message(FATAL_ERROR "Could not locate vswhere.exe - unable to source vc redistributable")
-    endif()
-    execute_process(
-        COMMAND "${_vswhere_tool}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/14.29.*/**/lib/spectre/x64 -sort
-        OUTPUT_VARIABLE _vs_install_loc_out
-        RESULT_VARIABLE _vs_where_exitcode
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    file(TO_CMAKE_PATH "${_vs_install_loc_out}" SPECTRE_LIB_PATH_OUT)
-    string(REGEX REPLACE "[\r\n]+" ";" SPECTRE_LIB_PATH ${SPECTRE_LIB_PATH_OUT})
-    message(INFO "*** install loc: ${SPECTRE_LIB_PATH}")
-
-    # Locate the spectre mitigated runtime libraries and fail if they can't be found. Targets in this
-    # cmake project can use the variables to explicitly link these libraries rather than using the 
-    # non-mitigated libraries that are found by default.
-    find_library(LIBCMT_SPECTRE_REL libcmt PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    find_library(LIBCMT_SPECTRE_DEB libcmtd PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    set(LIBCMT_SPECTRE debug ${LIBCMT_SPECTRE_DEB} optimized ${LIBCMT_SPECTRE_REL})
-    message(INFO "*** using spectre lib: ${LIBCMT_SPECTRE}")
-    find_library(LIBCPMT_SPECTRE_REL libcpmt PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    find_library(LIBCPMT_SPECTRE_DEB libcpmtd PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    set(LIBCPMT_SPECTRE debug ${LIBCPMT_SPECTRE_DEB} optimized ${LIBCPMT_SPECTRE_REL})
-    message(INFO "*** using spectre lib: ${LIBCPMT_SPECTRE}")
-    find_library(LIBVCRUNTIME_SPECTRE_REL libvcruntime PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    find_library(LIBVCRUNTIME_SPECTRE_DEB libvcruntimed PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    set(LIBVCRUNTIME_SPECTRE debug ${LIBVCRUNTIME_SPECTRE_DEB} optimized ${LIBVCRUNTIME_SPECTRE_REL})
-    message(INFO "*** using spectre lib: ${LIBVCRUNTIME_SPECTRE}")
-    set(SPECTRE_LIBS
-        ${LIBCMT_SPECTRE}
-        ${LIBCPMT_SPECTRE}
-        ${LIBVCRUNTIME_SPECTRE})
-
-    add_link_options("LINKER:/guard:cf")
-endif()
+locate_win32_spectre_static_runtime()
+configure_security_flags()
 
 # feel free to customize these flags for your local builds (don't check in)
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/src/Simulation/Native/CMakeLists.txt
+++ b/src/Simulation/Native/CMakeLists.txt
@@ -5,12 +5,10 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 message(INFO "*** build config: ${CMAKE_BUILD_TYPE}")
 
-if (WIN32)
-    # Enforce use of static runtime (avoids target machine needing msvcrt installed).
-    # Must set policy CMP0091 before any projects are declared (see https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html#cmake-msvc-runtime-library)
-    cmake_policy(SET CMP0091 NEW)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-endif (WIN32)
+# Load common utils and configure cmake policies
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../Common/cmake")
+include(secure_dependencies)
+set_msvc_static_runtime_policy()
 
 project(quantum-simulator)
 
@@ -40,53 +38,8 @@ option(USE_SINGLE_PRECISION "Use single-precision floating point operations" OFF
 option(HAVE_INTRINSICS "Have AVX intrinsics" OFF)
 option(USE_GATE_FUSION "Use gate fusion" ON)
 
-# Always use Spectre mitigations where available
-if (WIN32)
-    # Locate the vswhere application, which will provide paths to any installed Visual Studio instances.
-    # By invoking it with "-find **/lib/spectre/x64" we will find any Spectre mitigated libaries that
-    # have been installed.
-    find_program(_vswhere_tool
-        NAMES vswhere
-        PATHS "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer")
-    if (NOT ${vswhere})
-        message(FATAL_ERROR "Could not locate vswhere.exe - unable to source vc redistributable")
-    endif()
-    execute_process(
-        COMMAND "${_vswhere_tool}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/14.29.*/**/lib/spectre/x64 -sort
-        OUTPUT_VARIABLE _vs_install_loc_out
-        RESULT_VARIABLE _vs_where_exitcode
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    file(TO_CMAKE_PATH "${_vs_install_loc_out}" SPECTRE_LIB_PATH_OUT)
-    string(REGEX REPLACE "[\r\n]+" ";" SPECTRE_LIB_PATH ${SPECTRE_LIB_PATH_OUT})
-    message(INFO "*** install loc: ${SPECTRE_LIB_PATH}")
-
-    # Locate the spectre mitigated runtime libraries and fail if they can't be found. Targets in this
-    # cmake project can use the variables to explicitly link these libraries rather than using the 
-    # non-mitigated libraries that are found by default.
-    find_library(LIBCMT_SPECTRE_REL libcmt PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    find_library(LIBCMT_SPECTRE_DEB libcmtd PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    set(LIBCMT_SPECTRE debug ${LIBCMT_SPECTRE_DEB} optimized ${LIBCMT_SPECTRE_REL})
-    message(INFO "*** using spectre lib: ${LIBCMT_SPECTRE}")
-    find_library(LIBCPMT_SPECTRE_REL libcpmt PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    find_library(LIBCPMT_SPECTRE_DEB libcpmtd PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    set(LIBCPMT_SPECTRE debug ${LIBCPMT_SPECTRE_DEB} optimized ${LIBCPMT_SPECTRE_REL})
-    message(INFO "*** using spectre lib: ${LIBCPMT_SPECTRE}")
-    find_library(LIBVCRUNTIME_SPECTRE_REL libvcruntime PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    find_library(LIBVCRUNTIME_SPECTRE_DEB libvcruntimed PATHS ${SPECTRE_LIB_PATH} REQUIRED)
-    set(LIBVCRUNTIME_SPECTRE debug ${LIBVCRUNTIME_SPECTRE_DEB} optimized ${LIBVCRUNTIME_SPECTRE_REL})
-    message(INFO "*** using spectre lib: ${LIBVCRUNTIME_SPECTRE}")
-    set(SPECTRE_LIBS
-        ${LIBCMT_SPECTRE}
-        ${LIBCPMT_SPECTRE}
-        ${LIBVCRUNTIME_SPECTRE})
-
-    add_link_options("LINKER:/guard:cf")
-endif()
-
-if (NOT APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mspeculative-load-hardening -mretpoline")
-    set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -mspeculative-load-hardening -mretpoline")
-endif()
+locate_win32_spectre_static_runtime()
+configure_security_flags()
 
 include_directories(${PROJECT_BINARY_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src)

--- a/src/Simulation/NativeSparseSimulator/CMakeLists.txt
+++ b/src/Simulation/NativeSparseSimulator/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+
+# Load common utils and configure cmake policies
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../Common/cmake")
+include(secure_dependencies)
+set_msvc_static_runtime_policy()
+
 project(Microsoft.Quantum.SparseSimulator.Runtime)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -6,8 +12,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MACOSX_RPATH 1)
+
+locate_win32_spectre_static_runtime()
+configure_security_flags()
+
 # Main build files
 add_library(Microsoft.Quantum.SparseSimulator.Runtime SHARED factory.cpp capi.cpp)
+target_link_libraries(Microsoft.Quantum.SparseSimulator.Runtime ${SPECTRE_LIBS})
 
 # Windows adds a special dllexport command which must be defined
 if (WIN32)


### PR DESCRIPTION
This adds the sparse state simulator to the manifest script to ensure it gets properly scanned. It also updates the SparseSimulator native binary to compile with control flow guard security flags and link against Spectre mitigated static runtime such that it can pass the manifest checks. For ease of management, all security flags and runtime linking logic has been pulled into a common CMake macro so that the full state simulator, sparse state simulator, and QIR runtime can all share the same setup.