### PR TITLE
Revert "Clean up a few nullable warnings and an unnecessary interpolated string"

### DIFF
--- a/src/Simulation/Simulators/CommonNativeSimulator/SimulatorBase.cs
+++ b/src/Simulation/Simulators/CommonNativeSimulator/SimulatorBase.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 using Microsoft.Quantum.Simulation.Core;
 using Microsoft.Quantum.ClassicalControl;
-using System.Diagnostics;
 
 #nullable enable
 
@@ -175,9 +174,6 @@ namespace Microsoft.Quantum.Simulation.Common
             catch (Exception e) // Dumps q# call-stack in case of exception if CallStack tracking was enabled
             {
                 this.CallStack = stackTraceCollector.CallStack;
-                // StackTraceCollector should have set CallStack to a non-null value in its OnFail handler,
-                // since an exception was just thrown by the simulator.
-                Debug.Assert(this.CallStack != null, "Expected CallStack to be set");
                 this.OnException?.Invoke(e, this.CallStack);
                 throw;
             }

--- a/src/Simulation/Simulators/CommonNativeSimulator/StackTrace.cs
+++ b/src/Simulation/Simulators/CommonNativeSimulator/StackTrace.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Simulation.Common
         /// <summary>
         /// The path to the source where operation is defined
         /// </summary>
-        public string? SourceFile { get; private set; }
+        public string SourceFile { get; private set; }
 
         /// <summary>
         /// One based line number in the operation that resulted in failure. Note that for automatically derived Adjoint and Controlled 
@@ -79,17 +79,17 @@ namespace Microsoft.Quantum.Simulation.Common
             return PortablePdbSymbolReader.TryFormatGitHubUrl(result, FailedLineNumber);
         }
 
-        private const string messageFormat = "{0} on {1}:line {2}";
+        private const string messageFormat = "{0} on {1}";
 
         public override string ToString()
         {
-            return string.Format(messageFormat, Callable.FullName, SourceFile, FailedLineNumber);
+            return string.Format(messageFormat, Callable.FullName, $"{SourceFile}:line {FailedLineNumber}");
         }
 
         /// <summary>
         ///     Gets the best possible source location for this stack frame.
         ///     If the source is not available on local machine, the source
-        ///     location will be replaced by a URL pointing to GitHub repository.
+        //      location will be replaced by a URL pointing to GitHub repository.
         /// </summary>
         /// <remarks>
         ///     This is more costly than <see cref="SourceFile"/> because it
@@ -97,14 +97,10 @@ namespace Microsoft.Quantum.Simulation.Common
         ///     If the file does not exist it calls <see cref="GetURLFromPDB"/> to get the URL
         ///     which is also more costly than <see cref="SourceFile"/>.
         /// </remarks>
-        public virtual string GetBestSourceLocation()
-        {
-            // SourceFile should always be non-null here since StackTraceCollector sets this field before handing out StackFrame objects
-            Debug.Assert(SourceFile != null, "Expected StackTraceCollector.CallStack to have populated source locations");
-            return System.IO.File.Exists(SourceFile)
+        public virtual string GetBestSourceLocation() =>
+            System.IO.File.Exists(SourceFile)
             ? SourceFile
             : GetURLFromPDB() ?? SourceFile;
-        }
 
         /// <summary>
         /// The same as <see cref="ToString"/>, but tries to point to best source location.
@@ -115,7 +111,7 @@ namespace Microsoft.Quantum.Simulation.Common
         /// which is also more costly than <see cref="ToString"/>.
         /// </summary>
         public virtual string ToStringWithBestSourceLocation() =>
-            string.Format(messageFormat, Callable.FullName, GetBestSourceLocation(), FailedLineNumber);
+            string.Format(messageFormat, Callable.FullName, $"{GetBestSourceLocation()}:line {FailedLineNumber}");
 
         /// <summary>
         /// Finds correspondence between Q# and C# stack frames and populates Q# stack frame information from C# stack frames
@@ -129,7 +125,7 @@ namespace Microsoft.Quantum.Simulation.Common
                 object[] locations = op.GetType().GetCustomAttributes(typeof(SourceLocationAttribute), true);
                 foreach (object location in locations)
                 {
-                    SourceLocationAttribute? sourceLocation = (location as SourceLocationAttribute);
+                    SourceLocationAttribute sourceLocation = (location as SourceLocationAttribute);
                     if (sourceLocation != null && sourceLocation.SpecializationKind == op.Variant)
                     {
                         currentFrame.SourceFile = System.IO.Path.GetFullPath(sourceLocation.SourceFile);
@@ -147,8 +143,8 @@ namespace Microsoft.Quantum.Simulation.Common
             // A set of Q# stack frames is assumed to be a subset of C# stack frames.
             // When a C# stack frame doesn't have enough information to match with corresponding Q# frame
             // this assumption is essentially broken, which results in missing matches.
-            System.Diagnostics.StackFrame? csharpFrame = GetNextCSharpStackFrame(csharpStackFrames, ref currentCSharpFrameIndex);
-            StackFrame? qsharpFrame = GetNextQSharpStackFrame(qsharpStackFrames, ref currentQSharpFrameIndex);
+            System.Diagnostics.StackFrame csharpFrame = GetNextCSharpStackFrame(csharpStackFrames, ref currentCSharpFrameIndex);
+            StackFrame qsharpFrame = GetNextQSharpStackFrame(qsharpStackFrames, ref currentQSharpFrameIndex);
             while (csharpFrame != null && qsharpFrame != null)
             {
                 if (IsMatch(csharpFrame, qsharpFrame))
@@ -167,7 +163,7 @@ namespace Microsoft.Quantum.Simulation.Common
         /// <summary>
         /// Return next Q# stack frame that has enough information to match
         /// </summary>
-        private static StackFrame? GetNextQSharpStackFrame(StackFrame[] qsharpStackFrames, ref int currentFrameIndex)
+        private static StackFrame GetNextQSharpStackFrame(StackFrame[] qsharpStackFrames, ref int currentFrameIndex)
         {
             if (currentFrameIndex >= qsharpStackFrames.Length)
             {
@@ -189,7 +185,7 @@ namespace Microsoft.Quantum.Simulation.Common
         /// <summary>
         /// Return next C# stack frame
         /// </summary>
-        private static System.Diagnostics.StackFrame? GetNextCSharpStackFrame(System.Diagnostics.StackFrame[] csharpStackFrames, ref int currentFrameIndex)
+        private static System.Diagnostics.StackFrame GetNextCSharpStackFrame(System.Diagnostics.StackFrame[] csharpStackFrames, ref int currentFrameIndex)
         {
             if (currentFrameIndex >= csharpStackFrames.Length)
             {
@@ -208,7 +204,7 @@ namespace Microsoft.Quantum.Simulation.Common
         /// </summary>
         private static bool IsMatch(System.Diagnostics.StackFrame csharpFrame, StackFrame qsharpFrame)
         {
-            string? fileName = csharpFrame.GetFileName();
+            string fileName = csharpFrame.GetFileName();
             if (string.IsNullOrEmpty(fileName))
             {
                 return false;
@@ -249,8 +245,8 @@ namespace Microsoft.Quantum.Simulation.Common
     {
         private readonly Stack<StackFrame> callStack;
         private readonly SimulatorBase sim;
-        private System.Diagnostics.StackFrame[]? frames = null;
-        StackFrame[]? stackFramesWithLocations = null;
+        private System.Diagnostics.StackFrame[] frames = null;
+        StackFrame[] stackFramesWithLocations = null;
         bool hasFailed = false;
 
         public StackTraceCollector(SimulatorBase sim)
@@ -323,17 +319,14 @@ namespace Microsoft.Quantum.Simulation.Common
         /// If failure has happened returns the call-stack at time of failure.
         /// Returns null if the failure has not happened.
         /// </summary>
-        public StackFrame[]? CallStack
+        public StackFrame[] CallStack
         {
             get
             {
                 if (hasFailed)
                 {
-                    if(stackFramesWithLocations == null)
+                    if( stackFramesWithLocations == null )
                     {
-                        // The only way hasFailed can be set is if StackTraceCollector.OnFail was called, which also populates
-                        // the stack frames. So we should be fine here accessing frames
-                        Debug.Assert(frames != null, "Expected frames to be non-null");
                         stackFramesWithLocations = StackFrame.PopulateSourceLocations(callStack, frames);
                     }
                     return stackFramesWithLocations;


### PR DESCRIPTION
Reverts microsoft/qsharp-runtime#1130

Possibly causing test failures at https://ms-quantum.visualstudio.com/Quantum%20Program/_build/results?buildId=262812&view=results