### PR TITLE
Fixing deserialization security issue (non-issue)

### DIFF
--- a/src/Simulation/QCTraceSimulator/Utils.cs
+++ b/src/Simulation/QCTraceSimulator/Utils.cs
@@ -120,9 +120,11 @@ namespace Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime
                 stream.Position = 0;
                 // Deserialize the graph into a new set of objects and
                 // return the root of the graph (deep copy) to the caller
-                T res = formatter.Deserialize(stream) as T;
-                Debug.Assert(res != null);
-                return res;
+                object res = formatter.Deserialize(stream);
+                if (res.GetType() != typeof(T)) {
+                    throw new ApplicationException("Deserialization failed while copying an object.");
+                }
+                return (T)res;
             }
         }
 


### PR DESCRIPTION
Message: Call to method Deserialize is converted to T, allowing malicious subtypes
Description: Doing a conversion rather than a precise type check will succeed for potentially malicious subtypes.
Alert Locations:
src/Simulation/QCTraceSimulator/Utils.cs#L123
---
This is a non-issue as the buffer is fully trusted and has just been serialized into.
However, this is an attempt to change the code to comply with the rule.