### PR TITLE
Lock thiserror to 1.0.30.

### DIFF
--- a/src/Simulation/qdk_sim_rs/Cargo.toml
+++ b/src/Simulation/qdk_sim_rs/Cargo.toml
@@ -88,7 +88,7 @@ pyo3 = { version = "0.13.2", features = ["extension-module"], optional = true }
 rand = { version = "0.7.3", features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0.30"
+thiserror = "=1.0.30"
 
 # We only need web-sys when compiling with the wasm feature.
 web-sys = { version = "0.3.4", features = ['console'], optional = true }


### PR DESCRIPTION
This PR locks the `thiserror` crate to 1.0.30, as more recent versions use the newer provider API for error handling.