### PR TITLE
Fix `AssertOperationsEqualInPlace`

### DIFF
--- a/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualInPlace.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualInPlace.qs
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// ## expectedU
     /// Reference operation on $n$ qubits that givenU is to be compared against.
     internal operation AssertEqualOnBasisVector (basis : Int[], givenU : (Qubit[] => Unit), expectedU : (Qubit[] => Unit is Adj)) : Unit {
-        let tolerance = 1e-15;
+        let tolerance = 1e-10;
 
         use qubits = Qubit[Length(basis)] {
             AssertAllZeroWithinTolerance(qubits, tolerance);

--- a/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualInPlace.qs
+++ b/src/Simulation/TargetDefinitions/Decompositions/AssertOperationsEqualInPlace.qs
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// ## expectedU
     /// Reference operation on $n$ qubits that givenU is to be compared against.
     internal operation AssertEqualOnBasisVector (basis : Int[], givenU : (Qubit[] => Unit), expectedU : (Qubit[] => Unit is Adj)) : Unit {
-        let tolerance = 1e-5;
+        let tolerance = 1e-15;
 
         use qubits = Qubit[Length(basis)] {
             AssertAllZeroWithinTolerance(qubits, tolerance);
@@ -127,6 +127,7 @@ namespace Microsoft.Quantum.Diagnostics {
             Adjoint expectedU(qubits);
             Adjoint FlipToBasis(basis, qubits);
             AssertAllZeroWithinTolerance(qubits, tolerance);
+            ResetAll(qubits);
         }
     }
 


### PR DESCRIPTION
This updates the hard-coded tolerance and adds a call to `ResetAll` to fix #1129