### PR TITLE
Ensure capacity when multiple qubits are allocated

### DIFF
--- a/src/Simulation/QCTraceSimulator/QubitManagerRestrictedReuse.cs
+++ b/src/Simulation/QCTraceSimulator/QubitManagerRestrictedReuse.cs
@@ -372,6 +372,10 @@ namespace Microsoft.Quantum.Simulation.Common {
             QArray<Qubit> result = QArray<Qubit>.Create(numToAllocate);
             for (int i = 0; i < numToAllocate; i++) {
                 long newQubitId = AllocateQubit();
+                if (newQubitId == None && MayExtendCapacity) {
+                    EnsureCapacity(QubitCapacity * 2);
+                    newQubitId = AllocateQubit();
+                }
                 if (newQubitId == None) {
                     for (int k = 0; k < i; k++) {
                         Release(result[k]);

--- a/src/Simulation/Simulators.Tests/Circuits/ResourcesEstimator.qs
+++ b/src/Simulation/Simulators.Tests/Circuits/ResourcesEstimator.qs
@@ -95,6 +95,10 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
         }
     }
 
+    operation RestrictedUseManyQubits() : Unit {
+        use qubits = Qubit[2000];
+    }
+
 
     operation SimultaneousUse() : Unit {
         body (...){

--- a/src/Simulation/Simulators.Tests/ResourcesEstimatorTests.cs
+++ b/src/Simulation/Simulators.Tests/ResourcesEstimatorTests.cs
@@ -212,6 +212,16 @@ namespace Microsoft.Quantum.Simulation.Simulators.Tests
             Assert.Equal(1.0, sim.Data.Rows.Find("Depth")["Max"]);
         }
 
+        [Fact]
+        public void QubitRestrictedReuseManyQubitsTest() {
+            QCTraceSimulators.QCTraceSimulatorConfiguration config = ResourcesEstimator.RecommendedConfig();
+            config.OptimizeDepth = false;
+            config.EnableRestrictedReuse = true;
+            var sim = new ResourcesEstimator(config);
+
+            RestrictedUseManyQubits.Run(sim).Wait();
+        }
+
 
         /// <summary>
         /// Documents that the QubitCount and Depth statistics reflect independent lower


### PR DESCRIPTION
Capacity is not adjusted in the case when multiple qubits are allocated at once. This fixed the problem.