### PR TITLE
Removing the nested ternary in QArray.cs

### DIFF
--- a/src/Simulation/Core/QArray.cs
+++ b/src/Simulation/Core/QArray.cs
@@ -456,10 +456,18 @@ namespace Microsoft.Quantum.Simulation.Core
         ///     If both input arrays are null, it returns null.
         ///     If one of the input arrays is null, it returns the other.
         /// </summary>
-        public static QArray<T> Add(IQArray<T> arr1, IQArray<T> arr2) =>
-            arr1 == null ? arr2 == null ? null : new QArray<T>(arr2) :
-            arr2 == null ? new QArray<T>(arr1) :
-            Add(new QArray<T>(arr1), arr2);
+        public static QArray<T> Add(IQArray<T> arr1, IQArray<T> arr2)
+        {
+            if (arr1 == null)
+            {
+                return arr2 == null ? null : new QArray<T>(arr2);
+            }
+            if (arr2 == null)
+            {
+                return new QArray<T>(arr1)
+            }
+            return Add(new QArray<T>(arr1), arr2);
+        }
 
         /// <summary>
         /// Returns string that is a Q# representation of the value of the array.

--- a/src/Simulation/Core/QArray.cs
+++ b/src/Simulation/Core/QArray.cs
@@ -464,7 +464,7 @@ namespace Microsoft.Quantum.Simulation.Core
             }
             if (arr2 == null)
             {
-                return new QArray<T>(arr1)
+                return new QArray<T>(arr1);
             }
             return Add(new QArray<T>(arr1), arr2);
         }


### PR DESCRIPTION
Was reading through some of the code and the nested ternary was the only thing i needed to read twice in this file. I made it longer, but I think it is more readable

1 question that might clean it up further:
The last return is
`Add(new QArray<T>(arr1), arr2);`
Looking at the Add function, it looks like it is doing `new QArray<T>(arr1)` anyway. Do we want to reduce this further to just `Add(arr1, arr2);`?