### PR TITLE
Fix links and formulas in gates API docs

### DIFF
--- a/src/Simulation/TargetDefinitions/Decompositions/CYFromCNOT.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CYFromCNOT.qs
@@ -11,10 +11,12 @@ namespace Microsoft.Quantum.Canon {
     /// This operation can be simulated by the unitary matrix
     /// $$
     /// \begin{align}
-    ///     1 & 0 & 0 & 0 \\\\
-    ///     0 & 1 & 0 & 0 \\\\
-    ///     0 & 0 & 0 & -i \\\\
-    ///     0 & 0 & i & 0
+    ///     \left(\begin{matrix}
+    ///         1 & 0 & 0 & 0 \\\\
+    ///         0 & 1 & 0 & 0 \\\\
+    ///         0 & 0 & 0 & -i \\\\
+    ///         0 & 0 & i & 0
+    ///      \end{matrix}\right)
     /// \end{align},
     /// $$
     /// where rows and columns are organized as in the quantum concepts guide.

--- a/src/Simulation/TargetDefinitions/Decompositions/CZFromSinglyControlled.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/CZFromSinglyControlled.qs
@@ -11,10 +11,12 @@ namespace Microsoft.Quantum.Canon {
     /// This operation can be simulated by the unitary matrix
     /// $$
     /// \begin{align}
-    ///     1 & 0 & 0 & 0 \\\\
-    ///     0 & 1 & 0 & 0 \\\\
-    ///     0 & 0 & 1 & 0 \\\\
-    ///     0 & 0 & 0 & -1
+    ///     \left(\begin{matrix}
+    ///         1 & 0 & 0 & 0 \\\\
+    ///         0 & 1 & 0 & 0 \\\\
+    ///         0 & 0 & 1 & 0 \\\\
+    ///         0 & 0 & 0 & -1
+    ///     \end{matrix}\right)
     /// \end{align},
     /// $$
     /// where rows and columns are organized as in the quantum concepts guide.

--- a/src/Simulation/TargetDefinitions/Decompositions/R1Frac.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/R1Frac.qs
@@ -15,8 +15,8 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// > [!WARNING]
     /// > This operation uses the **opposite** sign convention from
-    /// > @"microsoft.quantum.intrinsic.r", and does not include the
-    /// > factor of $1/ 2$ included by @"microsoft.quantum.intrinsic.r1".
+    /// > <xref:Microsoft.Quantum.Intrinsic.R>, and does not include the
+    /// > factor of $1/ 2$ included by <xref:Microsoft.Quantum.Intrinsic.R1>.
     ///
     /// # Input
     /// ## numerator

--- a/src/Simulation/TargetDefinitions/Decompositions/RFrac.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/RFrac.qs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// > [!WARNING]
     /// > This operation uses the **opposite** sign convention from
-    /// > @"microsoft.quantum.intrinsic.r".
+    /// > <xref:Microsoft.Quantum.Intrinsic.R>.
     ///
     /// # Input
     /// ## pauli


### PR DESCRIPTION
* [CY](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.canon.cy) and [CZ](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.canon.cz) gate matrices should render as matrices (same as [CX](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.canon.cx))
* Links in [R1Frac](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.intrinsic.r1frac) and [RFrac](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.intrinsic.rfrac) need `xref` to render as links