### PR TITLE
Remove Honeywell provider and update test to use Quantinuum

### DIFF
--- a/Simulation.sln
+++ b/Simulation.sln
@@ -49,7 +49,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Quantum.Cli
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.Microsoft.Azure.Quantum.Client", "src\Azure\Azure.Quantum.Client.Test\Tests.Microsoft.Azure.Quantum.Client.csproj", "{4858E5E3-23FA-4928-B99A-54065875A2B9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HoneywellExe", "src\Simulation\Simulators.Tests\TestProjects\HoneywellExe\HoneywellExe.csproj", "{1448512E-132F-4DA8-BCBA-D98F16B31600}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuantinuumExe", "src\Simulation\Simulators.Tests\TestProjects\QuantinuumExe\QuantinuumExe.csproj", "{1448512E-132F-4DA8-BCBA-D98F16B31600}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IonQExe", "src\Simulation\Simulators.Tests\TestProjects\IonQExe\IonQExe.csproj", "{55833C6C-6E91-4413-9F77-96B3A09666B8}"
 EndProject

--- a/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/Machine/QuantumMachineFactory.cs
@@ -30,13 +30,11 @@ namespace Microsoft.Azure.Quantum
                 targetNameNormalized is null
                 ? null
                 : targetNameNormalized.StartsWith("quantinuum.")
-                ? "Microsoft.Quantum.Providers.Quantinuum.Targets.QuantinuumQuantumMachine, Microsoft.Quantum.Providers.Honeywell"
+                ? "Microsoft.Quantum.Providers.Quantinuum.Targets.QuantinuumQuantumMachine, Microsoft.Quantum.Providers.Quantinuum"
                 : targetNameNormalized.StartsWith("qci.")
                 ? "Microsoft.Quantum.Providers.QCI.Targets.QCIQuantumMachine, Microsoft.Quantum.Providers.QCI"
                 : targetNameNormalized.StartsWith("ionq.")
                 ? "Microsoft.Quantum.Providers.IonQ.Targets.IonQQuantumMachine, Microsoft.Quantum.Providers.IonQ"
-                : targetNameNormalized.StartsWith("honeywell.")
-                ? "Microsoft.Quantum.Providers.Honeywell.Targets.HoneywellQuantumMachine, Microsoft.Quantum.Providers.Honeywell"
                 : null;
 
             Type? machineType = null;

--- a/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
+++ b/src/Azure/Azure.Quantum.Client/SubmitterFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Quantum
                 ImmutableArray.Create("FullComputation")),
             new SubmitterInfo(
                 new Regex(@"\Aquantinuum\.([\w-_]+\.)*[\w-_]+\z"),
-                "Microsoft.Quantum.Providers.Quantinuum.Targets.QuantinuumQirSubmitter, Microsoft.Quantum.Providers.Honeywell",
+                "Microsoft.Quantum.Providers.Quantinuum.Targets.QuantinuumQirSubmitter, Microsoft.Quantum.Providers.Quantinuum",
                 "QirSubmitter",
                 ImmutableArray.Create("AdaptiveExecution", "BasicExecution")), // support for BasicMeasurementFeedback goes via the QSharpSubmitter
             new SubmitterInfo(

--- a/src/Simulation/Core/EntryPointInfo.cs
+++ b/src/Simulation/Core/EntryPointInfo.cs
@@ -20,19 +20,6 @@ namespace Microsoft.Quantum.Simulation.Core
 
     /// <summary>
     /// Base class containing information about an entry point 
-    /// for a Q# executable targeted for a Honeywell quantum processor.
-    /// </summary>
-    [Obsolete("Use QuantinuumEntryPointInfo instead.")]
-    public class HoneywellEntryPointInfo<I, O> 
-    : EntryPointInfo<I, O>
-    {
-        public HoneywellEntryPointInfo(Type operation) 
-        : base(operation)
-        { }
-    }
-
-    /// <summary>
-    /// Base class containing information about an entry point 
     /// for a Q# executable targeted for a IonQ quantum processor.
     /// </summary>
     public class IonQEntryPointInfo<I, O>

--- a/src/Simulation/Simulators.Tests/TestProjects/QuantinuumExe/ClassicallyControlledSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/QuantinuumExe/ClassicallyControlledSupportTests.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 
-namespace Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSupportTests {
+namespace Microsoft.Quantum.Simulation.Testing.Quantinuum.ClassicallyControlledSupportTests {
 
     open Microsoft.Quantum.Intrinsic;
 

--- a/src/Simulation/Simulators.Tests/TestProjects/QuantinuumExe/MeasurementSupportTests.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/QuantinuumExe/MeasurementSupportTests.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 
-namespace Microsoft.Quantum.Simulation.Testing.Honeywell.MeasurementSupportTests {
+namespace Microsoft.Quantum.Simulation.Testing.Quantinuum.MeasurementSupportTests {
 
     open Microsoft.Quantum.Intrinsic;
 

--- a/src/Simulation/Simulators.Tests/TestProjects/QuantinuumExe/QuantinuumExe.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/QuantinuumExe/QuantinuumExe.csproj
@@ -8,7 +8,7 @@
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>
     <IncludeProviderPackages>false</IncludeProviderPackages>
     <NoEntryPoint>true</NoEntryPoint>
-    <ExecutionTarget>honeywell.qpu</ExecutionTarget>
+    <ExecutionTarget>quantinuum.qpu</ExecutionTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Simulation/Simulators.Tests/TestProjects/QuantinuumExe/QuantinuumSimulation.qs
+++ b/src/Simulation/Simulators.Tests/TestProjects/QuantinuumExe/QuantinuumSimulation.qs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 
-namespace Microsoft.Quantum.Simulation.Testing.Honeywell {
+namespace Microsoft.Quantum.Simulation.Testing.Quantinuum {
     open Microsoft.Quantum.Diagnostics;
-    open Microsoft.Quantum.Simulation.Testing.Honeywell.ClassicallyControlledSupportTests;
-    open Microsoft.Quantum.Simulation.Testing.Honeywell.MeasurementSupportTests;
+    open Microsoft.Quantum.Simulation.Testing.Quantinuum.ClassicallyControlledSupportTests;
+    open Microsoft.Quantum.Simulation.Testing.Quantinuum.MeasurementSupportTests;
 
     @Test("QuantumSimulator")
     @Test("ResourcesEstimator")


### PR DESCRIPTION
### Context
In November 2021, Honeywell became Quantinuum: Press release: [Quantinuum is a result of the combination of two global leaders in quantum computing: Honeywell Quantum Solutions and Cambridge Quantum](https://www.quantinuum.com/pressrelease/introducing-quantinuum)

In February/March 2022, Azure Quantum started supporting the Quantinuum provider and targets.

### This PR
This PR removes the Honewell provider, targets and update tests to use Quantinuum provider.