### PR TITLE
Added Chocolatey and brew as prereqs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -49,7 +49,7 @@
 # is only available from the command line. Turn it on by uncommenting the 
 # entries below.
 ###############################################################################
-*.md   diff=astextplain
+#*.md   diff=astextplain
 #*.doc   diff=astextplain
 #*.DOC   diff=astextplain
 #*.docx  diff=astextplain

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ To build on Windows:
         * **Spectre-mitigated libraries. Once Visual Studio has been installed, using the installer for the VS version of interest,
           click the"Modify" button, go to the "Individual Components" tab, search for "spectre", select the latest version of "MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs", and click the "Modify" button to install the selected components**
         * **.NET 6.0 Runtime**
-    * Install [Chocolately](https://chocolatey.org/install). This is required to download other prerequisites if not installed, such
-    as LLVM, CMake, Ninja, and Rust. (If these are already installed and on your PATH, then Chocolately may not be not needed).
+    * Install [Chocolately](https://chocolatey.org/install). This is required to download other prerequisites if not already installed, such
+    as LLVM, CMake, Ninja, and Rust. (If these are already installed and on your PATH, then Chocolately may not be needed).
 
 2. Run [bootstrap.ps1](bootstrap.ps1) from PowerShell
     * pre-req (in PowerShell): `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ To build on Windows:
         * **Spectre-mitigated libraries. Once Visual Studio has been installed, using the installer for the VS version of interest,
           click the"Modify" button, go to the "Individual Components" tab, search for "spectre", select the latest version of "MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs", and click the "Modify" button to install the selected components**
         * **.NET 6.0 Runtime**
+    * Install [Chocolately](https://chocolatey.org/install). This is required to download other prerequisites if not installed, such
+    as LLVM, CMake, Ninja, and Rust. (If these are already installed and on your PATH, then Chocolately may not be not needed).
+
 2. Run [bootstrap.ps1](bootstrap.ps1) from PowerShell
     * pre-req (in PowerShell): `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
     * The script might install additional tools (a specific compiler, build tools, etc)
@@ -60,6 +63,7 @@ To build on other platforms:
 
 1. Install the pre-reqs:
     * Install [.NET 6.0](https://dotnet.microsoft.com/download) (version lower than 6.0.300 is recommended)
+    * Install [Homebrew](https://brew.sh/). This is needed to install other prerequisites such as Ninja and LLVM.
     * On [WSL](https://docs.microsoft.com/en-us/windows/wsl/)/Linux:
       * .NET 6.0: `sudo apt install dotnet-sdk-6.0 dotnet-runtime-6.0`. The possible result can be as in listing B below.  
         See also other ways [here](https://docs.microsoft.com/en-us/dotnet/core/install/linux) or [here](https://dotnet.microsoft.com/en-us/download).


### PR DESCRIPTION
Some prereqs weren't listed for Windows and macOS that are used by the scripts.

Without the gitattributes change, trying to git diff on a markdown file was giving me errors.