### PR TITLE
Prevent GitHub from excluding the build/ directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -60,3 +60,9 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# Prevent GitHub from excluding the build/ directory from the file finder.
+# See: https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github
+###############################################################################
+build/** linguist-generated=false


### PR DESCRIPTION
Add a line to the `.gitattributes` file, [as described in the GitHub documentation](https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files), to prevent GitHub from excluding this folder from "Go to file". In our repo, this file contains lots of build scripts, so it helps when they're easily findable.

For the same change in another QDK repo, see: https://github.com/microsoft/qdk/pull/346