### PR TITLE
Cleanup: removed defines, added logging, etc.

### DIFF
--- a/src/Common/cmake/secure_dependencies.cmake
+++ b/src/Common/cmake/secure_dependencies.cmake
@@ -37,15 +37,21 @@ macro(locate_win32_spectre_static_runtime)
         find_program(_vswhere_tool
             NAMES vswhere
             PATHS "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer")
+        message(INFO "*** _vswhere_tool: ${_vswhere_tool}")
         if (NOT ${vswhere})
             message(FATAL_ERROR "Could not locate vswhere - unable to search for installed vcruntime libraries.")
         endif()
+
         execute_process(
             COMMAND "${_vswhere_tool}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/14.*.*/**/lib/spectre/x64 -sort
             OUTPUT_VARIABLE _vs_install_loc_out
             RESULT_VARIABLE _vs_where_exitcode
             OUTPUT_STRIP_TRAILING_WHITESPACE)
+        message(INFO "*** _vs_install_loc_out: ${_vs_install_loc_out}")
+
         file(TO_CMAKE_PATH "${_vs_install_loc_out}" SPECTRE_LIB_PATH_OUT)
+        message(INFO "*** SPECTRE_LIB_PATH_OUT: ${SPECTRE_LIB_PATH_OUT}")
+
         string(REGEX REPLACE "[\r\n]+" ";" SPECTRE_LIB_PATH ${SPECTRE_LIB_PATH_OUT})
         list(REVERSE SPECTRE_LIB_PATH)
         message(INFO "*** install loc: ${SPECTRE_LIB_PATH}")

--- a/src/Simulation/NativeSparseSimulator/CMakeLists.txt
+++ b/src/Simulation/NativeSparseSimulator/CMakeLists.txt
@@ -30,6 +30,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	target_compile_options(Microsoft.Quantum.SparseSimulator.Runtime PUBLIC -O3 -ftree-vectorize -mavx2 -mfma)
 endif()
 
+if (MSVC)
+    add_compile_options(/bigobj)
+endif()
+
 message("Compiler flags: ${CMAKE_CXX_FLAGS_RELEASE}")
 
 

--- a/src/Simulation/NativeSparseSimulator/SparseSimulatorTests.cpp
+++ b/src/Simulation/NativeSparseSimulator/SparseSimulatorTests.cpp
@@ -468,24 +468,24 @@ TEST_CASE("SWAPGateTest") {
     const qubit_label_type<num_qubits> zero(0);
     SparseSimulator sim = SparseSimulator(num_qubits);
     std::vector<logical_qubit_id> qubits{ 0,1 };
-    sim.SWAP({ qubits[0] }, qubits[1]); // 00 -> 00
+    sim.SWAP(qubits[0], qubits[1]); // 00 -> 00
     assert_amplitude_equality(sim.probe("00"), 1.0, 0.0);
     assert_amplitude_equality(sim.probe("01"), 0.0, 0.0);
     assert_amplitude_equality(sim.probe("10"), 0.0, 0.0);
     assert_amplitude_equality(sim.probe("11"), 0.0, 0.0);
     sim.X(qubits[0]);
-    sim.SWAP( qubits[0] , qubits[1]); // 10 -> 01
+    sim.SWAP(qubits[0], qubits[1]); // 10 -> 01
     assert_amplitude_equality(sim.probe("00"), 0.0, 0.0);
     assert_amplitude_equality(sim.probe("01"), 0.0, 0.0);
     assert_amplitude_equality(sim.probe("10"), 1.0, 0.0);
     assert_amplitude_equality(sim.probe("11"), 0.0, 0.0);
-    sim.SWAP( qubits[0] , qubits[1]); // 01 -> 10
+    sim.SWAP(qubits[0], qubits[1]); // 01 -> 10
     assert_amplitude_equality(sim.probe("0"), 0.0, 0.0);
     assert_amplitude_equality(sim.probe("1"), 1.0, 0.0);
     assert_amplitude_equality(sim.probe("10"), 0.0, 0.0);
     assert_amplitude_equality(sim.probe("11"), 0.0, 0.0);
     sim.X(qubits[1]);
-    sim.SWAP( qubits[0] , qubits[1]); // 11 -> 11
+    sim.SWAP(qubits[0], qubits[1]); // 11 -> 11
     assert_amplitude_equality(sim.probe("00"), 0.0, 0.0);
     assert_amplitude_equality(sim.probe("01"), 0.0, 0.0);
     assert_amplitude_equality(sim.probe("10"), 0.0, 0.0);

--- a/src/Simulation/NativeSparseSimulator/capi.cpp
+++ b/src/Simulation/NativeSparseSimulator/capi.cpp
@@ -52,45 +52,56 @@ extern "C"
         return getSimulator(sim_id)->get_num_qubits();
     }
 
-// Generic single-qubit gate
-#define FWDGATE1(G)                                                                                                    \
-    MICROSOFT_QUANTUM_DECL void G##_cpp(simulator_id_type sim_id, logical_qubit_id q)                                                   \
-    {                                                                                                                  \
-        getSimulator(sim_id)->G(q);                                                                  \
-    }
-// Generic multi-qubit gate
-#define FWDCSGATE1(G)                                                                                                  \
-    MICROSOFT_QUANTUM_DECL void MC##G##_cpp(simulator_id_type sim_id, int n, logical_qubit_id* c, logical_qubit_id q)   \
-    {                                                                                                                  \
-                                                                                                                       \
-        getSimulator(sim_id)->MC##G(std::vector<logical_qubit_id>(c, c + n), q);                                                   \
-    }
-#define FWD(G) FWDGATE1(G)
-
     // single-qubit gates
-        FWD(X)
-        FWD(Y)
-        FWD(Z)
-        FWD(H)
+    MICROSOFT_QUANTUM_DECL void X_cpp(simulator_id_type sim_id, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->X(q);
+    }
+    MICROSOFT_QUANTUM_DECL void Y_cpp(simulator_id_type sim_id, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->Y(q);
+    }
+    MICROSOFT_QUANTUM_DECL void Z_cpp(simulator_id_type sim_id, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->Z(q);
+    }
+    MICROSOFT_QUANTUM_DECL void H_cpp(simulator_id_type sim_id, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->H(q);
+    }
+    MICROSOFT_QUANTUM_DECL void S_cpp(simulator_id_type sim_id, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->S(q);
+    }
+    MICROSOFT_QUANTUM_DECL void T_cpp(simulator_id_type sim_id, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->T(q);
+    }
+    MICROSOFT_QUANTUM_DECL void AdjS_cpp(simulator_id_type sim_id, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->AdjS(q);
+    }
+    MICROSOFT_QUANTUM_DECL void AdjT_cpp(simulator_id_type sim_id, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->AdjT(q);
+    }
 
-        FWD(S)
-        FWD(T)
-        FWD(AdjS)
-        FWD(AdjT)
-
-#define MFWD(G) FWDCSGATE1(G)
-        MFWD(H)
-        MFWD(X)
-        MFWD(Y)
-        MFWD(Z)
-
-#undef FWDGATE1
-#undef FWDGATE2
-#undef FWDGATE3
-#undef FWDCSGATE1
-#undef FWD
-
-
+    MICROSOFT_QUANTUM_DECL void MCX_cpp(simulator_id_type sim_id, int n, logical_qubit_id* c, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->MCX(std::vector<logical_qubit_id>(c, c + n), q);
+    }
+    MICROSOFT_QUANTUM_DECL void MCY_cpp(simulator_id_type sim_id, int n, logical_qubit_id* c, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->MCY(std::vector<logical_qubit_id>(c, c + n), q);
+    }
+    MICROSOFT_QUANTUM_DECL void MCZ_cpp(simulator_id_type sim_id, int n, logical_qubit_id* c, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->MCZ(std::vector<logical_qubit_id>(c, c + n), q);
+    }
+    MICROSOFT_QUANTUM_DECL void MCH_cpp(simulator_id_type sim_id, int n, logical_qubit_id* c, logical_qubit_id q)
+    {
+        getSimulator(sim_id)->MCH(std::vector<logical_qubit_id>(c, c + n), q);
+    }
 
     MICROSOFT_QUANTUM_DECL void SWAP_cpp(simulator_id_type sim_id, logical_qubit_id q1, logical_qubit_id q2){
         getSimulator(sim_id)->SWAP(q1, q2);

--- a/src/Simulation/NativeSparseSimulator/capi.hpp
+++ b/src/Simulation/NativeSparseSimulator/capi.hpp
@@ -36,7 +36,6 @@ extern "C"
     MICROSOFT_QUANTUM_DECL void AdjS_cpp(simulator_id_type sim_id, logical_qubit_id q);
     MICROSOFT_QUANTUM_DECL void AdjT_cpp(simulator_id_type sim_id, logical_qubit_id q);
 
-
     MICROSOFT_QUANTUM_DECL void MCX_cpp(simulator_id_type sim_id, int n, logical_qubit_id* c, logical_qubit_id q);
     MICROSOFT_QUANTUM_DECL void MCY_cpp(simulator_id_type sim_id, int n, logical_qubit_id* c, logical_qubit_id q);
     MICROSOFT_QUANTUM_DECL void MCZ_cpp(simulator_id_type sim_id, int n, logical_qubit_id* c, logical_qubit_id q);


### PR DESCRIPTION
Some cleanup of the Sparse Simulator code that helps debugging.
- Removed (expanded) defines. These defines were used to construct function names and bodies by literal concatenation so resulting functions were very hard to debug or find in the code.
- Added /bigobj switch when using MSVC compiler. Although we don't use MSVC compiler in the official builds, it may help identify additional issues in the code.
- Added additional logging to the build scripts to log tool locations and some other locations in the file system. This helps with diagnostics when build fails.
- Removed unnecessary {} and spaces.