### PR TITLE
Output Recording Fixups

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "Microsoft.Quantum.Sdk": "0.24.217480-beta"
+        "Microsoft.Quantum.Sdk": "0.25.223055-beta"
     }
 }

--- a/src/Qir/Runtime/lib/QIR/QirOutputHandling.cpp
+++ b/src/Qir/Runtime/lib/QIR/QirOutputHandling.cpp
@@ -70,7 +70,7 @@ extern "C"
         }
     }
 
-    void __quantum__rt__integer_record_output(int64_t i64Val) // NOLINT
+    void __quantum__rt__int_record_output(int64_t i64Val) // NOLINT
     {
         std::stringstream strStream;
         strStream << QOH_REC_PREFIX << i64Val;

--- a/src/Qir/Runtime/public/QirOutputHandling.hpp
+++ b/src/Qir/Runtime/public/QirOutputHandling.hpp
@@ -57,7 +57,7 @@ extern "C"
 
     /// Produces output records of the format "RESULT\\tn" where n is the string representation of the integer value,
     /// such as "RESULT\\t42"
-    QIR_SHARED_API void __quantum__rt__integer_record_output(int64_t); // NOLINT
+    QIR_SHARED_API void __quantum__rt__int_record_output(int64_t); // NOLINT
 
     /// Produces output records of the format "RESULT\\td" where d is the string representation of the double value,
     /// such as "RESULT\\t3.14"

--- a/src/Qir/Runtime/unittests/QirOutputHandlingTests.cpp
+++ b/src/Qir/Runtime/unittests/QirOutputHandlingTests.cpp
@@ -151,7 +151,7 @@ TEST_CASE("QIR: i64OutHandle", "[qir][out_handl][i64_record_output]")
         ostringstream actualStrStream;
         {
             OutputStream::ScopedRedirector qOStreamRedirector(actualStrStream);
-            __quantum__rt__integer_record_output(i64Value);
+            __quantum__rt__int_record_output(i64Value);
         }
 
         std::stringstream expectedStrStream;
@@ -197,14 +197,14 @@ TEST_CASE("QIR: MixedOutHandle", "[qir][out_handl][tuple_record_output]")
             __quantum__rt__array_start_record_output();
                 __quantum__rt__tuple_start_record_output();
                     __quantum__rt__double_record_output(6.67E+23);
-                    __quantum__rt__integer_record_output(42LL);
+                    __quantum__rt__int_record_output(42LL);
                     __quantum__rt__bool_record_output(true);
                     __quantum__rt__result_record_output(__quantum__rt__result_get_one());
                 __quantum__rt__tuple_end_record_output();
 
                 __quantum__rt__tuple_start_record_output();
                     __quantum__rt__double_record_output(-10.123);
-                    __quantum__rt__integer_record_output(-2049LL);
+                    __quantum__rt__int_record_output(-2049LL);
                     __quantum__rt__bool_record_output(false);
                     __quantum__rt__result_record_output(__quantum__rt__result_get_zero());
                 __quantum__rt__tuple_end_record_output();

--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-	<PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.25.223055-beta" />
+    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.25.223055-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.24.217480-beta" />
+	<PackageReference Include="Microsoft.Quantum.QirGeneration" Version="0.25.223055-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Qir/Tools/QirTools.cs
+++ b/src/Qir/Tools/QirTools.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using LlvmBindings;
 using Microsoft.Quantum.Qir.Runtime.Tools.Executable;
 using Microsoft.Quantum.QsCompiler;
 
@@ -38,13 +39,15 @@ namespace Microsoft.Quantum.Qir.Runtime.Tools
             }
 
             executablesDirectory.Create();
+            var qirBitcode = qirContentStream.ToArray();
+            var bitcodeModule = BitcodeModule.LoadFrom(qirBitcode, new Context());
 
             // Build an executable for each entry point operation. The builds must run one at a time because they write
             // to the same intermediate files.
-            foreach (var entryPointOp in EntryPointLoader.LoadEntryPointOperations(qsharpDll))
+            foreach (var entryPointOp in EntryPointLoader.LoadEntryPointOperations(bitcodeModule))
             {
                 var exeFileInfo = new FileInfo(Path.Combine(executablesDirectory.FullName, $"{entryPointOp.Name}.exe"));
-                var exe = new QirFullStateExecutable(exeFileInfo, qirContentStream.ToArray(), debug);
+                var exe = new QirFullStateExecutable(exeFileInfo, qirBitcode, debug);
                 await exe.BuildAsync(entryPointOp, libraryDirectories, includeDirectories);
             }
 

--- a/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
+++ b/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.217480-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.25.223055-beta" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
   </ItemGroup>
 

--- a/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
+++ b/src/Simulation/EntryPointDriver.Tests/Tests.Microsoft.Quantum.EntryPointDriver.fsproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.217480-beta" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.25.223055-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xunit/Microsoft.Quantum.Xunit.nuspec
+++ b/src/Xunit/Microsoft.Quantum.Xunit.nuspec
@@ -22,7 +22,7 @@
     <dependencies>
       <dependency id="xunit" version="2.3.1" />
       <dependency id="Microsoft.NET.Test.Sdk" version="15.3.0" />
-      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.24.217480-beta" />
+      <dependency id="Microsoft.Quantum.Runtime.Core" version="0.25.223055-beta" />
     </dependencies>
   </metadata>
 


### PR DESCRIPTION
Updates the EntryPointOperationLoader to use the QIR bit-code to get Entry Point information instead of the Q# AST. This allows the loader to get the wrapped versions of the entry point operation appropriate for QIR compilations.

This also fixes a misnamed function in the API, from `__quantum__rt__integer_record_output` to `__quantum__rt__int_record_output`.