### PR TITLE
Fixing the undesirable dependencies issue for qdk.

### DIFF
--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -49,7 +49,7 @@ $artifacts = @{
         ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Simulation.Common.dll",
         ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
         ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Simulators.dll",
-        ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Xunit.dll"
+        ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Xunit.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
     
     Native = @(

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -35,26 +35,26 @@ $artifacts = @{
     ) | ForEach-Object { Join-Path $Env:NUGET_OUTDIR "$_.$Env:NUGET_VERSION.nupkg" };
 
     Assemblies = @(
-        ".\src\Azure\Azure.Quantum.Client\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Azure.Quantum.Client.dll",
-        ".\src\Simulation\AutoSubstitution\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.AutoSubstitution.dll",
-        ".\src\Qir\Tools\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Qir.Runtime.Tools.dll",
-        ".\src\Simulation\Core\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Runtime.Core.dll",
-        ".\src\Simulation\EntryPointDriver\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.EntryPointDriver.dll",
-        ".\src\Simulation\QSharpCore\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QSharp.Core.dll",
-        ".\src\Simulation\Type1Core\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Type1.Core.dll",
-        ".\src\Simulation\Type2Core\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Type2.Core.dll",
-        ".\src\Simulation\Type3Core\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Type3.Core.dll",
-        ".\src\Simulation\Type4Core\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Type4.Core.dll",
-        ".\src\Simulation\QSharpFoundation\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QSharp.Foundation.dll",
-        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.Common.dll",
-        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
-        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulators.dll",
+        ".\src\Azure\Azure.Quantum.Client\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Azure.Quantum.Client.dll",
+        ".\src\Simulation\AutoSubstitution\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.AutoSubstitution.dll",
+        ".\src\Qir\Tools\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Qir.Runtime.Tools.dll",
+        ".\src\Simulation\Core\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Runtime.Core.dll",
+        ".\src\Simulation\EntryPointDriver\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.EntryPointDriver.dll",
+        ".\src\Simulation\QSharpCore\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.QSharp.Core.dll",
+        ".\src\Simulation\Type1Core\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Type1.Core.dll",
+        ".\src\Simulation\Type2Core\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Type2.Core.dll",
+        ".\src\Simulation\Type3Core\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Type3.Core.dll",
+        ".\src\Simulation\Type4Core\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Type4.Core.dll",
+        ".\src\Simulation\QSharpFoundation\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.QSharp.Foundation.dll",
+        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Simulation.Common.dll",
+        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.dll",
+        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Simulators.dll",
         ".\src\Xunit\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Xunit.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
     
     Native = @(
-        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Simulator.Runtime.dll",
-        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.SparseSimulator.Runtime.dll"
+        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Simulator.Runtime.dll",
+        ".\src\Simulation\Simulators\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.SparseSimulator.Runtime.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 }
 

--- a/src/Azure/Azure.Quantum.Client/Microsoft.Azure.Quantum.Client.csproj
+++ b/src/Azure/Azure.Quantum.Client/Microsoft.Azure.Quantum.Client.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\Common\AssemblyCommon.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Description>Client library for Azure Quantum.</Description>
     <RootNamespace>Microsoft.Azure.Quantum</RootNamespace>

--- a/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
+++ b/src/Qir/Tools/Microsoft.Quantum.Qir.Runtime.Tools.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Simulation\Common\AssemblyCommon.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <PackageId>Microsoft.Quantum.Qir.Runtime</PackageId>
     <Description>Native libraries and build tools for linking and executing Quantum Intermediate Representation.</Description>

--- a/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
+++ b/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>Enable</Nullable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblyName>Microsoft.Quantum.AutoSubstitution</AssemblyName>

--- a/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.props
+++ b/src/Simulation/AutoSubstitution/Microsoft.Quantum.AutoSubstitution.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <QscRef_Microsoft_Quantum_AutoSubstitution>$(MSBuildThisFileDirectory)/../lib/netstandard2.1/Microsoft.Quantum.AutoSubstitution.dll</QscRef_Microsoft_Quantum_AutoSubstitution>
+    <QscRef_Microsoft_Quantum_AutoSubstitution>$(MSBuildThisFileDirectory)/../lib/net6.0/Microsoft.Quantum.AutoSubstitution.dll</QscRef_Microsoft_Quantum_AutoSubstitution>
   </PropertyGroup>
 
 </Project>

--- a/src/Simulation/Common/Microsoft.Quantum.Simulation.Common.csproj
+++ b/src/Simulation/Common/Microsoft.Quantum.Simulation.Common.csproj
@@ -4,7 +4,7 @@
   <Import Project="DebugSymbols.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/src/Simulation/Core/Microsoft.Quantum.Runtime.Core.csproj
+++ b/src/Simulation/Core/Microsoft.Quantum.Runtime.Core.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\Common\DebugSymbols.props" />
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.Runtime</RootNamespace>
   </PropertyGroup>

--- a/src/Simulation/EntryPointDriver/Microsoft.Quantum.EntryPointDriver.csproj
+++ b/src/Simulation/EntryPointDriver/Microsoft.Quantum.EntryPointDriver.csproj
@@ -3,9 +3,9 @@
   <Import Project="..\Common\DebugSymbols.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <Nullable>enable</Nullable>
+    <Nullable>annotations</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Simulation/QCTraceSimulator/Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
+++ b/src/Simulation/QCTraceSimulator/Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\Common\DebugSymbols.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/src/Simulation/QSharpFoundation/Microsoft.Quantum.QSharp.Foundation.csproj
+++ b/src/Simulation/QSharpFoundation/Microsoft.Quantum.QSharp.Foundation.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\Common\DebugSymbols.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <QSharpDocsGeneration>true</QSharpDocsGeneration>
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library with Spaces/Library with Spaces.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Quantum.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>
   

--- a/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library1/Library1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- we will provide our own -->
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>

--- a/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
+++ b/src/Simulation/Simulators.Tests/TestProjects/Library2/Library2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- we will provide our own -->
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>

--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulators.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <LanguageVersion>10.0</LanguageVersion>
     <Nullable>enable</Nullable>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <QSharpDocsGeneration>false</QSharpDocsGeneration>

--- a/src/Simulation/TargetDefinitions/Interfaces/Microsoft.Quantum.Targets.Interfaces.csproj
+++ b/src/Simulation/TargetDefinitions/Interfaces/Microsoft.Quantum.Targets.Interfaces.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Common\AssemblyCommon.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/src/Simulation/TargetDefinitions/TargetPackages/Common.Package.props
+++ b/src/Simulation/TargetDefinitions/TargetPackages/Common.Package.props
@@ -5,7 +5,7 @@
   <Import Project="..\..\Common\DebugSymbols.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <QSharpDocsGeneration>true</QSharpDocsGeneration>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <IncludeCSharpRuntime>false</IncludeCSharpRuntime>

--- a/src/Simulation/Type1Core/Microsoft.Quantum.Type1.Core.props
+++ b/src/Simulation/Type1Core/Microsoft.Quantum.Type1.Core.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <QscRef_Microsoft_Quantum_Type1_Core>$(MSBuildThisFileDirectory)/../lib/netstandard2.1/Microsoft.Quantum.Type1.Core.dll</QscRef_Microsoft_Quantum_Type1_Core>
+    <QscRef_Microsoft_Quantum_Type1_Core>$(MSBuildThisFileDirectory)/../lib/net6.0/Microsoft.Quantum.Type1.Core.dll</QscRef_Microsoft_Quantum_Type1_Core>
   </PropertyGroup>
 
 </Project>

--- a/src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.props
+++ b/src/Simulation/Type2Core/Microsoft.Quantum.Type2.Core.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <QscRef_Microsoft_Quantum_Type2_Core>$(MSBuildThisFileDirectory)/../lib/netstandard2.1/Microsoft.Quantum.Type2.Core.dll</QscRef_Microsoft_Quantum_Type2_Core>
+    <QscRef_Microsoft_Quantum_Type2_Core>$(MSBuildThisFileDirectory)/../lib/net6.0/Microsoft.Quantum.Type2.Core.dll</QscRef_Microsoft_Quantum_Type2_Core>
   </PropertyGroup>
 
 </Project>

--- a/src/Simulation/Type3Core/Microsoft.Quantum.Type3.Core.props
+++ b/src/Simulation/Type3Core/Microsoft.Quantum.Type3.Core.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <QscRef_Microsoft_Quantum_Type3_Core>$(MSBuildThisFileDirectory)/../lib/netstandard2.1/Microsoft.Quantum.Type3.Core.dll</QscRef_Microsoft_Quantum_Type3_Core>
+    <QscRef_Microsoft_Quantum_Type3_Core>$(MSBuildThisFileDirectory)/../lib/net6.0/Microsoft.Quantum.Type3.Core.dll</QscRef_Microsoft_Quantum_Type3_Core>
   </PropertyGroup>
 
 </Project>

--- a/src/Simulation/Type4Core/Microsoft.Quantum.Type4.Core.props
+++ b/src/Simulation/Type4Core/Microsoft.Quantum.Type4.Core.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <QscRef_Microsoft_Quantum_Type4_Core>$(MSBuildThisFileDirectory)/../lib/netstandard2.1/Microsoft.Quantum.Type4.Core.dll</QscRef_Microsoft_Quantum_Type4_Core>
+    <QscRef_Microsoft_Quantum_Type4_Core>$(MSBuildThisFileDirectory)/../lib/net6.0/Microsoft.Quantum.Type4.Core.dll</QscRef_Microsoft_Quantum_Type4_Core>
   </PropertyGroup>
 
 </Project>

--- a/src/Xunit/Microsoft.Quantum.Xunit.csproj
+++ b/src/Xunit/Microsoft.Quantum.Xunit.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\Simulation\Common\DebugSymbols.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
DevOps 48463, 48471.
The `netstandard2.1` target framework has undesirable dependencies, migrating the affected packages to `net6.0`.

Multi-repo PR:
[Q#Compiler](https://github.com/microsoft/qsharp-compiler/pull/1601), [Q#RT](https://github.com/microsoft/qsharp-runtime/pull/1121), [iQ#](https://github.com/microsoft/iqsharp/pull/760), [QuantumLibraries](https://github.com/microsoft/QuantumLibraries/pull/656), [Quantum-NC](https://github.com/microsoft/Quantum-NC/pull/84), [Quantum](https://github.com/microsoft/Quantum/pull/771) (samples), [Katas](https://github.com/microsoft/QuantumKatas/pull/868), QDK, and a private repo.

PR CI build can fail, but overall qdk.release (0.27.254480) has succeeded.