### PR TITLE
Disable criterion to avoid dependency issue

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -6,20 +6,21 @@
 $ErrorActionPreference = 'Stop'
 
 Push-Location (Join-Path $PSScriptRoot "build")
-    .\prerequisites.ps1
+.\prerequisites.ps1
 Pop-Location
 
-cargo install cargo-edit@0.11.0
-Push-Location (Join-Path $PSScriptRoot "./src/Simulation/qdk_sim_rs")
-    cargo set-version $Env:NUGET_VERSION;
-Pop-Location
+# cargo install cargo-edit@0.11.0
+# Push-Location (Join-Path $PSScriptRoot "./src/Simulation/qdk_sim_rs")
+#     cargo set-version $Env:NUGET_VERSION;
+# Pop-Location
 
-if (-not (Test-Path Env:/AGENT_OS)) {                                    # If not CI build, i.e. local build (if AGENT_OS envvar is not defined)
+if (-not (Test-Path Env:/AGENT_OS)) {
+    # If not CI build, i.e. local build (if AGENT_OS envvar is not defined)
     if ($Env:ENABLE_QIRRUNTIME -ne "false") {
         Write-Host "Build release flavor of the QIR standard library"
         $Env:BUILD_CONFIGURATION = "Release"
         Push-Location (Join-Path $PSScriptRoot "src/Qir/Runtime")
-            .\build-qir-stdlib.ps1
+        .\build-qir-stdlib.ps1
         Pop-Location
         $Env:BUILD_CONFIGURATION = $null
     }
@@ -27,21 +28,22 @@ if (-not (Test-Path Env:/AGENT_OS)) {                                    # If no
         $Env:BUILD_CONFIGURATION = "Release"
         Write-Host "Build release flavor of the full state simulator"
         Push-Location (Join-Path $PSScriptRoot "src/Simulation/Native")
-            .\build-native-simulator.ps1
+        .\build-native-simulator.ps1
         Pop-Location
 
         Write-Host "Build release flavor of the Sparse Simulator"
         & (Join-Path $PSScriptRoot "src" "Simulation" "NativeSparseSimulator" "build.ps1")
 
         Push-Location (Join-Path $PSScriptRoot "src" "Simulation" "qdk_sim_rs")
-            # Don't run the experimental simulator build if we're local
-            # and prerequisites are missing.
-            $IsCI = "$Env:TF_BUILD" -ne "" -or "$Env:CI" -eq "true";
-            if ((Get-Command cargo -ErrorAction SilentlyContinue) -or $IsCI) {
-                .\build-qdk-sim-rs.ps1
-            } else {
-                Write-Verbose "cargo was not installed, skipping qdk_sim_rs build.";
-            }
+        # Don't run the experimental simulator build if we're local
+        # and prerequisites are missing.
+        $IsCI = "$Env:TF_BUILD" -ne "" -or "$Env:CI" -eq "true";
+        if ((Get-Command cargo -ErrorAction SilentlyContinue) -or $IsCI) {
+            .\build-qdk-sim-rs.ps1
+        }
+        else {
+            Write-Verbose "cargo was not installed, skipping qdk_sim_rs build.";
+        }
         Pop-Location
         $Env:BUILD_CONFIGURATION = $null
     }

--- a/src/Simulation/qdk_sim_rs/Cargo.toml
+++ b/src/Simulation/qdk_sim_rs/Cargo.toml
@@ -101,13 +101,13 @@ built = "0.5.0"
 approx = { version = "0.5.1", features = ["num-complex"] }
 assert-json-diff = "2.0.1"
 backtrace = "=0.3.65"
-criterion = { version = "0.3", features = ['html_reports', 'csv_output'] }
+# criterion = { version = "0.3", features = ['html_reports', 'csv_output'] }
 ndarray = { version = "0.15.4", features = ["approx"] }
 
-[[bench]]
-harness = false
-name = "c_api_benchmark"
+# [[bench]]
+# harness = false
+# name = "c_api_benchmark"
 
-[[bench]]
-harness = false
-name = "microbenchmark"
+# [[bench]]
+# harness = false
+# name = "microbenchmark"

--- a/src/Simulation/qdk_sim_rs/test-qdk-sim-rs.ps1
+++ b/src/Simulation/qdk_sim_rs/test-qdk-sim-rs.ps1
@@ -25,16 +25,16 @@ Push-Location $PSScriptRoot
     }
 
     # Run performance benchmarks as well.
-    cargo bench
-    $script:allOk = $script:allOk -and $LASTEXITCODE -eq 0;
+    # cargo bench
+    # $script:allOk = $script:allOk -and $LASTEXITCODE -eq 0;
 
     # This step isn't required, but we use it to upload run summaries.
-    $reportPath = (Join-Path "target" "criterion");
-    $perfDest = (Join-Path $Env:DROPS_DIR "perf" "qdk_sim_rs");
-    if (Get-Item -ErrorAction SilentlyContinue $reportPath) {
-        New-Item -Type Directory -Force -Path $perfDest;
-        Copy-Item -Recurse -Force -Path $reportPath -Destination $perfDest;
-    }
+    # $reportPath = (Join-Path "target" "criterion");
+    # $perfDest = (Join-Path $Env:DROPS_DIR "perf" "qdk_sim_rs");
+    # if (Get-Item -ErrorAction SilentlyContinue $reportPath) {
+    #     New-Item -Type Directory -Force -Path $perfDest;
+    #     Copy-Item -Recurse -Force -Path $reportPath -Destination $perfDest;
+    # }
 
     # Free disk space by cleaning up.
     # Note that this takes longer, but saves ~1 GB of space, which is


### PR DESCRIPTION
Since we build with a specific pinned version of Rust but do not check in a Cargo.lock, we have contradictions in our toolchain and our dependencies. For now, we avoid this issue by skipping the benchmarks that depend on criterion.