### PR TITLE
Add support for new microsoft-qc provider

### DIFF
--- a/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.Quantum
                 "QirSubmitter",
                 ImmutableArray.Create("FullComputation")),
             new SubmitterInfo(
-                new Regex(@"\Amicrosoft\.((?!simulator\.)[\w-_]+\.)*[\w-_]+\z"), // does not match microsoft.simulator.*, but matches any other microsoft.*
-                "Microsoft.Quantum.Providers.Targets.MicrosoftQuantumSubmitter, Microsoft.Quantum.Providers.Core",
+                new Regex(@"\Amicrosoft\.estimator(\.[\w-_]+)?\z"),
+                "Microsoft.Quantum.Providers.Targets.MicrosoftEstimatorSubmitter, Microsoft.Quantum.Providers.Core",
                 "QirSubmitter",
                 ImmutableArray.Create("FullComputation")),
             new SubmitterInfo(

--- a/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
@@ -56,8 +56,8 @@ namespace Microsoft.Azure.Quantum
                 "QirPayloadGenerator",
                 ImmutableArray.Create("FullComputation")),
             new SubmitterInfo(
-                new Regex(@"\Amicrosoft\.((?!simulator\.)[\w-_]+\.)*[\w-_]+\z"), // does not match microsoft.simulator.*, but matches any other microsoft.*
-                "Microsoft.Quantum.Providers.Targets.MicrosoftQuantumSubmitter, Microsoft.Quantum.Providers.Core",
+                new Regex(@"\Amicrosoft\.estimator(\.[\w-_]+)?\z"),
+                "Microsoft.Quantum.Providers.Targets.MicrosoftEstimatorSubmitter, Microsoft.Quantum.Providers.Core",
                 "QirPayloadGenerator",
                 ImmutableArray.Create("FullComputation"))
             );

--- a/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Azure.Quantum
                 "QirSubmitter",
                 ImmutableArray.Create("FullComputation")),
             new SubmitterInfo(
+                new Regex(@"\Amicrosoft\.((?!simulator\.)[\w-_]+\.)*[\w-_]+\z"), // does not match microsoft.simulator.*, but matches any other microsoft.*
+                "Microsoft.Quantum.Providers.Targets.MicrosoftQuantumSubmitter, Microsoft.Quantum.Providers.Core",
+                "QirSubmitter",
+                ImmutableArray.Create("FullComputation")),
+            new SubmitterInfo(
                 new Regex(@"\Aquantinuum\.([\w-_]+\.)*[\w-_]+\z"),
                 "Microsoft.Quantum.Providers.Quantinuum.Targets.QuantinuumQirSubmitter, Microsoft.Quantum.Providers.Honeywell",
                 "QirSubmitter",
@@ -49,7 +54,13 @@ namespace Microsoft.Azure.Quantum
                 new Regex(@"\Amicrosoft\.simulator\.([\w]+\.)*[\w]+\z"),
                 "Microsoft.Quantum.Providers.Targets.MicrosoftSimulatorSubmitter, Microsoft.Quantum.Providers.Core",
                 "QirPayloadGenerator",
-                ImmutableArray.Create("FullComputation")));
+                ImmutableArray.Create("FullComputation")),
+            new SubmitterInfo(
+                new Regex(@"\Amicrosoft\.((?!simulator\.)[\w-_]+\.)*[\w-_]+\z"), // does not match microsoft.simulator.*, but matches any other microsoft.*
+                "Microsoft.Quantum.Providers.Targets.MicrosoftQuantumSubmitter, Microsoft.Quantum.Providers.Core",
+                "QirPayloadGenerator",
+                ImmutableArray.Create("FullComputation"))
+            );
 
         /// <summary>
         /// Information about each supported Q# submitter.


### PR DESCRIPTION
Add support for new microsoft-qc provider.

This new provider, called Microsoft Quantum Computing will contain all future targets for Microsoft's first party quantum offerings. With targets such as:

- microsoft.estimator
- microsoft.sim.*
- microsoft.qpu.*

For now, maintain support for older provider called Microsoft.Simulator (soon to be deprecated) and older targets such as:

- microsoft.simulator.*